### PR TITLE
FAC-48 feat: add dimension CRUD controller with role-based authorization

### DIFF
--- a/src/modules/dimensions/dimensions.controller.ts
+++ b/src/modules/dimensions/dimensions.controller.ts
@@ -1,0 +1,60 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { UseJwtGuard, Roles } from 'src/security/decorators';
+import { RolesGuard } from 'src/security/guards/roles.guard';
+import { UserRole } from '../auth/roles.enum';
+import { DimensionsService } from './services/dimensions.service';
+import { CreateDimensionRequestDto } from './dto/requests/create-dimension.request.dto';
+import { UpdateDimensionRequestDto } from './dto/requests/update-dimension.request.dto';
+import { ListDimensionsQueryDto } from './dto/requests/list-dimensions-query.dto';
+
+@ApiTags('Dimensions')
+@Controller('dimensions')
+@UseJwtGuard()
+@Roles(UserRole.SUPER_ADMIN, UserRole.ADMIN)
+@UseGuards(RolesGuard)
+export class DimensionsController {
+  constructor(private readonly dimensionsService: DimensionsService) {}
+
+  @Post()
+  async create(@Body() dto: CreateDimensionRequestDto) {
+    return this.dimensionsService.create(dto);
+  }
+
+  @Get()
+  async findAll(@Query() query: ListDimensionsQueryDto) {
+    return this.dimensionsService.findAll(query);
+  }
+
+  @Get(':id')
+  async findOne(@Param('id') id: string) {
+    return this.dimensionsService.findOne(id);
+  }
+
+  @Patch(':id')
+  async update(
+    @Param('id') id: string,
+    @Body() dto: UpdateDimensionRequestDto,
+  ) {
+    return this.dimensionsService.update(id, dto);
+  }
+
+  @Patch(':id/deactivate')
+  async deactivate(@Param('id') id: string) {
+    return this.dimensionsService.deactivate(id);
+  }
+
+  @Patch(':id/activate')
+  async activate(@Param('id') id: string) {
+    return this.dimensionsService.activate(id);
+  }
+}

--- a/src/modules/dimensions/dimensions.module.ts
+++ b/src/modules/dimensions/dimensions.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { MikroOrmModule } from '@mikro-orm/nestjs';
+import { Dimension } from 'src/entities/dimension.entity';
+import { User } from 'src/entities/user.entity';
+import { DimensionsController } from './dimensions.controller';
+import { DimensionsService } from './services/dimensions.service';
+
+@Module({
+  imports: [MikroOrmModule.forFeature([Dimension, User])],
+  controllers: [DimensionsController],
+  providers: [DimensionsService],
+  exports: [DimensionsService],
+})
+export class DimensionsModule {}

--- a/src/modules/dimensions/dto/requests/create-dimension.request.dto.ts
+++ b/src/modules/dimensions/dto/requests/create-dimension.request.dto.ts
@@ -1,0 +1,27 @@
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+} from 'class-validator';
+import { QuestionnaireType } from 'src/modules/questionnaires/lib/questionnaire.types';
+
+export class CreateDimensionRequestDto {
+  @IsString()
+  @IsOptional()
+  @Matches(/^[A-Z][A-Z0-9_]*$/, {
+    message:
+      'code must be uppercase alphanumeric with underscores (e.g. TEACHING_QUALITY)',
+  })
+  code?: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  displayName: string;
+
+  @IsEnum(QuestionnaireType)
+  questionnaireType: QuestionnaireType;
+}

--- a/src/modules/dimensions/dto/requests/list-dimensions-query.dto.ts
+++ b/src/modules/dimensions/dto/requests/list-dimensions-query.dto.ts
@@ -1,0 +1,27 @@
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
+import { QuestionnaireType } from 'src/modules/questionnaires/lib/questionnaire.types';
+import { Transform } from 'class-transformer';
+
+export class ListDimensionsQueryDto {
+  @IsEnum(QuestionnaireType)
+  @IsOptional()
+  questionnaireType?: QuestionnaireType;
+
+  @IsOptional()
+  @Transform(({ value }) => value === 'true' || value === true)
+  active?: boolean;
+
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  @Type(() => Number)
+  page?: number = 1;
+
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @IsOptional()
+  @Type(() => Number)
+  limit?: number = 20;
+}

