### PR TITLE
FAC-41 feat: add questionnaire type and version queries

### DIFF
--- a/src/modules/questionnaires/dto/requests/get-versions-by-type-request.dto.ts
+++ b/src/modules/questionnaires/dto/requests/get-versions-by-type-request.dto.ts
@@ -1,0 +1,7 @@
+import { IsEnum } from 'class-validator';
+import { QuestionnaireType } from '../../lib/questionnaire.types';
+
+export class GetVersionsByTypeParam {
+  @IsEnum(QuestionnaireType)
+  type!: QuestionnaireType;
+}

--- a/src/modules/questionnaires/dto/responses/questionnaire-type-response.dto.ts
+++ b/src/modules/questionnaires/dto/responses/questionnaire-type-response.dto.ts
@@ -1,0 +1,11 @@
+import {
+  QuestionnaireStatus,
+  QuestionnaireType,
+} from '../../lib/questionnaire.types';
+
+export class QuestionnaireTypeResponse {
+  type!: QuestionnaireType;
+  questionnaireId!: string | null;
+  title!: string | null;
+  status!: QuestionnaireStatus | null;
+}

--- a/src/modules/questionnaires/dto/responses/questionnaire-version-response.dto.ts
+++ b/src/modules/questionnaires/dto/responses/questionnaire-version-response.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  QuestionnaireStatus,
+  QuestionnaireType,
+} from '../../lib/questionnaire.types';
+
+export class QuestionnaireVersionItem {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  versionNumber!: number;
+
+  @ApiProperty({ enum: QuestionnaireStatus })
+  status!: QuestionnaireStatus;
+
+  @ApiProperty()
+  isActive!: boolean;
+
+  @ApiProperty({ required: false, nullable: true })
+  publishedAt?: Date;
+
+  @ApiProperty()
+  createdAt!: Date;
+}
+
+export class QuestionnaireVersionsResponse {
+  @ApiProperty({ nullable: true })
+  questionnaireId!: string | null;
+
+  @ApiProperty({ nullable: true })
+  questionnaireTitle!: string | null;
+
+  @ApiProperty({ enum: QuestionnaireType })
+  type!: QuestionnaireType;
+
+  @ApiProperty({ type: [QuestionnaireVersionItem] })
+  versions!: QuestionnaireVersionItem[];
+}

--- a/src/modules/questionnaires/questionnaire.controller.ts
+++ b/src/modules/questionnaires/questionnaire.controller.ts
@@ -17,6 +17,8 @@ import { CreateVersionRequest } from './dto/requests/create-version-request.dto'
 import { SubmitQuestionnaireRequest } from './dto/requests/submit-questionnaire-request.dto';
 import { SaveDraftRequest } from './dto/requests/save-draft-request.dto';
 import { GetDraftRequest } from './dto/requests/get-draft-request.dto';
+import { GetVersionsByTypeParam } from './dto/requests/get-versions-by-type-request.dto';
+import { QuestionnaireVersionsResponse } from './dto/responses/questionnaire-version-response.dto';
 import { DraftResponse } from './dto/responses/draft-response.dto';
 import { UseJwtGuard } from 'src/security/decorators';
 import { CurrentUserInterceptor } from '../common/interceptors/current-user.interceptor';
