### PR TITLE
FAC-49 feat: add draft questionnaire version update endpoint

### DIFF
--- a/src/modules/questionnaires/dto/requests/update-version-request.dto.ts
+++ b/src/modules/questionnaires/dto/requests/update-version-request.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsObject, IsNotEmpty, IsString, IsOptional } from 'class-validator';
+import type { QuestionnaireSchemaSnapshot } from '../../lib/questionnaire.types';
+
+export class UpdateVersionRequest {
+  @ApiProperty()
+  @IsObject()
+  @IsNotEmpty()
+  schema!: QuestionnaireSchemaSnapshot;
+
+  @ApiProperty({ required: false })
+  @IsString()
+  @IsNotEmpty()
+  @IsOptional()
+  title?: string;
+}

--- a/src/modules/questionnaires/dto/responses/questionnaire-version-detail-response.dto.ts
+++ b/src/modules/questionnaires/dto/responses/questionnaire-version-detail-response.dto.ts
@@ -1,0 +1,60 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  QuestionnaireStatus,
+  QuestionnaireType,
+} from '../../lib/questionnaire.types';
+import type { QuestionnaireSchemaSnapshot } from '../../lib/questionnaire.types';
+import type { QuestionnaireVersion } from 'src/entities/questionnaire-version.entity';
+
+export class QuestionnaireVersionDetailResponse {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  questionnaireId: string;
+
+  @ApiProperty()
+  questionnaireTitle: string;
+
+  @ApiProperty({ enum: QuestionnaireType })
+  questionnaireType: QuestionnaireType;
+
+  @ApiProperty()
+  versionNumber: number;
+
+  @ApiProperty({ enum: QuestionnaireStatus })
+  status: QuestionnaireStatus;
+
+  @ApiProperty()
+  isActive: boolean;
+
+  @ApiProperty()
+  schemaSnapshot: QuestionnaireSchemaSnapshot;
+
+  @ApiProperty({ required: false, nullable: true })
+  publishedAt?: Date;
+
+  @ApiProperty()
+  createdAt: Date;
+
+  @ApiProperty()
+  updatedAt: Date;
+
+  static Map(
+    version: QuestionnaireVersion,
+  ): QuestionnaireVersionDetailResponse {
+    return {
+      id: version.id,
+      questionnaireId: version.questionnaire.id,
+      questionnaireTitle: version.questionnaire.title,
+      questionnaireType: version.questionnaire.type,
+      versionNumber: version.versionNumber,
+      status: version.status,
+      isActive: version.isActive,
+      schemaSnapshot: version.schemaSnapshot,
+      publishedAt: version.publishedAt,
+      createdAt: version.createdAt,
+      updatedAt: version.updatedAt,
+    };
+  }
+}

--- a/src/modules/questionnaires/questionnaire.controller.ts
+++ b/src/modules/questionnaires/questionnaire.controller.ts
@@ -9,18 +9,23 @@ import {
   Query,
   Request,
   UseInterceptors,
+  UseGuards,
 } from '@nestjs/common';
 import { QuestionnaireService } from './services/questionnaire.service';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { CreateQuestionnaireRequest } from './dto/requests/create-questionnaire-request.dto';
 import { CreateVersionRequest } from './dto/requests/create-version-request.dto';
+import { UpdateVersionRequest } from './dto/requests/update-version-request.dto';
 import { SubmitQuestionnaireRequest } from './dto/requests/submit-questionnaire-request.dto';
 import { SaveDraftRequest } from './dto/requests/save-draft-request.dto';
 import { GetDraftRequest } from './dto/requests/get-draft-request.dto';
 import { GetVersionsByTypeParam } from './dto/requests/get-versions-by-type-request.dto';
 import { QuestionnaireVersionsResponse } from './dto/responses/questionnaire-version-response.dto';
+import { QuestionnaireVersionDetailResponse } from './dto/responses/questionnaire-version-detail-response.dto';
 import { DraftResponse } from './dto/responses/draft-response.dto';
-import { UseJwtGuard } from 'src/security/decorators';
+import { UseJwtGuard, Roles } from 'src/security/decorators';
+import { RolesGuard } from 'src/security/guards/roles.guard';
+import { UserRole } from '../auth/roles.enum';
 import { CurrentUserInterceptor } from '../common/interceptors/current-user.interceptor';
 import type { AuthenticatedRequest } from '../common/interceptors/http/authenticated-request';
 
