### PR TITLE
FAC-52 feat: add topic labeling pipeline step with LLM-based label generation

### DIFF
--- a/docs/architecture/ai-inference-pipeline.md
+++ b/docs/architecture/ai-inference-pipeline.md
@@ -37,7 +37,8 @@ stateDiagram-v2
 
     SENTIMENT_ANALYSIS --> SENTIMENT_GATE: OnSentimentComplete()
     SENTIMENT_GATE --> TOPIC_MODELING: Gate applied, dispatch topic model
-    TOPIC_MODELING --> GENERATING_RECOMMENDATIONS: OnTopicModelComplete()
+    TOPIC_MODELING --> TOPIC_LABELING: OnTopicModelComplete()
+    TOPIC_LABELING --> GENERATING_RECOMMENDATIONS: Labels generated
     GENERATING_RECOMMENDATIONS --> COMPLETED: OnRecommendationsComplete()
 
     SENTIMENT_ANALYSIS --> FAILED: stage error
@@ -59,6 +60,7 @@ stateDiagram-v2
 | **Sentiment Analysis** | Batch of comments                       | Per-submission sentiment scores                                          |
 | **Sentiment Gate**     | Sentiment results                       | Filtered corpus (negative/neutral always pass; positive needs ≥10 words) |
 | **Topic Modeling**     | Gate-passing submissions + embeddings   | Topics, keyword clusters, soft assignments                               |
+| **Topic Labeling**     | Topics with raw labels + keywords       | Human-readable labels (2-4 words) via LLM                                |
 | **Recommendations**    | Aggregated sentiment + topics           | Prioritized action items                                                 |
 
 ### Coverage Warnings
@@ -216,7 +218,21 @@ BaseBatchProcessor          ← HTTP dispatch, Zod validation, retry
 | `unwrapResponse(body)` | Pass-through                     | RunPod `{ output: ... }` unwrapping           |
 | `getHttpTimeoutMs()`   | `BULLMQ_HTTP_TIMEOUT_MS`         | Per-processor timeout (topic model uses 300s) |
 
-## 11. Adding a New Analysis Type
+## 11. Topic Labeling
+
+After topic modeling completes and before recommendations are dispatched, the `TopicLabelService` generates human-readable labels for each discovered topic using an LLM (OpenAI `gpt-4o-mini`).
+
+**How it works:**
+
+1. The orchestrator fetches the latest `TopicModelRun` and its `Topic` entities.
+2. `TopicLabelService.generateLabels()` sends all topics (raw labels + keywords) to the LLM in a single request.
+3. The LLM returns short (2-4 word, title case) labels via structured output (`zodResponseFormat`).
+4. Labels are written to the `Topic.label` field and flushed to the database.
+5. Downstream consumers (recommendations, status endpoint) prefer `topic.label` over `topic.rawLabel`.
+
+**Resilience:** If the LLM call fails (rate limit, network error, empty response), the service logs a warning and falls back silently — topics retain their BERTopic-generated `rawLabel`. This is a non-blocking, best-effort enrichment step.
+
+## 12. Adding a New Analysis Type
 
 1. Create `NewTypeProcessor extends BaseBatchProcessor` (or `RunPodBatchProcessor` for RunPod workers) in `src/modules/analysis/processors/`
 2. Add `NEW_TYPE_WORKER_URL` and `NEW_TYPE_CONCURRENCY` to `src/configurations/env/bullmq.env.ts`
@@ -226,3 +242,5 @@ BaseBatchProcessor          ← HTTP dispatch, Zod validation, retry
 6. Update `PipelineStatus` enum with new stage
 7. Add worker contract doc in `docs/worker-contracts/`
 8. Add mock endpoint in `mock-worker/server.ts`
+
+For **non-queue enrichment steps** (like topic labeling), create a service in `src/modules/analysis/services/`, register it in `AnalysisModule`, inject it into `PipelineOrchestratorService`, and call it inline during stage transitions.

