### PR TITLE
feat(auth): implement hybrid authentication strategy

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,7 +15,7 @@ Establishing the bedrock of the system: identity, hierarchy, and reliable data f
 - [x] **Identity Management:** Moodle-integrated JWT authentication and automatic user profile hydration.
 - [x] **Institutional Hierarchy:** Rebuilding Campus/Semester/Department/Program structures from Moodle categories.
 - [x] **Idempotent Infrastructure:** Automated migrations and self-healing infrastructure seeders (e.g., Dimension registry).
-- [ ] **Hybrid Authentication Strategy:** implementing local credential support alongside Moodle SSO for administrative users (Deans/Admins).
+- [ ] **Hybrid Authentication Strategy:** implementing local credential support alongside Moodle SSO for administrative users (Admins/SuperAdmins/Higher-ups).
 - [x] **Robust Startup:** Fail-fast initialization sequence ensuring migration execution, seed idempotency, and schema integrity enforcement.
 - [~] **Data Sync Engine:** Background jobs for Moodle category and course mirroring (Refinement in progress).
 - [~] **Enrollment Mirroring:** Efficient synchronization of user-course relationships with role mapping.

--- a/src/configurations/env/admin.env.ts
+++ b/src/configurations/env/admin.env.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+
+export const adminEnvSchema = z.object({
+  SUPER_ADMIN_USERNAME: z.string().default('superadmin'),
+  SUPER_ADMIN_PASSWORD: z.string().default('password123'),
+});

--- a/src/configurations/env/index.ts
+++ b/src/configurations/env/index.ts
@@ -7,6 +7,7 @@ import { DEFAULT_PORT } from '../common/constants';
 import { databaseEnvSchema } from './database.env';
 import { jwtEnvSchema } from './jwt.env';
 import { openaiEnvSchema } from './openai.env';