@@ -96,6 +101,47 @@ export class QuestionnaireController {
   @ApiResponse({ status: 404, description: 'Version not found' })
   async deprecateVersion(@Param('versionId') versionId: string) {
     return this.questionnaireService.DeprecateVersion(versionId);
+  }
+
+  @Get('versions/:versionId')
+  @UseJwtGuard()
+  @Roles(UserRole.SUPER_ADMIN, UserRole.ADMIN)
+  @UseGuards(RolesGuard)
+  @ApiOperation({ summary: 'Get a questionnaire version by ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Version found',
+    type: QuestionnaireVersionDetailResponse,
+  })
+  @ApiResponse({ status: 404, description: 'Version not found' })
+  async getVersionById(
+    @Param('versionId') versionId: string,
+  ): Promise<QuestionnaireVersionDetailResponse> {
+    const version = await this.questionnaireService.GetVersionById(versionId);
+    return QuestionnaireVersionDetailResponse.Map(version);
+  }
+
+  @Patch('versions/:versionId')
+  @UseJwtGuard()
+  @Roles(UserRole.SUPER_ADMIN, UserRole.ADMIN)
+  @UseGuards(RolesGuard)
+  @ApiOperation({ summary: 'Update a draft questionnaire version' })
+  @ApiResponse({
+    status: 200,
+    description: 'Version updated successfully',
+    type: QuestionnaireVersionDetailResponse,
+  })
+  @ApiResponse({ status: 400, description: 'Version is not a draft' })
+  @ApiResponse({ status: 404, description: 'Version not found' })
+  async updateDraftVersion(
+    @Param('versionId') versionId: string,
+    @Body() data: UpdateVersionRequest,
+  ): Promise<QuestionnaireVersionDetailResponse> {
+    const version = await this.questionnaireService.UpdateDraftVersion(
+      versionId,
+      { schema: data.schema, title: data.title },
+    );
+    return QuestionnaireVersionDetailResponse.Map(version);
   }
 
   @Post('submissions')

--- a/src/modules/questionnaires/questionnaires.module.ts
+++ b/src/modules/questionnaires/questionnaires.module.ts
@@ -8,6 +8,7 @@ import {
   QuestionnaireDraft,
   Dimension,
   Enrollment,
+  User,
 } from '../../entities/index.entity';
 import { QuestionnaireService } from './services/questionnaire.service';
 import { QuestionnaireController } from './questionnaire.controller';
@@ -35,6 +36,7 @@ import { AnalysisModule } from '../analysis/analysis.module';
       QuestionnaireDraft,
       Dimension,
       Enrollment,
+      User,
     ]),
     DataLoaderModule,
     CommonModule,

--- a/src/modules/questionnaires/services/questionnaire.service.spec.ts
+++ b/src/modules/questionnaires/services/questionnaire.service.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { env } from 'src/configurations/env';
 import { Test, TestingModule } from '@nestjs/testing';
 import { QuestionnaireService } from './questionnaire.service';