--- a/docs/architecture/core-components.md
+++ b/docs/architecture/core-components.md
@@ -67,6 +67,7 @@ classDiagram
         +AnalysisService
         +AnalysisController
         +PipelineOrchestratorService
+        +TopicLabelService
         +SentimentProcessor
         +TopicModelProcessor
         +RecommendationsProcessor
@@ -150,22 +151,23 @@ The `PipelineOrchestratorService` manages the full analysis lifecycle through a 
 
 ### Components
 
-| Component                     | Purpose                                                                       |
-| ----------------------------- | ----------------------------------------------------------------------------- |
-| `PipelineOrchestratorService` | Creates pipelines, manages stage transitions, dispatches batch jobs           |
-| `AnalysisService`             | Low-level entry point — `EnqueueJob()` and `EnqueueBatch()` for ad-hoc jobs   |
-| `AnalysisController`          | REST API for pipeline CRUD (`POST/GET /analysis/pipelines`)                   |
-| `BaseBatchProcessor`          | Abstract base — HTTP dispatch, Zod validation, retry, stall detection         |
-| `RunPodBatchProcessor`        | RunPod-specific subclass — auth headers, `{ input/output }` envelope handling |
-| `SentimentProcessor`          | Batch sentiment analysis, triggers sentiment gate on completion               |
-| `TopicModelProcessor`         | Batch topic modeling via RunPod, chunked assignment persistence               |
-| `RecommendationsProcessor`    | Generates prioritized action items from aggregated analysis data              |
-| `EmbeddingProcessor`          | Per-submission embedding generation (upsert, extends `BaseAnalysisProcessor`) |
+| Component                     | Purpose                                                                            |
+| ----------------------------- | ---------------------------------------------------------------------------------- |
+| `PipelineOrchestratorService` | Creates pipelines, manages stage transitions, dispatches batch jobs                |
+| `AnalysisService`             | Low-level entry point — `EnqueueJob()` and `EnqueueBatch()` for ad-hoc jobs        |
+| `AnalysisController`          | REST API for pipeline CRUD (`POST/GET /analysis/pipelines`)                        |
+| `BaseBatchProcessor`          | Abstract base — HTTP dispatch, Zod validation, retry, stall detection              |
+| `RunPodBatchProcessor`        | RunPod-specific subclass — auth headers, `{ input/output }` envelope handling      |
+| `SentimentProcessor`          | Batch sentiment analysis, triggers sentiment gate on completion                    |
+| `TopicModelProcessor`         | Batch topic modeling via RunPod, chunked assignment persistence                    |
+| `TopicLabelService`           | LLM-based labeling of BERTopic topics (gpt-4o-mini, inline before recommendations) |
+| `RecommendationsProcessor`    | Generates prioritized action items from aggregated analysis data                   |
+| `EmbeddingProcessor`          | Per-submission embedding generation (upsert, extends `BaseAnalysisProcessor`)      |
 
 ### Pipeline Stages
 
 ```
-AWAITING_CONFIRMATION → SENTIMENT_ANALYSIS → SENTIMENT_GATE → TOPIC_MODELING → GENERATING_RECOMMENDATIONS → COMPLETED
+AWAITING_CONFIRMATION → SENTIMENT_ANALYSIS → SENTIMENT_GATE → TOPIC_MODELING → TOPIC_LABELING → GENERATING_RECOMMENDATIONS → COMPLETED
 ```
 
 Each stage has a corresponding `RunStatus` (`PENDING` → `PROCESSING` → `COMPLETED` / `FAILED`).

--- a/docs/decisions/decisions.md
+++ b/docs/decisions/decisions.md
@@ -108,3 +108,11 @@ Topic modeling (and future GPU-bound workers) use a `RunPodBatchProcessor` base 
 
 - **Rationale:** RunPod serverless has a fixed request/response envelope format. Encoding this in a shared base class avoids duplicating wrapping logic across multiple GPU worker processors.
 - **Trade-off:** Adds an inheritance layer. Acceptable because the alternative (conditionals in `BaseBatchProcessor`) would couple the base class to a specific vendor.
