### PR TITLE
FAC-47 refactor: add PipelineResponseDto to flatten pipeline API responses

### DIFF
--- a/src/modules/analysis/analysis.controller.spec.ts
+++ b/src/modules/analysis/analysis.controller.spec.ts
@@ -3,6 +3,31 @@ import { AnalysisController } from './analysis.controller';
 import { PipelineOrchestratorService } from './services/pipeline-orchestrator.service';
 import { PipelineStatus } from './enums';
 
+const makeMockPipeline = (
+  overrides: Partial<Record<string, unknown>> = {},
+) => ({
+  id: 'p1',
+  status: PipelineStatus.AWAITING_CONFIRMATION,
+  semester: { id: 's1' },
+  faculty: undefined,
+  questionnaireVersion: undefined,
+  department: undefined,
+  program: undefined,
+  campus: undefined,
+  course: undefined,
+  triggeredBy: { id: 'u1' },
+  totalEnrolled: 100,
+  submissionCount: 50,
+  commentCount: 10,
+  responseRate: '0.5000',
+  warnings: [],
+  errorMessage: undefined,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  confirmedAt: undefined,
+  completedAt: undefined,
+  ...overrides,
+});
+
 describe('AnalysisController', () => {
   let controller: AnalysisController;
   let mockOrchestrator: {
@@ -38,11 +63,8 @@ describe('AnalysisController', () => {
   });
 
   describe('CreatePipeline', () => {
-    it('should delegate to orchestrator with userId', async () => {
-      const mockPipeline = {
-        id: 'p1',
-        status: PipelineStatus.AWAITING_CONFIRMATION,
-      };
+    it('should delegate to orchestrator with userId and return mapped DTO', async () => {
+      const mockPipeline = makeMockPipeline();
       mockOrchestrator.CreatePipeline.mockResolvedValue(mockPipeline);
 
       const body = { semesterId: 's1' };
@@ -52,31 +74,55 @@ describe('AnalysisController', () => {
 
       const result = await controller.CreatePipeline(body, req);
 
-      expect(result).toBe(mockPipeline);
+      expect(result).toEqual(
+        expect.objectContaining({
+          id: 'p1',
+          status: PipelineStatus.AWAITING_CONFIRMATION,
+          semesterId: 's1',
+          triggeredById: 'u1',
+          responseRate: 0.5,
+        }),
+      );
       expect(mockOrchestrator.CreatePipeline).toHaveBeenCalledWith(body, 'u1');
     });
   });
 
   describe('ConfirmPipeline', () => {
-    it('should delegate to orchestrator', async () => {
-      const mockPipeline = { id: 'p1', status: PipelineStatus.EMBEDDING_CHECK };
+    it('should delegate to orchestrator and return mapped DTO', async () => {
+      const mockPipeline = makeMockPipeline({
+        status: PipelineStatus.EMBEDDING_CHECK,
+      });
       mockOrchestrator.ConfirmPipeline.mockResolvedValue(mockPipeline);
 
       const result = await controller.ConfirmPipeline('p1');
 
-      expect(result).toBe(mockPipeline);
+      expect(result).toEqual(
+        expect.objectContaining({
+          id: 'p1',
+          status: PipelineStatus.EMBEDDING_CHECK,
+          semesterId: 's1',
+        }),
+      );
       expect(mockOrchestrator.ConfirmPipeline).toHaveBeenCalledWith('p1');
     });
   });
 
   describe('CancelPipeline', () => {
-    it('should delegate to orchestrator', async () => {
-      const mockPipeline = { id: 'p1', status: PipelineStatus.CANCELLED };
+    it('should delegate to orchestrator and return mapped DTO', async () => {
+      const mockPipeline = makeMockPipeline({
+        status: PipelineStatus.CANCELLED,
+      });
       mockOrchestrator.CancelPipeline.mockResolvedValue(mockPipeline);
 
       const result = await controller.CancelPipeline('p1');
 
-      expect(result).toBe(mockPipeline);
+      expect(result).toEqual(
+        expect.objectContaining({
+          id: 'p1',
+          status: PipelineStatus.CANCELLED,
+          semesterId: 's1',
+        }),
+      );
       expect(mockOrchestrator.CancelPipeline).toHaveBeenCalledWith('p1');
     });
   });

--- a/src/modules/analysis/analysis.controller.ts
+++ b/src/modules/analysis/analysis.controller.ts
@@ -4,6 +4,7 @@ import { UseJwtGuard } from 'src/security/decorators';
 import type { AuthenticatedRequest } from '../common/interceptors/http/authenticated-request';
 import { PipelineOrchestratorService } from './services/pipeline-orchestrator.service';
 import { CreatePipelineDto } from './dto/create-pipeline.dto';
+import { PipelineResponseDto } from './dto/responses/pipeline.response.dto';
 
 @ApiTags('Analysis')
 @Controller('analysis')
@@ -17,19 +18,25 @@ export class AnalysisController {
     @Body() body: CreatePipelineDto,
     @Req() req: AuthenticatedRequest,
   ) {
-    return this.orchestrator.CreatePipeline(body, req.user!.userId);
+    const pipeline = await this.orchestrator.CreatePipeline(
+      body,
+      req.user!.userId,
+    );
+    return PipelineResponseDto.Map(pipeline);
   }
 
   @Post('pipelines/:id/confirm')
   @ApiOperation({ summary: 'Confirm and start pipeline execution' })
   async ConfirmPipeline(@Param('id') id: string) {
-    return this.orchestrator.ConfirmPipeline(id);
+    const pipeline = await this.orchestrator.ConfirmPipeline(id);
+    return PipelineResponseDto.Map(pipeline);
   }
 
   @Post('pipelines/:id/cancel')
   @ApiOperation({ summary: 'Cancel a non-terminal pipeline' })
   async CancelPipeline(@Param('id') id: string) {
-    return this.orchestrator.CancelPipeline(id);
+    const pipeline = await this.orchestrator.CancelPipeline(id);
+    return PipelineResponseDto.Map(pipeline);
   }
 
   @Get('pipelines/:id/status')

--- a/src/modules/analysis/dto/responses/pipeline.response.dto.ts
+++ b/src/modules/analysis/dto/responses/pipeline.response.dto.ts
@@ -1,0 +1,86 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { AnalysisPipeline } from 'src/entities/analysis-pipeline.entity';
+import { PipelineStatus } from '../../enums';
+
+export class PipelineResponseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty({ enum: PipelineStatus })
+  status: PipelineStatus;
+
+  @ApiProperty()
+  semesterId: string;
+
+  @ApiPropertyOptional({ nullable: true })
+  facultyId: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  questionnaireVersionId: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  departmentId: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  programId: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  campusId: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  courseId: string | null;
+
+  @ApiProperty()
+  triggeredById: string;
+
+  @ApiProperty()
+  totalEnrolled: number;
+
+  @ApiProperty()
+  submissionCount: number;
+
+  @ApiProperty()
+  commentCount: number;
+
+  @ApiProperty()
+  responseRate: number;
+
+  @ApiProperty({ type: [String] })
+  warnings: string[];
+
+  @ApiPropertyOptional({ nullable: true })
+  errorMessage: string | null;
+
+  @ApiProperty()
+  createdAt: string;
+
+  @ApiPropertyOptional({ nullable: true })
+  confirmedAt: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  completedAt: string | null;
+
+  static Map(pipeline: AnalysisPipeline): PipelineResponseDto {
+    return {
+      id: pipeline.id,
+      status: pipeline.status,
+      semesterId: pipeline.semester.id,
+      facultyId: pipeline.faculty?.id ?? null,
+      questionnaireVersionId: pipeline.questionnaireVersion?.id ?? null,
+      departmentId: pipeline.department?.id ?? null,
+      programId: pipeline.program?.id ?? null,
+      campusId: pipeline.campus?.id ?? null,
+      courseId: pipeline.course?.id ?? null,
+      triggeredById: pipeline.triggeredBy.id,
+      totalEnrolled: pipeline.totalEnrolled,
+      submissionCount: pipeline.submissionCount,
+      commentCount: pipeline.commentCount,
+      responseRate: Number(pipeline.responseRate),
+      warnings: pipeline.warnings,
+      errorMessage: pipeline.errorMessage ?? null,
+      createdAt: pipeline.createdAt.toISOString(),
+      confirmedAt: pipeline.confirmedAt?.toISOString() ?? null,
+      completedAt: pipeline.completedAt?.toISOString() ?? null,
+    };
+  }
+}


### PR DESCRIPTION
Replace raw AnalysisPipeline entity returns with a flat DTO that maps ManyToOne relations to UUID strings, preventing deeply nested entity graphs from leaking into the OpenAPI spec.