@@ -818,6 +819,121 @@ describe('QuestionnaireService', () => {
       const result = await service.ListMyDrafts(RESPONDENT_ID);
 
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('GetVersionById', () => {
+    it('should throw NotFoundException if version is not found', async () => {
+      versionRepo.findOne.mockResolvedValue(null);
+      await expect(service.GetVersionById('v1')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should return version with populated questionnaire', async () => {
+      const mockVersion = {
+        id: 'v1',
+        questionnaire: {
+          id: 'q1',
+          title: 'Test',
+          type: 'FACULTY_IN_CLASSROOM',
+        },
+        versionNumber: 1,
+        status: QuestionnaireStatus.DRAFT,
+        isActive: false,
+        schemaSnapshot: { sections: [] },
+      };
+      versionRepo.findOne.mockResolvedValue(mockVersion as any);
+
+      const result = await service.GetVersionById('v1');
+
+      expect(result).toEqual(mockVersion);
+      expect(versionRepo.findOne).toHaveBeenCalledWith('v1', {
+        populate: ['questionnaire'],
+      });
+    });
+  });
+
+  describe('UpdateDraftVersion', () => {
+    const mockSchema = {
+      meta: {
+        questionnaireType: 'FACULTY_IN_CLASSROOM',
+        version: 1,
+        maxScore: 5,
+      },
+      sections: [{ id: 'sec1', questions: [] }],
+    };
+
+    it('should throw NotFoundException if version is not found', async () => {
+      versionRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.UpdateDraftVersion('v1', { schema: mockSchema as any }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw BadRequestException if version is not a draft', async () => {
+      versionRepo.findOne.mockResolvedValue({
+        id: 'v1',
+        status: QuestionnaireStatus.ACTIVE,
+        questionnaire: { id: 'q1', title: 'Test' },
+      } as any);
+
+      await expect(
+        service.UpdateDraftVersion('v1', { schema: mockSchema as any }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should update schema successfully', async () => {
+      const mockVersion = {
+        id: 'v1',
+        status: QuestionnaireStatus.DRAFT,
+        schemaSnapshot: { sections: [] },
+        questionnaire: { id: 'q1', title: 'Original Title' },
+      };
+      versionRepo.findOne.mockResolvedValue(mockVersion as any);
+
+      const result = await service.UpdateDraftVersion('v1', {
+        schema: mockSchema as any,
+      });
+
+      expect(result.schemaSnapshot).toEqual(mockSchema);
+      expect(result.questionnaire.title).toBe('Original Title');
+      expect(em.flush).toHaveBeenCalled();
+    });
+
+    it('should update both schema and title when title is provided', async () => {
+      const mockVersion = {
+        id: 'v1',
+        status: QuestionnaireStatus.DRAFT,
+        schemaSnapshot: { sections: [] },
+        questionnaire: { id: 'q1', title: 'Original Title' },
+      };
+      versionRepo.findOne.mockResolvedValue(mockVersion as any);
+
+      const result = await service.UpdateDraftVersion('v1', {
+        schema: mockSchema as any,
+        title: 'New Title',
+      });
+
+      expect(result.schemaSnapshot).toEqual(mockSchema);
+      expect(result.questionnaire.title).toBe('New Title');
+      expect(em.flush).toHaveBeenCalled();
+    });
+
+    it('should not update title when title is omitted', async () => {
+      const mockVersion = {
+        id: 'v1',
+        status: QuestionnaireStatus.DRAFT,
+        schemaSnapshot: { sections: [] },
+        questionnaire: { id: 'q1', title: 'Original Title' },
+      };
+      versionRepo.findOne.mockResolvedValue(mockVersion as any);
+
+      await service.UpdateDraftVersion('v1', {
+        schema: mockSchema as any,
+      });
+
+      expect(mockVersion.questionnaire.title).toBe('Original Title');
     });
   });
 

--- a/src/modules/questionnaires/services/questionnaire.service.ts
+++ b/src/modules/questionnaires/services/questionnaire.service.ts
@@ -289,6 +289,53 @@ export class QuestionnaireService {
     return version;
   }
 
+  async GetVersionById(versionId: string): Promise<QuestionnaireVersion> {
+    const version = await this.versionRepo.findOne(versionId, {
+      populate: ['questionnaire'],
+    });
+
+    if (!version) {
+      throw new NotFoundException(
+        `Questionnaire version with ID ${versionId} not found.`,
+      );
+    }
+
+    return version;
+  }
+
+  async UpdateDraftVersion(
+    versionId: string,
+    data: { schema: QuestionnaireSchemaSnapshot; title?: string },
+  ): Promise<QuestionnaireVersion> {
+    const version = await this.versionRepo.findOne(versionId, {
+      populate: ['questionnaire'],
+    });
+
+    if (!version) {
+      throw new NotFoundException(
+        `Questionnaire version with ID ${versionId} not found.`,
+      );
+    }
+
+    if (version.status !== QuestionnaireStatus.DRAFT) {
+      throw new BadRequestException('Only draft versions can be updated.');
+    }
+
+    version.schemaSnapshot = data.schema;
+
+    if (data.title !== undefined) {
+      version.questionnaire.title = data.title;
+    }
+
+    await this.em.flush();
+    await this.cacheService.invalidateNamespaces(
+      CacheNamespace.QUESTIONNAIRE_TYPES,
+      CacheNamespace.QUESTIONNAIRE_VERSIONS,
+    );
+
+    return version;
+  }
+
   async GetLatestActiveVersion(questionnaireId: string) {
     const questionnaire = await this.questionnaireRepo.findOne(questionnaireId);
 


### PR DESCRIPTION
Add GET and PATCH endpoints for questionnaire versions to support editing draft schemas before publishing. Includes role-based auth guards (SUPER_ADMIN, ADMIN), version detail response DTO with parent questionnaire context, and OpenAPI response type annotations.