+
+## 18. LLM-Based Topic Labeling as Inline Pipeline Step
+
+BERTopic produces machine-generated raw labels (e.g., `0_teaching_maayo_method`) that are not human-readable. The `TopicLabelService` calls OpenAI `gpt-4o-mini` with structured output (Zod schema via `zodResponseFormat`) to generate short (2-4 word) English labels for each topic before the recommendations stage.
+
+- **Inline, not queued:** Topic labeling runs synchronously inside the orchestrator's `OnTopicModelComplete()` handler rather than as a separate BullMQ stage. The LLM call is fast (single request for all topics) and doesn't justify queue overhead.
+- **Non-blocking fallback:** If the LLM call fails, topics retain their `rawLabel`. Downstream consumers (recommendations aggregation, status endpoint) use `topic.label ?? topic.rawLabel`, so the pipeline never fails due to labeling.
+- **Trade-off:** Adds an OpenAI dependency to the pipeline. Acceptable because `OPENAI_API_KEY` is already required for the ChatKit module, and the cost per call is minimal (one request per pipeline run with a small payload).

--- a/docs/workflows/analysis-pipeline.md
+++ b/docs/workflows/analysis-pipeline.md
@@ -82,12 +82,23 @@ The `TopicModelProcessor`:
 6. Updates run metadata (topic count, outlier count, quality metrics).
 7. Calls `OnTopicModelComplete()`.
 
-## 6. Recommendations
+## 6. Topic Labeling
+
+After topic modeling completes and before recommendations are dispatched, the orchestrator runs an inline enrichment step:
+
+1. Fetches the latest `TopicModelRun` and all its `Topic` entities.
+2. Calls `TopicLabelService.generateLabels(topics)`, which sends topics (raw labels + keywords) to OpenAI `gpt-4o-mini`.
+3. The LLM returns short, human-readable labels (2-4 words, title case) via Zod-validated structured output.
+4. Labels are written to `Topic.label` and flushed to the database.
+
+**Fallback:** If the LLM call fails, topics keep their BERTopic-generated `rawLabel`. This step is non-blocking.
+
+## 7. Recommendations
 
 The orchestrator aggregates data from previous stages:
 
 - Sentiment label counts (positive/neutral/negative)
-- Top 10 topics with keywords and document counts
+- Top 10 topics with keywords and document counts (using `topic.label` when available, falling back to `topic.rawLabel`)
 - Coverage metadata
 
 Creates a `RecommendationRun` and dispatches to the recommendations queue.
@@ -98,7 +109,7 @@ The `RecommendationsProcessor`:
 2. Creates `RecommendedAction` entities with category, priority (HIGH/MEDIUM/LOW), action text, and supporting evidence (JSONB).
 3. Calls `OnRecommendationsComplete()`.
 
-## 7. Completion
+## 8. Completion
 
 Pipeline status moves to `COMPLETED` with `completedAt` timestamp.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "ioredis": "^5.10.0",
         "js-yaml": "^4.1.1",
         "nestjs-pino": "^4.6.0",
+        "openai": "^6.29.0",
         "p-limit": "^7.3.0",
         "passport-jwt": "^4.0.1",
         "pgvector": "^0.2.1",
@@ -10837,9 +10838,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.22.0.tgz",
-      "integrity": "sha512-7Yvy17F33Bi9RutWbsaYt5hJEEJ/krRPOrwan+f9aCPuMat1WVsb2VNSII5W1EksKT6fF69TG/xj4XzodK3JZw==",
+      "version": "6.29.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.29.0.tgz",
+      "integrity": "sha512-YxoArl2BItucdO89/sN6edksV0x47WUTgkgVfCgX7EuEMhbirENsgYe5oO4LTjBL9PtdKtk2WqND1gSLcTd2yw==",
       "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "ioredis": "^5.10.0",
     "js-yaml": "^4.1.1",
     "nestjs-pino": "^4.6.0",