--- a/src/modules/dimensions/dto/requests/update-dimension.request.dto.ts
+++ b/src/modules/dimensions/dto/requests/update-dimension.request.dto.ts
@@ -1,0 +1,8 @@
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class UpdateDimensionRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  displayName: string;
+}

--- a/src/modules/dimensions/dto/responses/dimension-list.response.dto.ts
+++ b/src/modules/dimensions/dto/responses/dimension-list.response.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PaginationMeta } from 'src/modules/common/dto/pagination.dto';
+import { DimensionResponseDto } from './dimension.response.dto';
+
+export class DimensionListResponseDto {
+  @ApiProperty({ type: [DimensionResponseDto] })
+  data: DimensionResponseDto[];
+
+  @ApiProperty({ type: PaginationMeta })
+  meta: PaginationMeta;
+}

--- a/src/modules/dimensions/dto/responses/dimension.response.dto.ts
+++ b/src/modules/dimensions/dto/responses/dimension.response.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Dimension } from 'src/entities/dimension.entity';
+import { QuestionnaireType } from 'src/modules/questionnaires/lib/questionnaire.types';
+
+export class DimensionResponseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  code: string;
+
+  @ApiProperty()
+  displayName: string;
+
+  @ApiProperty({ enum: QuestionnaireType })
+  questionnaireType: QuestionnaireType;
+
+  @ApiProperty()
+  active: boolean;
+
+  @ApiProperty()
+  createdAt: string;
+
+  @ApiProperty()
+  updatedAt: string;
+
+  static Map(dimension: Dimension): DimensionResponseDto {
+    return {
+      id: dimension.id,
+      code: dimension.code,
+      displayName: dimension.displayName,
+      questionnaireType: dimension.questionnaireType,
+      active: dimension.active,
+      createdAt: dimension.createdAt.toISOString(),
+      updatedAt: dimension.updatedAt.toISOString(),
+    };
+  }
+}

