### PR TITLE
FAC-51 fix: compose JWT and RolesGuard in single UseGuards call to fix execution order

### DIFF
--- a/src/modules/dimensions/dimensions.controller.ts
+++ b/src/modules/dimensions/dimensions.controller.ts
@@ -6,11 +6,9 @@ import {
   Patch,
   Post,
   Query,
-  UseGuards,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { UseJwtGuard, Roles } from 'src/security/decorators';
-import { RolesGuard } from 'src/security/guards/roles.guard';
+import { UseJwtGuard } from 'src/security/decorators';
 import { UserRole } from '../auth/roles.enum';
 import { DimensionsService } from './services/dimensions.service';
 import { CreateDimensionRequestDto } from './dto/requests/create-dimension.request.dto';
@@ -19,9 +17,7 @@ import { ListDimensionsQueryDto } from './dto/requests/list-dimensions-query.dto
 
 @ApiTags('Dimensions')
 @Controller('dimensions')
-@UseJwtGuard()
-@Roles(UserRole.SUPER_ADMIN, UserRole.ADMIN)
-@UseGuards(RolesGuard)
+@UseJwtGuard(UserRole.SUPER_ADMIN, UserRole.ADMIN)
 export class DimensionsController {
   constructor(private readonly dimensionsService: DimensionsService) {}
 

--- a/src/modules/questionnaires/questionnaire.controller.ts
+++ b/src/modules/questionnaires/questionnaire.controller.ts
@@ -9,7 +9,6 @@ import {
   Query,
   Request,
   UseInterceptors,
-  UseGuards,
 } from '@nestjs/common';
 import { QuestionnaireService } from './services/questionnaire.service';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
@@ -23,8 +22,7 @@ import { GetVersionsByTypeParam } from './dto/requests/get-versions-by-type-requ
 import { QuestionnaireVersionsResponse } from './dto/responses/questionnaire-version-response.dto';
 import { QuestionnaireVersionDetailResponse } from './dto/responses/questionnaire-version-detail-response.dto';
 import { DraftResponse } from './dto/responses/draft-response.dto';
-import { UseJwtGuard, Roles } from 'src/security/decorators';
-import { RolesGuard } from 'src/security/guards/roles.guard';
+import { UseJwtGuard } from 'src/security/decorators';
 import { UserRole } from '../auth/roles.enum';
 import { CurrentUserInterceptor } from '../common/interceptors/current-user.interceptor';
 import type { AuthenticatedRequest } from '../common/interceptors/http/authenticated-request';
@@ -104,9 +102,7 @@ export class QuestionnaireController {
   }
 
   @Get('versions/:versionId')
-  @UseJwtGuard()
-  @Roles(UserRole.SUPER_ADMIN, UserRole.ADMIN)
-  @UseGuards(RolesGuard)
+  @UseJwtGuard(UserRole.SUPER_ADMIN, UserRole.ADMIN)
   @ApiOperation({ summary: 'Get a questionnaire version by ID' })
   @ApiResponse({
     status: 200,
@@ -122,9 +118,7 @@ export class QuestionnaireController {
   }
 
   @Patch('versions/:versionId')
-  @UseJwtGuard()
-  @Roles(UserRole.SUPER_ADMIN, UserRole.ADMIN)
-  @UseGuards(RolesGuard)
+  @UseJwtGuard(UserRole.SUPER_ADMIN, UserRole.ADMIN)
   @ApiOperation({ summary: 'Update a draft questionnaire version' })
   @ApiResponse({
     status: 200,

--- a/src/security/decorators/index.ts
+++ b/src/security/decorators/index.ts
@@ -1,11 +1,22 @@
-import { applyDecorators, UseGuards } from '@nestjs/common';
+import { applyDecorators, SetMetadata, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { ApiBearerAuth } from '@nestjs/swagger';
 import { ACCESS_TOKEN } from 'src/configurations/index.config';
+import { UserRole } from 'src/modules/auth/roles.enum';
+import { RolesGuard } from 'src/security/guards/roles.guard';
+import { ROLES_KEY } from './roles.decorator';
 
 export { Roles, ROLES_KEY } from './roles.decorator';
 
-export function UseJwtGuard() {
+export function UseJwtGuard(...roles: UserRole[]) {
+  if (roles.length > 0) {
+    return applyDecorators(
+      ApiBearerAuth(ACCESS_TOKEN),
+      SetMetadata(ROLES_KEY, roles),
+      UseGuards(AuthGuard('jwt'), RolesGuard),
+    );
+  }
+
   return applyDecorators(
     ApiBearerAuth(ACCESS_TOKEN),
     UseGuards(AuthGuard('jwt')),

--- a/src/security/decorators/use-jwt-guard.decorator.spec.ts
+++ b/src/security/decorators/use-jwt-guard.decorator.spec.ts
@@ -1,0 +1,47 @@
+import { Type } from '@nestjs/common';
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { AuthGuard } from '@nestjs/passport';
+import { UseJwtGuard, ROLES_KEY } from './index';
+import { RolesGuard } from 'src/security/guards/roles.guard';
+import { UserRole } from 'src/modules/auth/roles.enum';
+
+describe('UseJwtGuard', () => {
+  function applyDecorator(...roles: UserRole[]) {
+    @UseJwtGuard(...roles)
+    class TestController {}
+    return TestController;
+  }
+
+  it('should apply only JWT guard when no roles provided', () => {
+    const target = applyDecorator();
+    const guards = Reflect.getMetadata(GUARDS_METADATA, target) as Type[];
+
+    expect(guards).toHaveLength(1);
+    expect(guards[0]).toBe(AuthGuard('jwt'));
+  });
+
+  it('should not set roles metadata when no roles provided', () => {
+    const target = applyDecorator();
+    const roles = Reflect.getMetadata(ROLES_KEY, target) as
+      | UserRole[]
+      | undefined;
+
+    expect(roles).toBeUndefined();
+  });
+
+  it('should apply JWT guard and RolesGuard in correct order when roles provided', () => {
+    const target = applyDecorator(UserRole.SUPER_ADMIN, UserRole.ADMIN);
+    const guards = Reflect.getMetadata(GUARDS_METADATA, target) as Type[];
+
+    expect(guards).toHaveLength(2);
+    expect(guards[0]).toBe(AuthGuard('jwt'));
+    expect(guards[1]).toBe(RolesGuard);
+  });
+
+  it('should set roles metadata when roles provided', () => {
+    const target = applyDecorator(UserRole.SUPER_ADMIN, UserRole.ADMIN);
+    const roles = Reflect.getMetadata(ROLES_KEY, target) as UserRole[];
+
+    expect(roles).toEqual([UserRole.SUPER_ADMIN, UserRole.ADMIN]);
+  });
+});


### PR DESCRIPTION
UseJwtGuard now accepts optional roles and composes both guards in one UseGuards() call, ensuring JWT always runs before RolesGuard. This fixes 403 Forbidden errors for superadmin on drafted questionnaire versions and dimension endpoints.