### PR TITLE
FAC-45 fix: add Redis service to publish-contract workflow

### DIFF
--- a/.github/workflows/publish-contract.yml
+++ b/.github/workflows/publish-contract.yml
@@ -26,6 +26,16 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v4
 
@@ -50,6 +60,7 @@ jobs:
           MOODLE_MASTER_KEY: dummy_moodle_key
           OPENAI_API_KEY: dummy_openai_key
           CORS_ORIGINS: '["*"]'
+          REDIS_URL: redis://localhost:6379
         run: node dist/scripts/generate-openapi.js
 
       - name: Determine branch folder


### PR DESCRIPTION
BullMQ (FAC-44) requires Redis at startup, which broke the OpenAPI spec generation in CI. Add Redis service container and REDIS_URL env var.