+    "openai": "^6.29.0",
     "p-limit": "^7.3.0",
     "passport-jwt": "^4.0.1",
     "pgvector": "^0.2.1",

--- a/src/modules/analysis/analysis.module.ts
+++ b/src/modules/analysis/analysis.module.ts
@@ -20,6 +20,7 @@ import { EmbeddingProcessor } from './processors/embedding.processor';
 import { TopicModelProcessor } from './processors/topic-model.processor';
 import { RecommendationsProcessor } from './processors/recommendations.processor';
 import { PipelineOrchestratorService } from './services/pipeline-orchestrator.service';
+import { TopicLabelService } from './services/topic-label.service';
 
 @Module({
   imports: [
@@ -50,6 +51,7 @@ import { PipelineOrchestratorService } from './services/pipeline-orchestrator.se
     TopicModelProcessor,
     RecommendationsProcessor,
     PipelineOrchestratorService,
+    TopicLabelService,
   ],
   exports: [AnalysisService, PipelineOrchestratorService],
 })

--- a/src/modules/analysis/services/pipeline-orchestrator.service.spec.ts
+++ b/src/modules/analysis/services/pipeline-orchestrator.service.spec.ts
@@ -5,6 +5,7 @@ import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { getQueueToken } from '@nestjs/bullmq';
 import { EntityManager } from '@mikro-orm/postgresql';
 import { PipelineOrchestratorService } from './pipeline-orchestrator.service';
+import { TopicLabelService } from './topic-label.service';
 import { AnalysisService } from '../analysis.service';
 import { PipelineStatus, RunStatus } from '../enums';
 import { SENTIMENT_GATE } from '../constants';