@@ -26,6 +28,23 @@ import type { AuthenticatedRequest } from '../common/interceptors/http/authentic
 @Controller('questionnaires')
 export class QuestionnaireController {
   constructor(private readonly questionnaireService: QuestionnaireService) {}
+
+  @Get('types')
+  @ApiOperation({ summary: 'List all questionnaire types' })
+  async getQuestionnaireTypes() {
+    return this.questionnaireService.getQuestionnaireTypes();
+  }
+
+  @Get('types/:type/versions')
+  @ApiOperation({ summary: 'Get versions for a questionnaire type' })
+  @ApiResponse({
+    status: 200,
+    description: 'Versions found',
+    type: QuestionnaireVersionsResponse,
+  })
+  async getVersionsByType(@Param() params: GetVersionsByTypeParam) {
+    return this.questionnaireService.getVersionsByType(params.type);
+  }
 
   @Post()
   @ApiOperation({ summary: 'Create a new questionnaire' })

--- a/src/modules/questionnaires/services/__tests__/questionnaire-types.spec.ts
+++ b/src/modules/questionnaires/services/__tests__/questionnaire-types.spec.ts
@@ -1,0 +1,228 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { Test, TestingModule } from '@nestjs/testing';
+import { QuestionnaireService } from '../questionnaire.service';
+import { getRepositoryToken } from '@mikro-orm/nestjs';
+import {
+  Questionnaire,
+  QuestionnaireVersion,
+  QuestionnaireSubmission,
+  QuestionnaireDraft,
+  Enrollment,
+} from '../../../../entities/index.entity';
+import { QuestionnaireSchemaValidator } from '../questionnaire-schema.validator';
+import { ScoringService } from '../scoring.service';
+import { EntityManager } from '@mikro-orm/postgresql';
+import {
+  QuestionnaireStatus,
+  QuestionnaireType,
+} from '../../lib/questionnaire.types';
+
+describe('QuestionnaireService - Types & Versions', () => {
+  let service: QuestionnaireService;
+  let questionnaireRepo: any;
+  let versionRepo: any;
+
+  beforeEach(async () => {
+    const createMockRepo = () => ({
+      create: jest.fn().mockImplementation((data: Record<string, unknown>) => ({
+        ...data,
+        answers: { add: jest.fn() },
+      })),
+      findOne: jest.fn(),
+      findAll: jest.fn(),
+      find: jest.fn(),
+    });
+
+    const questionnaireRepoMock = createMockRepo();
+    const versionRepoMock = createMockRepo();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        QuestionnaireService,
+        {
+          provide: getRepositoryToken(Questionnaire),
+          useValue: questionnaireRepoMock,
+        },
+        {
+          provide: getRepositoryToken(QuestionnaireVersion),
+          useValue: versionRepoMock,
+        },
+        {
+          provide: getRepositoryToken(QuestionnaireSubmission),
+          useValue: createMockRepo(),
+        },
+        {
+          provide: getRepositoryToken(QuestionnaireDraft),
+          useValue: { ...createMockRepo(), find: jest.fn() },
+        },
+        {
+          provide: getRepositoryToken(Enrollment),
+          useValue: createMockRepo(),
+        },
+        {
+          provide: QuestionnaireSchemaValidator,
+          useValue: { validate: jest.fn() },
+        },
+        {
+          provide: ScoringService,
+          useValue: { calculateScores: jest.fn() },
+        },
+        {
+          provide: EntityManager,
+          useValue: {
+            persist: jest.fn(),
+            flush: jest.fn(),
+            findOne: jest.fn(),
+            upsert: jest.fn(),
+            create: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<QuestionnaireService>(QuestionnaireService);
+    questionnaireRepo = module.get(getRepositoryToken(Questionnaire));
+    versionRepo = module.get(getRepositoryToken(QuestionnaireVersion));
+  });
+
+  describe('getQuestionnaireTypes', () => {
+    it('should return all enum values even when only some have entities', async () => {
+      questionnaireRepo.findAll.mockResolvedValue([
+        {
+          id: 'q1',
+          title: 'Faculty In Classroom Eval',
+          type: QuestionnaireType.FACULTY_IN_CLASSROOM,
+          status: QuestionnaireStatus.ACTIVE,
+        },
+      ]);
+
+      const result = await service.getQuestionnaireTypes();
+
+      expect(result).toHaveLength(3);
+      expect(result.map((r: any) => r.type)).toEqual(
+        Object.values(QuestionnaireType),
+      );
+    });
+
+    it('should map existing questionnaire data correctly', async () => {
+      questionnaireRepo.findAll.mockResolvedValue([
+        {
+          id: 'q1',
+          title: 'Faculty In Classroom Eval',
+          type: QuestionnaireType.FACULTY_IN_CLASSROOM,
+          status: QuestionnaireStatus.ACTIVE,
+        },
+        {
+          id: 'q2',
+          title: 'Faculty Feedback Form',
+          type: QuestionnaireType.FACULTY_FEEDBACK,
+          status: QuestionnaireStatus.DRAFT,
+        },
+      ]);
+
+      const result = await service.getQuestionnaireTypes();
+
+      const inClassroom = result.find(
+        (r: any) => r.type === QuestionnaireType.FACULTY_IN_CLASSROOM,
+      );
+      expect(inClassroom).toEqual({
+        type: QuestionnaireType.FACULTY_IN_CLASSROOM,
+        questionnaireId: 'q1',
+        title: 'Faculty In Classroom Eval',
+        status: QuestionnaireStatus.ACTIVE,
+      });
+
+      const outOfClassroom = result.find(
+        (r: any) => r.type === QuestionnaireType.FACULTY_OUT_OF_CLASSROOM,
+      );
+      expect(outOfClassroom).toEqual({
+        type: QuestionnaireType.FACULTY_OUT_OF_CLASSROOM,
+        questionnaireId: null,
+        title: null,
+        status: null,
+      });
+
+      const feedback = result.find(
+        (r: any) => r.type === QuestionnaireType.FACULTY_FEEDBACK,
+      );
+      expect(feedback).toEqual({
+        type: QuestionnaireType.FACULTY_FEEDBACK,
+        questionnaireId: 'q2',
+        title: 'Faculty Feedback Form',
+        status: QuestionnaireStatus.DRAFT,
+      });
+    });
+  });
+
+  describe('getVersionsByType', () => {
+    it('should return versions in DESC order', async () => {
+      const mockQuestionnaire = {
+        id: 'q1',
+        title: 'Faculty In Classroom Eval',
+        type: QuestionnaireType.FACULTY_IN_CLASSROOM,
+      };
+
+      questionnaireRepo.findOne.mockResolvedValue(mockQuestionnaire);
+      versionRepo.find.mockResolvedValue([
+        {
+          id: 'v2',
+          versionNumber: 2,
+          status: QuestionnaireStatus.ACTIVE,
+          isActive: true,
+          publishedAt: new Date('2026-02-01'),
+          createdAt: new Date('2026-02-01'),
+        },
+        {
+          id: 'v1',
+          versionNumber: 1,
+          status: QuestionnaireStatus.DEPRECATED,
+          isActive: false,
+          publishedAt: new Date('2026-01-01'),
+          createdAt: new Date('2026-01-01'),
+        },
+      ]);
+
+      const result = await service.getVersionsByType(
+        QuestionnaireType.FACULTY_IN_CLASSROOM,
+      );
+
+      expect(result.questionnaireId).toBe('q1');
+      expect(result.questionnaireTitle).toBe('Faculty In Classroom Eval');
+      expect(result.type).toBe(QuestionnaireType.FACULTY_IN_CLASSROOM);
+      expect(result.versions).toHaveLength(2);
+      expect(result.versions[0].versionNumber).toBe(2);
+      expect(result.versions[1].versionNumber).toBe(1);
+
+      expect(versionRepo.find).toHaveBeenCalledWith(
+        { questionnaire: mockQuestionnaire },
+        {
+          orderBy: { versionNumber: 'DESC' },
+          fields: [
+            'id',
+            'versionNumber',
+            'status',
+            'isActive',
+            'publishedAt',
+            'createdAt',
+          ],
+        },
+      );
+    });
+
+    it('should return empty versions when no questionnaire exists for type', async () => {
+      questionnaireRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.getVersionsByType(
+        QuestionnaireType.FACULTY_FEEDBACK,
+      );
+
+      expect(result.questionnaireId).toBeNull();
+      expect(result.questionnaireTitle).toBeNull();
+      expect(result.type).toBe(QuestionnaireType.FACULTY_FEEDBACK);
+      expect(result.versions).toEqual([]);
+    });
+  });
+});

--- a/src/modules/questionnaires/services/questionnaire.service.ts
+++ b/src/modules/questionnaires/services/questionnaire.service.ts
@@ -33,6 +33,8 @@ import {
   QuestionNode,
   EnrollmentRole,
 } from '../lib/questionnaire.types';
+import { QuestionnaireTypeResponse } from '../dto/responses/questionnaire-type-response.dto';
+import { QuestionnaireVersionsResponse } from '../dto/responses/questionnaire-version-response.dto';
 import { QuestionnaireSchemaValidator } from './questionnaire-schema.validator';
 import { ScoringService } from './scoring.service';
 import { EntityManager } from '@mikro-orm/postgresql';
@@ -55,6 +57,70 @@ export class QuestionnaireService {
     private readonly scoringService: ScoringService,
     private readonly em: EntityManager,
   ) {}
+
+  async getQuestionnaireTypes(): Promise<QuestionnaireTypeResponse[]> {
+    const questionnaires = await this.questionnaireRepo.findAll();
+
+    const questionnaireMap = new Map(questionnaires.map((q) => [q.type, q]));
+
+    return Object.values(QuestionnaireType).map((type) => {
+      const questionnaire = questionnaireMap.get(type);
+      return {
+        type,
+        questionnaireId: questionnaire?.id ?? null,
+        title: questionnaire?.title ?? null,
+        status: questionnaire?.status ?? null,
+      };
+    });
+  }
+
+  async getVersionsByType(
+    type: QuestionnaireType,
+  ): Promise<QuestionnaireVersionsResponse> {
+    if (!Object.values(QuestionnaireType).includes(type)) {
+      throw new NotFoundException(`Questionnaire type ${type} not found.`);
+    }
+
+    const questionnaire = await this.questionnaireRepo.findOne({ type });
+
+    if (!questionnaire) {
+      return {
+        questionnaireId: null,
+        questionnaireTitle: null,
+        type,
+        versions: [],
+      };
+    }
+
+    const versions = await this.versionRepo.find(
+      { questionnaire },
+      {
+        orderBy: { versionNumber: 'DESC' },
+        fields: [
+          'id',
+          'versionNumber',
+          'status',
+          'isActive',
+          'publishedAt',
+          'createdAt',
+        ],
+      },
+    );
+
+    return {
+      questionnaireId: questionnaire.id,
+      questionnaireTitle: questionnaire.title,
+      type: questionnaire.type,
+      versions: versions.map((v) => ({
+        id: v.id,
+        versionNumber: v.versionNumber,
+        status: v.status,
+        isActive: v.isActive,
+        publishedAt: v.publishedAt,
+        createdAt: v.createdAt,
+      })),
+    };
+  }
 
   async createQuestionnaire(data: { title: string; type: QuestionnaireType }) {
     const questionnaire = this.questionnaireRepo.create({


### PR DESCRIPTION
Add GET /questionnaires/types and GET /questionnaires/types/:type/versions endpoints for listing questionnaire types with their associated entities and browsing versions by type with OpenAPI schema definitions.