+import { adminEnvSchema } from './admin.env';
 
 export const envSchema = z.object({
   ...databaseEnvSchema.shape,
@@ -15,6 +16,7 @@ export const envSchema = z.object({
   ...corsEnvSchema.shape,
   ...moodleEnvSchema.shape,
   ...openaiEnvSchema.shape,
+  ...adminEnvSchema.shape,
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/src/entities/moodle-token.entity.ts
+++ b/src/entities/moodle-token.entity.ts
@@ -25,6 +25,11 @@ export class MoodleToken extends CustomBaseEntity {
   user: Rel<User>;
 
   static Create(user: User, moodleTokens: MoodleTokenResponse) {
+    if (!user.moodleUserId) {
+      throw new Error(
+        'Cannot create MoodleToken for user without moodleUserId',
+      );
+    }
     const newMoodleToken = new MoodleToken();
     newMoodleToken.token = moodleTokens.token;
     newMoodleToken.moodleUserId = user.moodleUserId;

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -20,8 +20,11 @@ export class User extends CustomBaseEntity {
   @Property({ unique: true })
   userName: string;
 
-  @Property({ unique: true })
-  moodleUserId: number;
+  @Property({ unique: true, nullable: true })
+  moodleUserId?: number;
+
+  @Property({ hidden: true, nullable: true })
+  password?: string;
 
   @Property()
   firstName: string;

--- a/src/migrations/.snapshot-faculytics_db.json
+++ b/src/migrations/.snapshot-faculytics_db.json
@@ -1458,8 +1458,18 @@
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
-          "nullable": false,
+          "nullable": true,
           "mappedType": "integer"
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "length": 255,
+          "mappedType": "string"
         },
         "first_name": {
           "name": "first_name",

--- a/src/migrations/Migration20260216194934.ts
+++ b/src/migrations/Migration20260216194934.ts
@@ -1,0 +1,18 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260216194934 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table "user" add column "password" varchar(255) null;`);
+    this.addSql(`alter table "user" alter column "moodle_user_id" type int using ("moodle_user_id"::int);`);
+    this.addSql(`alter table "user" alter column "moodle_user_id" drop not null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "user" drop column "password";`);
+
+    this.addSql(`alter table "user" alter column "moodle_user_id" type int using ("moodle_user_id"::int);`);
+    this.addSql(`alter table "user" alter column "moodle_user_id" set not null;`);
+  }
+
+}

--- a/src/modules/auth/auth.service.spec.ts
+++ b/src/modules/auth/auth.service.spec.ts
@@ -5,18 +5,21 @@ import { MoodleSyncService } from '../moodle/moodle-sync.service';
 import { MoodleUserHydrationService } from '../moodle/moodle-user-hydration.service';
 import { CustomJwtService } from '../common/custom-jwt-service';
 import UnitOfWork from '../common/unit-of-work';
+import { User } from '../../entities/user.entity';
+import * as bcrypt from 'bcrypt';
+import { UnauthorizedException } from '@nestjs/common';
 
 describe('AuthService', () => {
   let service: AuthService;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
   let moodleService: MoodleService;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
   let moodleSyncService: MoodleSyncService;
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let moodleUserHydrationService: MoodleUserHydrationService;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
   let jwtService: CustomJwtService;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
   let unitOfWork: UnitOfWork;
 
   beforeEach(async () => {
@@ -26,13 +29,13 @@ describe('AuthService', () => {
         {
           provide: MoodleService,
           useValue: {
-            // TODO: Mock methods
+            Login: jest.fn(),
           },
         },
         {
           provide: MoodleSyncService,
           useValue: {
-            // TODO: Mock methods
+            SyncUserContext: jest.fn(),
           },
         },
         {
@@ -44,7 +47,7 @@ describe('AuthService', () => {
         {
           provide: CustomJwtService,
           useValue: {
-            // TODO: Mock methods
+            CreateSignedTokens: jest.fn(),
           },
         },
         {
@@ -54,7 +57,14 @@ describe('AuthService', () => {
               .fn()
               .mockImplementation((cb: (em: any) => any) =>
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-                cb({ getRepository: jest.fn() }),
+                cb({
+                  getRepository: jest.fn().mockReturnValue({
+                    UpsertFromMoodle: jest.fn(),
+                    revokeAllForUser: jest.fn(),
+                  }),
+                  findOne: jest.fn(),
+                  findOneOrFail: jest.fn(),
+                }),
               ),
           },
         },
@@ -73,5 +83,122 @@ describe('AuthService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('Login', () => {
+    it('should login locally if user has a password', async () => {
+      const password = 'password123';
+      const hashedPassword = await bcrypt.hash(password, 10);
+      const mockUser = new User();
+      mockUser.userName = 'admin';
+      mockUser.password = hashedPassword;
+      mockUser.id = 'user-id';
+
+      const mockEm = {
+        findOne: jest.fn().mockResolvedValue(mockUser),
+        getRepository: jest.fn().mockReturnValue({}),
+      };
+
+      (unitOfWork.runInTransaction as jest.Mock).mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        (cb: (em: any) => any) => cb(mockEm),
+      );
+
+      (jwtService.CreateSignedTokens as jest.Mock).mockResolvedValue({
+        token: 'access',
+        refreshToken: 'refresh',
+      });
+
+      const mockMetadata = {
+        browserName: 'test',
+        os: 'test',
+        ipAddress: '127.0.0.1',
+      };
+
+      const result = await service.Login(
+        { username: 'admin', password: 'password123' },
+        mockMetadata,
+      );
+
+      expect(mockEm.findOne).toHaveBeenCalledWith(User, { userName: 'admin' });
+      expect(result).toBeDefined();
+      expect(result.token).toBe('access');
+    });
+
+    it('should fall back to Moodle login if no local user exists', async () => {
+      const mockEm = {
+        findOne: jest.fn().mockResolvedValue(null),
+        getRepository: jest.fn().mockReturnValue({
+          UpsertFromMoodle: jest.fn(),
+        }),
+      };
+
+      (unitOfWork.runInTransaction as jest.Mock).mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        (cb: (em: any) => any) => cb(mockEm),
+      );
+
+      (moodleService.Login as jest.Mock).mockResolvedValue({
+        token: 'moodle-token',
+      });
+
+      const mockUser = new User();
+      mockUser.id = 'moodle-user-id';
+      mockUser.moodleUserId = 123;
+      (moodleSyncService.SyncUserContext as jest.Mock).mockResolvedValue(
+        mockUser,
+      );
+
+      (jwtService.CreateSignedTokens as jest.Mock).mockResolvedValue({
+        token: 'access',
+        refreshToken: 'refresh',
+      });
+
+      const mockMetadata = {
+        browserName: 'test',
+        os: 'test',
+        ipAddress: '127.0.0.1',
+      };
+
+      await service.Login(
+        { username: 'moodleuser', password: 'moodlepassword' },
+        mockMetadata,
+      );
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(moodleService.Login).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(moodleSyncService.SyncUserContext).toHaveBeenCalledWith(
+        'moodle-token',
+      );
+    });
+
+    it('should throw UnauthorizedException if local password is invalid', async () => {
+      const mockUser = new User();
+      mockUser.userName = 'admin';
+      mockUser.password = await bcrypt.hash('correct-password', 10);
+
+      const mockEm = {
+        findOne: jest.fn().mockResolvedValue(mockUser),
+      };
+
+      (unitOfWork.runInTransaction as jest.Mock).mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        (cb: (em: any) => any) => cb(mockEm),
+      );
+
+      const mockMetadata = {
+        browserName: 'test',
+        os: 'test',
+        ipAddress: '127.0.0.1',
+      };
+
+      await expect(
+        service.Login(
+          { username: 'admin', password: 'wrong-password' },
+          mockMetadata,
+        ),
+      ).rejects.toThrow(UnauthorizedException);
+    });
   });
 });

--- a/src/modules/auth/dto/responses/me.response.dto.ts
+++ b/src/modules/auth/dto/responses/me.response.dto.ts
@@ -3,7 +3,7 @@ import { User } from 'src/entities/user.entity';
 export class MeResponse {
   id: string;
   userName: string;
-  moodleUserId: number;
+  moodleUserId?: number;
   firstName: string;
   lastName: string;
   userProfilePicture: string;

--- a/src/modules/common/custom-jwt-service/jwt-payload.dto.ts
+++ b/src/modules/common/custom-jwt-service/jwt-payload.dto.ts
@@ -1,8 +1,8 @@
 export class JwtPayload {
   sub: string;
-  moodleUserId: number;
+  moodleUserId?: number;
 
-  static Create(userId: string, moodleUserId: number): JwtPayload {
+  static Create(userId: string, moodleUserId?: number): JwtPayload {
     return {
       sub: userId,
       moodleUserId,

--- a/src/modules/moodle/moodle-enrollment-sync.service.ts
+++ b/src/modules/moodle/moodle-enrollment-sync.service.ts
@@ -110,7 +110,10 @@ export class EnrollmentSyncService {
 
       // 4. Soft deactivate users missing from remote
       for (const enrollment of existing) {
-        if (!remoteIds.has(enrollment.user.moodleUserId)) {
+        if (
+          enrollment.user.moodleUserId &&
+          !remoteIds.has(enrollment.user.moodleUserId)
+        ) {
           enrollment.isActive = false;
           tx.persist(enrollment);
         }

--- a/src/seeders/infrastructure/infrastructure.seeder.ts
+++ b/src/seeders/infrastructure/infrastructure.seeder.ts
@@ -1,9 +1,10 @@
 import { EntityManager } from '@mikro-orm/core';
 import { Seeder } from '@mikro-orm/seeder';
 import { DimensionSeeder } from './dimension.seeder';
+import { UserSeeder } from './user.seeder';
 
 export class InfrastructureSeeder extends Seeder {
   async run(em: EntityManager): Promise<void> {
-    await this.call(em, [DimensionSeeder]);
+    await this.call(em, [DimensionSeeder, UserSeeder]);
   }
 }

--- a/src/seeders/infrastructure/user.seeder.ts
+++ b/src/seeders/infrastructure/user.seeder.ts
@@ -1,0 +1,35 @@
+import { EntityManager } from '@mikro-orm/core';
+import { Seeder } from '@mikro-orm/seeder';
+import { User } from '../../entities/user.entity';
+import * as bcrypt from 'bcrypt';
+import { env } from '../../configurations/env';
+
+export class UserSeeder extends Seeder {
+  async run(em: EntityManager): Promise<void> {
+    const superAdminUsername = env.SUPER_ADMIN_USERNAME;
+    const superAdminPassword = env.SUPER_ADMIN_PASSWORD;
+
+    const existingUser = await em.findOne(User, {
+      userName: superAdminUsername,
+    });
+
+    if (!existingUser) {
+      const user = new User();
+      user.userName = superAdminUsername;
+      user.password = await bcrypt.hash(superAdminPassword, 10);
+      user.firstName = 'Super';
+      user.lastName = 'Admin';
+      user.fullName = 'Super Admin';
+      user.userProfilePicture = '';
+      user.isActive = true;
+      user.lastLoginAt = new Date();
+      user.roles = ['SUPER_ADMIN'];
+
+      em.persist(user);
+    } else {
+      // Update password if it exists to ensure it matches env
+      existingUser.password = await bcrypt.hash(superAdminPassword, 10);
+      existingUser.roles = ['SUPER_ADMIN']; // Ensure role is correct
+    }
+  }
+}


### PR DESCRIPTION
## Description
This PR implements a hybrid authentication strategy to support local administrative credentials alongside the existing Moodle SSO.

### Key Changes:
- **User Entity**: Made `moodleUserId` nullable and added a hidden `password` field.
- **Auth Service**: Updated `Login` logic to check for local users with passwords before falling back to Moodle.
- **DTOs**: Updated `JwtPayload` and `MeResponse` to handle optional Moodle IDs.
- **Seeding**: Added `UserSeeder` to provision a default Super Admin (`superadmin` / `password123`).
- **Database**: Generated migration for schema changes.
- **Fixes**: Resolved TypeScript errors and linting issues in tests and services related to optional Moodle IDs.

### Verification:
- Unit tests for AuthService updated and passed.
- Linting and Type checks (`tsc`) passed.