@@ -59,6 +60,10 @@ describe('PipelineOrchestratorService', () => {
         PipelineOrchestratorService,
         { provide: EntityManager, useValue: mockEm },
         { provide: AnalysisService, useValue: mockAnalysisService },
+        {
+          provide: TopicLabelService,
+          useValue: { generateLabels: jest.fn().mockResolvedValue(undefined) },
+        },
         { provide: getQueueToken('sentiment'), useValue: sentimentQueue },
         { provide: getQueueToken('topic-model'), useValue: topicModelQueue },
         {

--- a/src/modules/analysis/services/pipeline-orchestrator.service.ts
+++ b/src/modules/analysis/services/pipeline-orchestrator.service.ts
@@ -36,6 +36,7 @@ import { BatchAnalysisJobMessage } from '../dto/batch-analysis-job-message.dto';
 import { batchAnalysisJobSchema } from '../dto/batch-analysis-job-message.dto';
 import { PipelineStatusResponse } from '../dto/pipeline-status.dto';
 import { AnalysisService } from '../analysis.service';
+import { TopicLabelService } from './topic-label.service';
 
 interface CoverageStats {
   totalEnrolled: number;
@@ -68,6 +69,7 @@ export class PipelineOrchestratorService {
   constructor(
     private readonly em: EntityManager,
     private readonly analysisService: AnalysisService,
+    private readonly topicLabelService: TopicLabelService,
     @InjectQueue('sentiment') private readonly sentimentQueue: Queue,
     @InjectQueue('topic-model') private readonly topicModelQueue: Queue,
     @InjectQueue('recommendations')
@@ -383,6 +385,18 @@ export class PipelineOrchestratorService {
         'RECOMMENDATIONS_WORKER_URL not configured',
       );
       return;
+    }
+
+    // Generate human-readable labels before dispatching recommendations
+    const topicModelRun = await fork.findOne(
+      TopicModelRun,
+      { pipeline },
+      { orderBy: { createdAt: 'DESC' } },
+    );
+    if (topicModelRun) {
+      const topics = await fork.find(Topic, { run: topicModelRun });
+      await this.topicLabelService.generateLabels(topics);
+      await fork.flush();
     }
 
     pipeline.status = PipelineStatus.GENERATING_RECOMMENDATIONS;
@@ -889,7 +903,7 @@ export class PipelineOrchestratorService {
       );
       for (const t of topics) {
         topTopics.push({
-          label: t.rawLabel,
+          label: t.label ?? t.rawLabel,
           keywords: t.keywords,
           docCount: t.docCount,
         });

--- a/src/modules/analysis/services/topic-label.service.spec.ts
+++ b/src/modules/analysis/services/topic-label.service.spec.ts
@@ -1,0 +1,167 @@
+import { TopicLabelService } from './topic-label.service';
+import { Topic } from 'src/entities/topic.entity';
+
+// Mock env before importing the service
+jest.mock('src/configurations/env', () => ({
+  env: { OPENAI_API_KEY: 'test-key' },
+}));
+
+// Mock OpenAI
+const mockParse = jest.fn();
+jest.mock('openai', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      chat: {
+        completions: {
+          parse: mockParse,
+        },
+      },
+    })),
+  };
+});
+
+jest.mock('openai/helpers/zod', () => ({
+  zodResponseFormat: jest.fn().mockReturnValue({ type: 'json_schema' }),
+}));
+
+describe('TopicLabelService', () => {
+  let service: TopicLabelService;
+
+  const createMockTopic = (
+    topicIndex: number,
+    rawLabel: string,
+    keywords: string[],
+  ): Topic =>
+    ({
+      topicIndex,
+      rawLabel,
+      keywords,
+      label: undefined,
+    }) as unknown as Topic;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new TopicLabelService();
+  });
+
+  it('should set labels on topics from LLM response', async () => {
+    const topics = [
+      createMockTopic(0, '0_teaching_maayo_method', [
+        'teaching',
+        'maayo',
+        'method',
+      ]),
+      createMockTopic(1, '1_schedule_time_class', [
+        'schedule',
+        'time',
+        'class',
+      ]),
+    ];
+
+    mockParse.mockResolvedValue({
+      choices: [
+        {
+          message: {
+            parsed: {
+              labels: [
+                { topicIndex: 0, label: 'Teaching Methods' },
+                { topicIndex: 1, label: 'Class Scheduling' },
+              ],
+            },
+          },
+        },
+      ],
+    });
+
+    await service.generateLabels(topics);
+
+    expect((topics[0] as unknown as Record<string, unknown>).label).toBe(
+      'Teaching Methods',
+    );
+    expect((topics[1] as unknown as Record<string, unknown>).label).toBe(
+      'Class Scheduling',
+    );
+    expect(mockParse).toHaveBeenCalledTimes(1);
+  });
+
+  it('should leave labels unchanged on LLM failure', async () => {
+    const topics = [
+      createMockTopic(0, '0_teaching_maayo_method', [
+        'teaching',
+        'maayo',
+        'method',
+      ]),
+    ];
+
+    mockParse.mockRejectedValue(new Error('API rate limit'));
+
+    await service.generateLabels(topics);
+
+    expect(
+      (topics[0] as unknown as Record<string, unknown>).label,
+    ).toBeUndefined();
+  });
+
+  it('should handle empty parsed response gracefully', async () => {
+    const topics = [
+      createMockTopic(0, '0_teaching_maayo_method', [
+        'teaching',
+        'maayo',
+        'method',
+      ]),
+    ];
+
+    mockParse.mockResolvedValue({
+      choices: [{ message: { parsed: null } }],
+    });
+
+    await service.generateLabels(topics);
+
+    expect(
+      (topics[0] as unknown as Record<string, unknown>).label,
+    ).toBeUndefined();
+  });
+
+  it('should skip topics not in LLM response', async () => {
+    const topics = [
+      createMockTopic(0, '0_teaching_maayo_method', [
+        'teaching',
+        'maayo',
+        'method',
+      ]),
+      createMockTopic(1, '1_schedule_time_class', [
+        'schedule',
+        'time',
+        'class',
+      ]),
+    ];
+
+    mockParse.mockResolvedValue({
+      choices: [
+        {
+          message: {
+            parsed: {
+              labels: [{ topicIndex: 0, label: 'Teaching Methods' }],
+            },
+          },
+        },
+      ],
+    });
+
+    await service.generateLabels(topics);
+
+    expect((topics[0] as unknown as Record<string, unknown>).label).toBe(
+      'Teaching Methods',
+    );
+    expect(
+      (topics[1] as unknown as Record<string, unknown>).label,
+    ).toBeUndefined();
+  });
+
+  it('should do nothing for empty topics array', async () => {
+    await service.generateLabels([]);
+
+    expect(mockParse).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/analysis/services/topic-label.service.ts
+++ b/src/modules/analysis/services/topic-label.service.ts
@@ -1,0 +1,85 @@
+import { Injectable, Logger } from '@nestjs/common';
+import OpenAI from 'openai';
+import { zodResponseFormat } from 'openai/helpers/zod';
+import z from 'zod';
+import { env } from 'src/configurations/env';
+import { Topic } from 'src/entities/topic.entity';
+
+const topicLabelResponseSchema = z.object({
+  labels: z.array(
+    z.object({
+      topicIndex: z.number().int(),
+      label: z.string(),
+    }),
+  ),
+});
+
+type TopicLabelResponse = z.infer<typeof topicLabelResponseSchema>;
+
+@Injectable()
+export class TopicLabelService {
+  private readonly logger = new Logger(TopicLabelService.name);
+  private readonly openai: OpenAI;
+
+  constructor() {
+    this.openai = new OpenAI({ apiKey: env.OPENAI_API_KEY });
+  }
+
+  async generateLabels(topics: Topic[]): Promise<void> {
+    if (topics.length === 0) return;
+
+    const topicDescriptions = topics
+      .map(
+        (t) =>
+          `- Topic ${t.topicIndex}: rawLabel="${t.rawLabel}", keywords=[${t.keywords.join(', ')}]`,
+      )
+      .join('\n');
+
+    try {
+      const response = await this.openai.chat.completions.parse({
+        model: 'gpt-4o-mini',
+        messages: [
+          {
+            role: 'system',
+            content:
+              'You generate short, human-readable topic labels for BERTopic outputs. ' +
+              'Each label should be 2-4 words in English that clearly describe the theme. ' +
+              'Use title case.',
+          },
+          {
+            role: 'user',
+            content: `Generate a concise human-readable label for each of the following topics:\n\n${topicDescriptions}`,
+          },
+        ],
+        response_format: zodResponseFormat(
+          topicLabelResponseSchema,
+          'topic_labels',
+        ),
+      });
+
+      const parsed: TopicLabelResponse | null | undefined =
+        response.choices[0]?.message?.parsed;
+      if (!parsed) {
+        this.logger.warn('LLM returned no parsed content for topic labels');
+        return;
+      }
+
+      const labelMap = new Map<number, string>(
+        parsed.labels.map((l) => [l.topicIndex, l.label]),
+      );
+
+      for (const topic of topics) {
+        const label = labelMap.get(topic.topicIndex);
+        if (label) {
+          topic.label = label;
+        }
+      }
+
+      this.logger.log(`Generated labels for ${labelMap.size} topics`);
+    } catch (error) {
+      this.logger.warn(
+        `Failed to generate topic labels via LLM, falling back to rawLabel: ${(error as Error).message}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
Introduce TopicLabelService that calls OpenAI gpt-4o-mini to generate human-readable labels (2-4 words) for BERTopic-discovered topics. Runs inline in the orchestrator after topic modeling completes and before recommendations dispatch. Falls back silently to rawLabel on failure.