--- a/src/modules/dimensions/services/dimensions.service.spec.ts
+++ b/src/modules/dimensions/services/dimensions.service.spec.ts
@@ -1,0 +1,268 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import { EntityManager } from '@mikro-orm/postgresql';
+import { UniqueConstraintViolationException } from '@mikro-orm/postgresql';
+import { DimensionsService } from './dimensions.service';
+import { DimensionRepository } from 'src/repositories/dimension.repository';
+import { QuestionnaireType } from 'src/modules/questionnaires/lib/questionnaire.types';
+
+describe('DimensionsService', () => {
+  let service: DimensionsService;
+  let dimensionRepository: {
+    findOne: jest.Mock;
+    findAndCount: jest.Mock;
+  };
+  let em: {
+    create: jest.Mock;
+    persist: jest.Mock;
+    flush: jest.Mock;
+  };
+
+  const mockDimension = {
+    id: 'dim-1',
+    code: 'TEACHING_QUALITY',
+    displayName: 'Teaching Quality',
+    questionnaireType: QuestionnaireType.FACULTY_IN_CLASSROOM,
+    active: true,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+  };
+
+  beforeEach(async () => {
+    dimensionRepository = {
+      findOne: jest.fn(),
+      findAndCount: jest.fn(),
+    };
+
+    const flushMock = jest.fn();
+    em = {
+      create: jest.fn().mockReturnValue({ ...mockDimension }),
+      persist: jest.fn().mockReturnValue({ flush: flushMock }),
+      flush: flushMock,
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DimensionsService,
+        { provide: DimensionRepository, useValue: dimensionRepository },
+        { provide: EntityManager, useValue: em },
+      ],
+    }).compile();
+
+    service = module.get(DimensionsService);
+  });
+
+  describe('create', () => {
+    it('should create a dimension with explicit code', async () => {
+      const dto = {
+        code: 'COURSE_CONTENT',
+        displayName: 'Course Content',
+        questionnaireType: QuestionnaireType.FACULTY_IN_CLASSROOM,
+      };
+
+      const result = await service.create(dto);
+
+      expect(em.create).toHaveBeenCalledWith(expect.anything(), {
+        code: 'COURSE_CONTENT',
+        displayName: 'Course Content',
+        questionnaireType: QuestionnaireType.FACULTY_IN_CLASSROOM,
+        active: true,
+      });
+      expect(em.persist).toHaveBeenCalled();
+      expect(result.id).toBe('dim-1');
+    });
+
+    it('should auto-generate code from displayName when code is omitted', async () => {
+      const dto = {
+        displayName: 'Teaching Quality',
+        questionnaireType: QuestionnaireType.FACULTY_IN_CLASSROOM,
+      };
+
+      await service.create(dto);
+
+      expect(em.create).toHaveBeenCalledWith(expect.anything(), {
+        code: 'TEACHING_QUALITY',
+        displayName: 'Teaching Quality',
+        questionnaireType: QuestionnaireType.FACULTY_IN_CLASSROOM,
+        active: true,
+      });
+    });
+
+    it('should throw ConflictException on duplicate [code, questionnaireType]', async () => {
+      const rejectingFlush = jest
+        .fn()
+        .mockRejectedValue(
+          new UniqueConstraintViolationException(new Error('duplicate')),
+        );
+      em.persist.mockReturnValue({ flush: rejectingFlush });
+
+      await expect(
+        service.create({
+          code: 'TEACHING_QUALITY',
+          displayName: 'Teaching Quality',
+          questionnaireType: QuestionnaireType.FACULTY_IN_CLASSROOM,
+        }),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return paginated results', async () => {
+      dimensionRepository.findAndCount.mockResolvedValue([[mockDimension], 1]);
+
+      const result = await service.findAll({ page: 1, limit: 20 });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.meta).toEqual({
+        totalItems: 1,
+        itemCount: 1,
+        itemsPerPage: 20,
+        totalPages: 1,
+        currentPage: 1,
+      });
+    });
+
+    it('should apply questionnaireType filter', async () => {
+      dimensionRepository.findAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({
+        questionnaireType: QuestionnaireType.FACULTY_IN_CLASSROOM,
+        page: 1,
+        limit: 20,
+      });
+
+      expect(dimensionRepository.findAndCount).toHaveBeenCalledWith(
+        { questionnaireType: QuestionnaireType.FACULTY_IN_CLASSROOM },
+        expect.objectContaining({ limit: 20, offset: 0 }),
+      );
+    });
+
+    it('should apply active filter', async () => {
+      dimensionRepository.findAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({ active: true, page: 1, limit: 20 });
+
+      expect(dimensionRepository.findAndCount).toHaveBeenCalledWith(
+        { active: true },
+        expect.anything(),
+      );
+    });
+
+    it('should return empty results', async () => {
+      dimensionRepository.findAndCount.mockResolvedValue([[], 0]);
+
+      const result = await service.findAll({ page: 1, limit: 20 });
+
+      expect(result.data).toHaveLength(0);
+      expect(result.meta.totalItems).toBe(0);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return the dimension when found', async () => {
+      dimensionRepository.findOne.mockResolvedValue(mockDimension);
+
+      const result = await service.findOne('dim-1');
+      expect(result.id).toBe('dim-1');
+    });
+
+    it('should throw NotFoundException when not found', async () => {
+      dimensionRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.findOne('missing')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('should update displayName', async () => {
+      const dimension = { ...mockDimension };
+      dimensionRepository.findOne.mockResolvedValue(dimension);
+
+      const result = await service.update('dim-1', {
+        displayName: 'Updated Name',
+      });
+
+      expect(dimension.displayName).toBe('Updated Name');
+      expect(em.flush).toHaveBeenCalled();
+      expect(result.displayName).toBe('Updated Name');
+    });
+
+    it('should throw NotFoundException when dimension not found', async () => {
+      dimensionRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.update('missing', { displayName: 'Test' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('deactivate', () => {
+    it('should deactivate an active dimension', async () => {
+      const dimension = { ...mockDimension, active: true };
+      dimensionRepository.findOne.mockResolvedValue(dimension);
+
+      const result = await service.deactivate('dim-1');
+
+      expect(dimension.active).toBe(false);
+      expect(em.flush).toHaveBeenCalled();
+      expect(result.active).toBe(false);
+    });
+
+    it('should throw BadRequestException when already inactive', async () => {
+      dimensionRepository.findOne.mockResolvedValue({
+        ...mockDimension,
+        active: false,
+      });
+
+      await expect(service.deactivate('dim-1')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw NotFoundException when not found', async () => {
+      dimensionRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.deactivate('missing')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('activate', () => {
+    it('should activate an inactive dimension', async () => {
+      const dimension = { ...mockDimension, active: false };
+      dimensionRepository.findOne.mockResolvedValue(dimension);
+
+      const result = await service.activate('dim-1');
+
+      expect(dimension.active).toBe(true);
+      expect(em.flush).toHaveBeenCalled();
+      expect(result.active).toBe(true);
+    });
+
+    it('should throw BadRequestException when already active', async () => {
+      dimensionRepository.findOne.mockResolvedValue({
+        ...mockDimension,
+        active: true,
+      });
+
+      await expect(service.activate('dim-1')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw NotFoundException when not found', async () => {
+      dimensionRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.activate('missing')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/src/modules/dimensions/services/dimensions.service.ts
+++ b/src/modules/dimensions/services/dimensions.service.ts
@@ -1,0 +1,150 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { EntityManager } from '@mikro-orm/postgresql';
+import { UniqueConstraintViolationException } from '@mikro-orm/postgresql';
+import { DimensionRepository } from 'src/repositories/dimension.repository';
+import { Dimension } from 'src/entities/dimension.entity';
+import { CreateDimensionRequestDto } from '../dto/requests/create-dimension.request.dto';
+import { UpdateDimensionRequestDto } from '../dto/requests/update-dimension.request.dto';
+import { ListDimensionsQueryDto } from '../dto/requests/list-dimensions-query.dto';
+import { DimensionResponseDto } from '../dto/responses/dimension.response.dto';
+import { DimensionListResponseDto } from '../dto/responses/dimension-list.response.dto';
+import { FilterQuery } from '@mikro-orm/core';
+
+@Injectable()
+export class DimensionsService {
+  constructor(
+    private readonly dimensionRepository: DimensionRepository,
+    private readonly em: EntityManager,
+  ) {}
+
+  async create(dto: CreateDimensionRequestDto): Promise<DimensionResponseDto> {
+    const code = dto.code ?? this.GenerateCode(dto.displayName);
+
+    const dimension = this.em.create(Dimension, {
+      code,
+      displayName: dto.displayName,
+      questionnaireType: dto.questionnaireType,
+      active: true,
+    });
+
+    try {
+      await this.em.persist(dimension).flush();
+    } catch (error) {
+      if (error instanceof UniqueConstraintViolationException) {
+        throw new ConflictException(
+          `Dimension with code '${code}' already exists for questionnaire type '${dto.questionnaireType}'.`,
+        );
+      }
+      throw error;
+    }
+
+    return DimensionResponseDto.Map(dimension);
+  }
+
+  async findAll(
+    query: ListDimensionsQueryDto,
+  ): Promise<DimensionListResponseDto> {
+    const filter: FilterQuery<Dimension> = {};
+
+    if (query.questionnaireType !== undefined) {
+      filter.questionnaireType = query.questionnaireType;
+    }
+    if (query.active !== undefined) {
+      filter.active = query.active;
+    }
+
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    const offset = (page - 1) * limit;
+
+    const [dimensions, totalItems] =
+      await this.dimensionRepository.findAndCount(filter, {
+        limit,
+        offset,
+        orderBy: { questionnaireType: 'ASC', code: 'ASC' },
+      });
+
+    return {
+      data: dimensions.map((d) => DimensionResponseDto.Map(d)),
+      meta: {
+        totalItems,
+        itemCount: dimensions.length,
+        itemsPerPage: limit,
+        totalPages: Math.ceil(totalItems / limit),
+        currentPage: page,
+      },
+    };
+  }
+
+  async findOne(id: string): Promise<DimensionResponseDto> {
+    const dimension = await this.dimensionRepository.findOne({ id });
+
+    if (!dimension) {
+      throw new NotFoundException(`Dimension with id '${id}' not found.`);
+    }
+
+    return DimensionResponseDto.Map(dimension);
+  }
+
+  async update(
+    id: string,
+    dto: UpdateDimensionRequestDto,
+  ): Promise<DimensionResponseDto> {
+    const dimension = await this.dimensionRepository.findOne({ id });
+
+    if (!dimension) {
+      throw new NotFoundException(`Dimension with id '${id}' not found.`);
+    }
+
+    dimension.displayName = dto.displayName;
+    await this.em.flush();
+
+    return DimensionResponseDto.Map(dimension);
+  }
+
+  async deactivate(id: string): Promise<DimensionResponseDto> {
+    const dimension = await this.dimensionRepository.findOne({ id });
+
+    if (!dimension) {
+      throw new NotFoundException(`Dimension with id '${id}' not found.`);
+    }
+
+    if (!dimension.active) {
+      throw new BadRequestException('Dimension is already inactive.');
+    }
+
+    dimension.active = false;
+    await this.em.flush();
+
+    return DimensionResponseDto.Map(dimension);
+  }
+
+  async activate(id: string): Promise<DimensionResponseDto> {
+    const dimension = await this.dimensionRepository.findOne({ id });
+
+    if (!dimension) {
+      throw new NotFoundException(`Dimension with id '${id}' not found.`);
+    }
+
+    if (dimension.active) {
+      throw new BadRequestException('Dimension is already active.');
+    }
+
+    dimension.active = true;
+    await this.em.flush();
+
+    return DimensionResponseDto.Map(dimension);
+  }
+
+  private GenerateCode(displayName: string): string {
+    return displayName
+      .toUpperCase()
+      .replace(/[^A-Z0-9]+/g, '_')
+      .replace(/^_+|_+$/g, '');
+  }
+}

--- a/src/modules/index.module.ts
+++ b/src/modules/index.module.ts
@@ -16,6 +16,7 @@ import { EnrollmentsModule } from './enrollments/enrollments.module';
 import { ScheduleModule } from '@nestjs/schedule';
 import { QuestionnaireModule } from './questionnaires/questionnaires.module';
 import { AnalysisModule } from './analysis/analysis.module';
+import { DimensionsModule } from './dimensions/dimensions.module';
 import { LoggerModule } from 'nestjs-pino';
 import { v4 } from 'uuid';
 
@@ -27,6 +28,7 @@ export const ApplicationModules = [
   EnrollmentsModule,
   QuestionnaireModule,
   AnalysisModule,
+  DimensionsModule,
 ];
 
 export const InfrastructureModules = [

--- a/src/security/decorators/index.ts
+++ b/src/security/decorators/index.ts
@@ -3,6 +3,8 @@ import { AuthGuard } from '@nestjs/passport';
 import { ApiBearerAuth } from '@nestjs/swagger';
 import { ACCESS_TOKEN } from 'src/configurations/index.config';
 
+export { Roles, ROLES_KEY } from './roles.decorator';
+
 export function UseJwtGuard() {
   return applyDecorators(
     ApiBearerAuth(ACCESS_TOKEN),

--- a/src/security/decorators/roles.decorator.ts
+++ b/src/security/decorators/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { UserRole } from 'src/modules/auth/roles.enum';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: UserRole[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/security/guards/roles.guard.spec.ts
+++ b/src/security/guards/roles.guard.spec.ts
@@ -1,0 +1,97 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Reflector } from '@nestjs/core';
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { RolesGuard } from './roles.guard';
+import { UserRepository } from 'src/repositories/user.repository';
+import { UserRole } from 'src/modules/auth/roles.enum';
+
+describe('RolesGuard', () => {
+  let guard: RolesGuard;
+  let reflector: Reflector;
+  let userRepository: { findOne: jest.Mock };
+
+  beforeEach(async () => {
+    userRepository = { findOne: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RolesGuard,
+        Reflector,
+        { provide: UserRepository, useValue: userRepository },
+      ],
+    }).compile();
+
+    guard = module.get(RolesGuard);
+    reflector = module.get(Reflector);
+  });
+
+  function createMockContext(userId?: string): ExecutionContext {
+    return {
+      getHandler: jest.fn(),
+      getClass: jest.fn(),
+      switchToHttp: () => ({
+        getRequest: () => ({
+          user: userId ? { userId } : undefined,
+        }),
+      }),
+    } as unknown as ExecutionContext;
+  }
+
+  it('should allow access when no roles metadata is set', async () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(undefined);
+
+    const result = await guard.canActivate(createMockContext('user-1'));
+    expect(result).toBe(true);
+  });
+
+  it('should allow access when user has a matching role', async () => {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue([UserRole.ADMIN, UserRole.SUPER_ADMIN]);
+
+    userRepository.findOne.mockResolvedValue({
+      id: 'user-1',
+      roles: [UserRole.ADMIN],
+    });
+
+    const result = await guard.canActivate(createMockContext('user-1'));
+    expect(result).toBe(true);
+  });
+
+  it('should throw ForbiddenException when user lacks required role', async () => {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue([UserRole.SUPER_ADMIN]);
+
+    userRepository.findOne.mockResolvedValue({
+      id: 'user-1',
+      roles: [UserRole.STUDENT],
+    });
+
+    await expect(
+      guard.canActivate(createMockContext('user-1')),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('should throw ForbiddenException when request.user is missing', async () => {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue([UserRole.ADMIN]);
+
+    await expect(guard.canActivate(createMockContext())).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('should throw ForbiddenException when user is not found in database', async () => {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue([UserRole.ADMIN]);
+
+    userRepository.findOne.mockResolvedValue(null);
+
+    await expect(
+      guard.canActivate(createMockContext('user-1')),
+    ).rejects.toThrow(ForbiddenException);
+  });
+});

--- a/src/security/guards/roles.guard.ts
+++ b/src/security/guards/roles.guard.ts
@@ -1,0 +1,54 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
+import { UserRepository } from 'src/repositories/user.repository';
+import { UserRole } from 'src/modules/auth/roles.enum';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+
+interface AuthenticatedUser {
+  userId: string;
+  moodleUserId: number;
+}
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly userRepository: UserRepository,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(
+      ROLES_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest<Request>();
+    const authUser = request.user as AuthenticatedUser | undefined;
+    const userId = authUser?.userId;
+
+    if (!userId) {
+      throw new ForbiddenException('Access denied');
+    }
+
+    const user = await this.userRepository.findOne(
+      { id: userId },
+      { fields: ['id', 'roles'] },
+    );
+
+    if (!user || !user.roles.some((role) => requiredRoles.includes(role))) {
+      throw new ForbiddenException('Access denied');
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
Introduce admin-only endpoints for managing dimensions used by the questionnaire engine. Dimensions can be created with an optional code that is auto-generated from displayName when omitted, supporting a seamless inline-creation UX in the questionnaire builder.

Also adds reusable @/Roles() decorator and RolesGuard infrastructure that queries the database for fresh user roles on each request.