### PR TITLE
FAC-56 feat: add NestJS CLS integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "exceljs": "^4.4.0",
         "ioredis": "^5.10.0",
         "js-yaml": "^4.1.1",
+        "nestjs-cls": "^6.2.0",
         "nestjs-pino": "^4.6.0",
         "openai": "^6.29.0",
         "p-limit": "^7.3.0",
@@ -10667,6 +10668,21 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nestjs-cls": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/nestjs-cls/-/nestjs-cls-6.2.0.tgz",
+      "integrity": "sha512-b2Remha7gV5gId3ezjr2tupjqqgYK7/JqjqX6oZ0ZIDFATUggKH1/32+ul2lOe7FepnHasDONDoePuWEE64cug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@nestjs/common": ">= 10 < 12",
+        "@nestjs/core": ">= 10 < 12",
+        "reflect-metadata": "*",
+        "rxjs": ">= 7"
+      }
     },
     "node_modules/nestjs-pino": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "exceljs": "^4.4.0",
     "ioredis": "^5.10.0",
     "js-yaml": "^4.1.1",
+    "nestjs-cls": "^6.2.0",
     "nestjs-pino": "^4.6.0",
     "openai": "^6.29.0",
     "p-limit": "^7.3.0",

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -4,17 +4,14 @@ import {
   Get,
   Post,
   Req,
-  Request,
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { LoginRequest } from './dto/requests/login.request.dto';
-import type { AuthenticatedRequest } from '../common/interceptors/http/authenticated-request';
 import { CurrentUserInterceptor } from '../common/interceptors/current-user.interceptor';
 import { UseJwtGuard } from 'src/security/decorators';
 import { MetaDataInterceptor } from '../common/interceptors/metadata.interceptor';
-import type { EnrichedRequest } from '../common/interceptors/http/enriched-request';
 import { JwtRefreshGuard } from 'src/security/guards/refresh-jwt-auth.guard';
 import type { RefreshTokenRequest } from '../common/interceptors/http/refresh-token-request';
 import { RefreshTokenRequestBody } from './dto/requests/refresh-token.request.dto';
@@ -25,36 +22,35 @@ export class AuthController {
 
   @Post('login')
   @UseInterceptors(MetaDataInterceptor)
-  async Login(@Body() body: LoginRequest, @Req() request: EnrichedRequest) {
-    return await this.authService.Login(body, request.metaData);
+  async Login(@Body() body: LoginRequest) {
+    return await this.authService.Login(body);
   }
 
   @Get('me')
   @UseJwtGuard()
   @UseInterceptors(CurrentUserInterceptor)
-  me(@Request() request: AuthenticatedRequest) {
-    return this.authService.Me(request.currentUser);
+  me() {
+    return this.authService.Me();
   }
 
   @Post('refresh')
   @UseGuards(JwtRefreshGuard)
   @UseInterceptors(MetaDataInterceptor)
   async Refresh(
-    @Req() request: RefreshTokenRequest & EnrichedRequest,
+    @Req() request: RefreshTokenRequest,
     @Body() body: RefreshTokenRequestBody,
   ) {
     return await this.authService.RefreshToken(
       request.user!.userId,
       body.refreshToken,
-      request.metaData,
     );
   }
 
   @Post('logout')
   @UseJwtGuard()
   @UseInterceptors(CurrentUserInterceptor)
-  async Logout(@Request() request: AuthenticatedRequest) {
-    await this.authService.Logout(request.currentUser!.id);
+  async Logout() {
+    await this.authService.Logout();
     return { message: 'Logged out successfully' };
   }
 }

--- a/src/modules/auth/auth.service.spec.ts
+++ b/src/modules/auth/auth.service.spec.ts
@@ -7,6 +7,20 @@ import * as bcrypt from 'bcrypt';
 import { UnauthorizedException } from '@nestjs/common';
 import { LOGIN_STRATEGIES, LoginStrategy } from './strategies';
 import { EntityManager } from '@mikro-orm/postgresql';
+import { CurrentUserService } from '../common/cls/current-user.service';
+import { RequestMetadataService } from '../common/cls/request-metadata.service';
+
+const mockMetadata = {
+  browserName: 'test',
+  os: 'test',
+  ipAddress: '127.0.0.1',
+};
+
+const mockRequestMetadataService = {
+  get: jest.fn().mockReturnValue(mockMetadata),
+  getOrFail: jest.fn().mockReturnValue(mockMetadata),
+  set: jest.fn(),
+};
 
 describe('AuthService', () => {
   let service: AuthService;
@@ -58,6 +72,20 @@ describe('AuthService', () => {
               ),
           },
         },
+        {
+          provide: CurrentUserService,
+          useValue: {
+            get: jest.fn(),
+            getOrFail: jest.fn().mockReturnValue({ id: 'user-id' }),
+            getUserId: jest.fn().mockReturnValue('user-id'),
+            set: jest.fn(),
+            setJwtPayload: jest.fn(),
+          },
+        },
+        {
+          provide: RequestMetadataService,
+          useValue: mockRequestMetadataService,
+        },
       ],
     }).compile();
 
@@ -107,16 +135,29 @@ describe('AuthService', () => {
                 ),
             },
           },
+          {
+            provide: CurrentUserService,
+            useValue: {
+              get: jest.fn(),
+              getOrFail: jest.fn().mockReturnValue({ id: 'user-id' }),
+              set: jest.fn(),
+              setJwtPayload: jest.fn(),
+            },
+          },
+          {
+            provide: RequestMetadataService,
+            useValue: mockRequestMetadataService,
+          },
         ],
       }).compile();
 
     const serviceWithReversedOrder =
       moduleWithReversedOrder.get<AuthService>(AuthService);
 
-    await serviceWithReversedOrder.Login(
-      { username: 'test', password: 'test' },
-      { browserName: 'test', os: 'test', ipAddress: '127.0.0.1' },
-    );
+    await serviceWithReversedOrder.Login({
+      username: 'test',
+      password: 'test',
+    });
 
     // High priority (5) should be checked first and executed
     // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -126,12 +167,6 @@ describe('AuthService', () => {
   });
 
   describe('Login', () => {
-    const mockMetadata = {
-      browserName: 'test',
-      os: 'test',
-      ipAddress: '127.0.0.1',
-    };
-
     it('should use local strategy when user has a password', async () => {
       const password = 'password123';
       const hashedPassword = await bcrypt.hash(password, 10);
@@ -159,10 +194,10 @@ describe('AuthService', () => {
         refreshToken: 'refresh',
       });
 
-      const result = await service.Login(
-        { username: 'admin', password: 'password123' },
-        mockMetadata,
-      );
+      const result = await service.Login({
+        username: 'admin',
+        password: 'password123',
+      });
 
       expect(mockEm.findOne).toHaveBeenCalledWith(User, { userName: 'admin' });
       // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -205,10 +240,10 @@ describe('AuthService', () => {
         refreshToken: 'refresh',
       });
 
-      await service.Login(
-        { username: 'moodleuser', password: 'moodlepassword' },
-        mockMetadata,
-      );
+      await service.Login({
+        username: 'moodleuser',
+        password: 'moodlepassword',
+      });
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockMoodleStrategy.CanHandle).toHaveBeenCalled();
@@ -230,10 +265,7 @@ describe('AuthService', () => {
       mockMoodleStrategy.CanHandle.mockReturnValue(false);
 
       await expect(
-        service.Login(
-          { username: 'unknown', password: 'password' },
-          mockMetadata,
-        ),
+        service.Login({ username: 'unknown', password: 'password' }),
       ).rejects.toThrow(UnauthorizedException);
     });
 
@@ -257,10 +289,7 @@ describe('AuthService', () => {
       );
 
       await expect(
-        service.Login(
-          { username: 'admin', password: 'wrong-password' },
-          mockMetadata,
-        ),
+        service.Login({ username: 'admin', password: 'wrong-password' }),
       ).rejects.toThrow(UnauthorizedException);
     });
   });

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -2,7 +2,6 @@ import {
   Inject,
   Injectable,
   Logger,
-  NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
 import { LoginRequest } from './dto/requests/login.request.dto';
@@ -12,13 +11,14 @@ import { CustomJwtService } from '../common/custom-jwt-service';
 import { LoginResponse } from './dto/responses/login.response.dto';
 import { User } from 'src/entities/user.entity';
 import { MeResponse } from './dto/responses/me.response.dto';
-import { RequestMetadata } from '../common/interceptors/http/enriched-request';
 import { RefreshJwtPayload } from '../common/custom-jwt-service/refresh-jwt-payload.dto';
 import { v4 } from 'uuid';
 import { RefreshToken } from 'src/entities/refresh-token.entity';
 import * as bcrypt from 'bcrypt';
 import { RefreshTokenRepository } from 'src/repositories/refresh-token.repository';
 import { LOGIN_STRATEGIES, LoginStrategy } from './strategies';
+import { CurrentUserService } from '../common/cls/current-user.service';
+import { RequestMetadataService } from '../common/cls/request-metadata.service';
 
 @Injectable()
 export class AuthService {
@@ -31,13 +31,15 @@ export class AuthService {
     loginStrategies: LoginStrategy[],
     private readonly jwtService: CustomJwtService,
     private readonly unitOfWork: UnitOfWork,
+    private readonly currentUserService: CurrentUserService,
+    private readonly requestMetadataService: RequestMetadataService,
   ) {
     this.sortedStrategies = [...loginStrategies].sort(
       (a, b) => a.priority - b.priority,
     );
   }
 
-  async Login(body: LoginRequest, metaData: RequestMetadata) {
+  async Login(body: LoginRequest) {
     return await this.unitOfWork.runInTransaction(async (em) => {
       const localUser = await em.findOne(User, { userName: body.username });
 
@@ -66,24 +68,18 @@ export class AuthService {
         jwt: jwtPayload,
         refreshJwt: refreshTokenPayload,
         userId: result.user.id,
-        metaData,
       });
 
       return LoginResponse.Map(signedTokens);
     });
   }
 
-  Me(user: User | null | undefined) {
-    if (user === null || user === undefined)
-      throw new NotFoundException('user not found');
-    else return MeResponse.Map(user);
+  Me() {
+    const user = this.currentUserService.getOrFail();
+    return MeResponse.Map(user);
   }
 
-  async RefreshToken(
-    userId: string,
-    refreshToken: string,
-    metaData: RequestMetadata,
-  ) {
+  async RefreshToken(userId: string, refreshToken: string) {
     return await this.unitOfWork.runInTransaction(async (em) => {
       const refreshTokenRepository: RefreshTokenRepository =
         em.getRepository(RefreshToken);
@@ -114,7 +110,6 @@ export class AuthService {
         jwt: jwtPayload,
         refreshJwt: refreshTokenPayload,
         userId: user.id,
-        metaData,
       });
 
       matchingToken.replacedByTokenId = refreshTokenPayload.jti;
@@ -123,11 +118,12 @@ export class AuthService {
     });
   }
 
-  async Logout(userId: string) {
+  async Logout() {
+    const user = this.currentUserService.getOrFail();
     await this.unitOfWork.runInTransaction(async (em) => {
       const refreshTokenRepository: RefreshTokenRepository =
         em.getRepository(RefreshToken);
-      await refreshTokenRepository.revokeAllForUser(userId);
+      await refreshTokenRepository.revokeAllForUser(user.id);
     });
   }
 }

--- a/src/modules/common/cls/cls-store.interface.ts
+++ b/src/modules/common/cls/cls-store.interface.ts
@@ -1,0 +1,9 @@
+import type { ClsStore } from 'nestjs-cls';
+import type { User } from 'src/entities/user.entity';
+import type { RequestMetadata } from '../interceptors/http/enriched-request';
+
+export interface AppClsStore extends ClsStore {
+  currentUser?: User | null;
+  jwtPayload?: { userId: string; moodleUserId: number };
+  requestMetadata?: RequestMetadata;
+}

--- a/src/modules/common/cls/cls.module.ts
+++ b/src/modules/common/cls/cls.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CurrentUserService } from './current-user.service';
+import { RequestMetadataService } from './request-metadata.service';
+
+@Module({
+  providers: [CurrentUserService, RequestMetadataService],
+  exports: [CurrentUserService, RequestMetadataService],
+})
+export class AppClsModule {}

--- a/src/modules/common/cls/current-user.service.ts
+++ b/src/modules/common/cls/current-user.service.ts
@@ -1,0 +1,32 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { ClsService } from 'nestjs-cls';
+import type { User } from 'src/entities/user.entity';
+
+@Injectable()
+export class CurrentUserService {
+  constructor(private readonly cls: ClsService) {}
+
+  get(): User | null {
+    return this.cls.get('currentUser') ?? null;
+  }
+
+  getOrFail(): User {
+    const user = this.get();
+    if (!user) throw new UnauthorizedException();
+    return user;
+  }
+
+  getUserId(): string | undefined {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const userId: string | undefined = this.cls.get('jwtPayload')?.userId;
+    return userId;
+  }
+
+  set(user: User | null): void {
+    this.cls.set('currentUser', user);
+  }
+
+  setJwtPayload(payload: { userId: string; moodleUserId: number }): void {
+    this.cls.set('jwtPayload', payload);
+  }
+}

--- a/src/modules/common/cls/request-metadata.service.ts
+++ b/src/modules/common/cls/request-metadata.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { ClsService } from 'nestjs-cls';
+import type { RequestMetadata } from '../interceptors/http/enriched-request';
+
+@Injectable()
+export class RequestMetadataService {
+  constructor(private readonly cls: ClsService) {}
+
+  get(): RequestMetadata | null {
+    return this.cls.get('requestMetadata') ?? null;
+  }
+
+  getOrFail(): RequestMetadata {
+    const meta = this.get();
+    if (!meta) throw new Error('RequestMetadata not available in CLS context');
+    return meta;
+  }
+
+  set(metadata: RequestMetadata): void {
+    this.cls.set('requestMetadata', metadata);
+  }
+}

--- a/src/modules/common/common.module.ts
+++ b/src/modules/common/common.module.ts
@@ -5,9 +5,10 @@ import { CacheService } from './cache/cache.service';
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { RefreshToken } from 'src/entities/refresh-token.entity';
 import { ScopeResolverService } from './services/scope-resolver.service';
+import { AppClsModule } from './cls/cls.module';
 
 @Module({
-  imports: [MikroOrmModule.forFeature([RefreshToken])],
+  imports: [MikroOrmModule.forFeature([RefreshToken]), AppClsModule],
   providers: [UnitOfWork, CustomJwtService, CacheService, ScopeResolverService],
   exports: [
     UnitOfWork,
@@ -15,6 +16,7 @@ import { ScopeResolverService } from './services/scope-resolver.service';
     MikroOrmModule,
     CacheService,
     ScopeResolverService,
+    AppClsModule,
   ],
 })
 export class CommonModule {}

--- a/src/modules/common/custom-jwt-service/index.ts
+++ b/src/modules/common/custom-jwt-service/index.ts
@@ -5,8 +5,8 @@ import { RefreshJwtPayload } from './refresh-jwt-payload.dto';
 import { env } from 'src/configurations/env';
 import { RefreshTokenRepository } from 'src/repositories/refresh-token.repository';
 import * as bcrypt from 'bcrypt';
-import { RequestMetadata } from '../interceptors/http/enriched-request';
 import { RefreshToken } from 'src/entities/refresh-token.entity';
+import { RequestMetadataService } from '../cls/request-metadata.service';
 
 export type SignedAuthenticationPayload = {
   token: string;
@@ -17,7 +17,6 @@ export type CreateTokensPayload = {
   jwt: JwtPayload;
   refreshJwt: RefreshJwtPayload;
   userId: string;
-  metaData: RequestMetadata;
 };
 
 @Injectable()
@@ -25,6 +24,7 @@ export class CustomJwtService {
   constructor(
     private readonly jwtService: JwtService,
     private readonly refreshTokenRepository: RefreshTokenRepository,
+    private readonly requestMetadataService: RequestMetadataService,
   ) {}
 
   async CreateSignedTokens(
@@ -38,7 +38,6 @@ export class CustomJwtService {
 
     await this.PersistRefreshToken(
       refreshToken,
-      payload.metaData,
       payload.userId,
       payload.refreshJwt.jti,
     );
@@ -51,10 +50,10 @@ export class CustomJwtService {
 
   private async PersistRefreshToken(
     refreshToken: string,
-    metaData: RequestMetadata,
     userId: string,
     refreshId: string,
   ) {
+    const metaData = this.requestMetadataService.getOrFail();
     const hashedToken = await bcrypt.hash(refreshToken, 10);
 
     // revoke refresh refresh tokens

--- a/src/modules/common/data-loaders/index.module.ts
+++ b/src/modules/common/data-loaders/index.module.ts
@@ -2,13 +2,20 @@ import { Module } from '@nestjs/common';
 import { UserLoader } from './user.loader';
 import { IngestionMappingLoader } from './ingestion-mapping.loader';
 import { MikroOrmModule } from '@mikro-orm/nestjs';
+import { ClsModule } from 'nestjs-cls';
 import { User } from 'src/entities/user.entity';
 import { Course } from 'src/entities/course.entity';
 import { Semester } from 'src/entities/semester.entity';
 
 @Module({
-  imports: [MikroOrmModule.forFeature([User, Course, Semester])],
-  providers: [UserLoader, IngestionMappingLoader],
-  exports: [UserLoader, IngestionMappingLoader],
+  imports: [
+    MikroOrmModule.forFeature([User, Course, Semester]),
+    ClsModule.forFeatureAsync({
+      useClass: UserLoader,
+      imports: [MikroOrmModule.forFeature([User])],
+    }),
+  ],
+  providers: [IngestionMappingLoader],
+  exports: [ClsModule, IngestionMappingLoader],
 })
 export default class DataLoaderModule {}

--- a/src/modules/common/data-loaders/user.loader.ts
+++ b/src/modules/common/data-loaders/user.loader.ts
@@ -1,9 +1,9 @@
-import { Injectable, Scope } from '@nestjs/common';
+import { InjectableProxy } from 'nestjs-cls';
 import DataLoader from 'dataloader';
 import { User } from 'src/entities/user.entity';
 import { UserRepository } from 'src/repositories/user.repository';
 
-@Injectable({ scope: Scope.REQUEST })
+@InjectableProxy()
 export class UserLoader {
   private loader: DataLoader<string, User | null>;
 

--- a/src/modules/common/interceptors/current-user.interceptor.ts
+++ b/src/modules/common/interceptors/current-user.interceptor.ts
@@ -5,17 +5,22 @@ import {
   NestInterceptor,
 } from '@nestjs/common';
 import { UserLoader } from '../data-loaders/user.loader';
+import { CurrentUserService } from '../cls/current-user.service';
 import { AuthenticatedRequest } from './http/authenticated-request';
 
 @Injectable()
 export class CurrentUserInterceptor implements NestInterceptor {
-  constructor(private readonly userLoader: UserLoader) {}
+  constructor(
+    private readonly userLoader: UserLoader,
+    private readonly currentUserService: CurrentUserService,
+  ) {}
 
   async intercept(context: ExecutionContext, next: CallHandler<any>) {
     const req = context.switchToHttp().getRequest<AuthenticatedRequest>();
 
     if (req.user?.userId) {
-      req.currentUser = await this.userLoader.load(req.user?.userId);
+      const user = await this.userLoader.load(req.user.userId);
+      this.currentUserService.set(user);
     }
 
     return next.handle();

--- a/src/modules/common/interceptors/http/authenticated-request.ts
+++ b/src/modules/common/interceptors/http/authenticated-request.ts
@@ -1,10 +1,8 @@
 import { Request } from 'express';
-import { User } from 'src/entities/user.entity';
 
 export interface AuthenticatedRequest extends Request {
   user?: {
     userId: string;
     moodleUserId: number;
   };
-  currentUser?: User | null;
 }

--- a/src/modules/common/interceptors/http/enriched-request.ts
+++ b/src/modules/common/interceptors/http/enriched-request.ts
@@ -1,9 +1,3 @@
-import { Request } from 'express';
-
-export interface EnrichedRequest extends Request {
-  metaData: RequestMetadata;
-}
-
 export type RequestMetadata = {
   browserName: string;
   os: string;

--- a/src/modules/common/interceptors/metadata.interceptor.ts
+++ b/src/modules/common/interceptors/metadata.interceptor.ts
@@ -5,15 +5,20 @@ import {
   Logger,
   NestInterceptor,
 } from '@nestjs/common';
+import { Request } from 'express';
 import { UAParser } from 'ua-parser-js';
-import { EnrichedRequest } from './http/enriched-request';
+import { RequestMetadataService } from '../cls/request-metadata.service';
 
 @Injectable()
 export class MetaDataInterceptor implements NestInterceptor {
   private readonly logger = new Logger(MetaDataInterceptor.name);
 
+  constructor(
+    private readonly requestMetadataService: RequestMetadataService,
+  ) {}
+
   intercept(context: ExecutionContext, next: CallHandler<any>) {
-    const request: EnrichedRequest = context.switchToHttp().getRequest();
+    const request: Request = context.switchToHttp().getRequest();
     const { method, url, headers, socket } = request;
 
     // Parse user-agent
@@ -26,18 +31,20 @@ export class MetaDataInterceptor implements NestInterceptor {
       ? forwarded.split(',')[0].trim()
       : socket.remoteAddress;
 
-    request.metaData = {
+    const metadata = {
       browserName: uaResult.browser.name ?? '',
       os: uaResult.os.name ?? '',
       ipAddress: ip ?? '',
     };
 
+    this.requestMetadataService.set(metadata);
+
     // 🔹 Clear, structured logging
     this.logger.log(
       `Metadata captured for [${method}] ${url} -> ` +
-        `IP="${request.metaData.ipAddress}", ` +
-        `Browser="${request.metaData.browserName}", ` +
-        `OS="${request.metaData.os}"`,
+        `IP="${metadata.ipAddress}", ` +
+        `Browser="${metadata.browserName}", ` +
+        `OS="${metadata.os}"`,
     );
 
     // Optional detailed debug log

--- a/src/modules/common/services/scope-resolver.service.spec.ts
+++ b/src/modules/common/services/scope-resolver.service.spec.ts
@@ -2,12 +2,14 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ForbiddenException } from '@nestjs/common';
 import { EntityManager } from '@mikro-orm/postgresql';
 import { ScopeResolverService } from './scope-resolver.service';
+import { CurrentUserService } from '../cls/current-user.service';
 import { UserRole } from 'src/modules/auth/roles.enum';
 import { User } from 'src/entities/user.entity';
 
 describe('ScopeResolverService', () => {
   let service: ScopeResolverService;
   let em: { find: jest.Mock };
+  let currentUserService: { getOrFail: jest.Mock };
 
   const semesterId = 'semester-1';
 
@@ -16,11 +18,15 @@ describe('ScopeResolverService', () => {
 
   beforeEach(async () => {
     em = { find: jest.fn() };
+    currentUserService = {
+      getOrFail: jest.fn(),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ScopeResolverService,
         { provide: EntityManager, useValue: em },
+        { provide: CurrentUserService, useValue: currentUserService },
       ],
     }).compile();
 
@@ -29,8 +35,9 @@ describe('ScopeResolverService', () => {
 
   it('should return null for super admin (unrestricted)', async () => {
     const user = createUser([UserRole.SUPER_ADMIN]);
+    currentUserService.getOrFail.mockReturnValue(user);
 
-    const result = await service.ResolveDepartmentIds(user, semesterId);
+    const result = await service.ResolveDepartmentIds(semesterId);
 
     expect(result).toBeNull();
     expect(em.find).not.toHaveBeenCalled();
@@ -38,12 +45,13 @@ describe('ScopeResolverService', () => {
 
   it('should return department IDs for dean with one department', async () => {
     const user = createUser([UserRole.DEAN]);
+    currentUserService.getOrFail.mockReturnValue(user);
 
     em.find
       .mockResolvedValueOnce([{ moodleCategory: { moodleCategoryId: 100 } }])
       .mockResolvedValueOnce([{ id: 'dept-1' }]);
 
-    const result = await service.ResolveDepartmentIds(user, semesterId);
+    const result = await service.ResolveDepartmentIds(semesterId);
 
     expect(result).toEqual(['dept-1']);
     expect(em.find).toHaveBeenCalledTimes(2);
@@ -51,6 +59,7 @@ describe('ScopeResolverService', () => {
 
   it('should return multiple department IDs for dean with multiple departments', async () => {
     const user = createUser([UserRole.DEAN]);
+    currentUserService.getOrFail.mockReturnValue(user);
 
     em.find
       .mockResolvedValueOnce([
@@ -59,17 +68,18 @@ describe('ScopeResolverService', () => {
       ])
       .mockResolvedValueOnce([{ id: 'dept-1' }, { id: 'dept-2' }]);
 
-    const result = await service.ResolveDepartmentIds(user, semesterId);
+    const result = await service.ResolveDepartmentIds(semesterId);
 
     expect(result).toEqual(['dept-1', 'dept-2']);
   });
 
   it('should return empty array for dean with no institutional roles for given semester', async () => {
     const user = createUser([UserRole.DEAN]);
+    currentUserService.getOrFail.mockReturnValue(user);
 
     em.find.mockResolvedValueOnce([]);
 
-    const result = await service.ResolveDepartmentIds(user, semesterId);
+    const result = await service.ResolveDepartmentIds(semesterId);
 
     expect(result).toEqual([]);
     expect(em.find).toHaveBeenCalledTimes(1);
@@ -77,24 +87,27 @@ describe('ScopeResolverService', () => {
 
   it('should throw ForbiddenException for user with neither SUPER_ADMIN nor DEAN role', async () => {
     const user = createUser([UserRole.FACULTY]);
+    currentUserService.getOrFail.mockReturnValue(user);
 
-    await expect(
-      service.ResolveDepartmentIds(user, semesterId),
-    ).rejects.toThrow(ForbiddenException);
+    await expect(service.ResolveDepartmentIds(semesterId)).rejects.toThrow(
+      ForbiddenException,
+    );
   });
 
   it('should throw ForbiddenException for student role', async () => {
     const user = createUser([UserRole.STUDENT]);
+    currentUserService.getOrFail.mockReturnValue(user);
 
-    await expect(
-      service.ResolveDepartmentIds(user, semesterId),
-    ).rejects.toThrow(ForbiddenException);
+    await expect(service.ResolveDepartmentIds(semesterId)).rejects.toThrow(
+      ForbiddenException,
+    );
   });
 
   it('should prioritize SUPER_ADMIN when user has both SUPER_ADMIN and DEAN roles', async () => {
     const user = createUser([UserRole.SUPER_ADMIN, UserRole.DEAN]);
+    currentUserService.getOrFail.mockReturnValue(user);
 
-    const result = await service.ResolveDepartmentIds(user, semesterId);
+    const result = await service.ResolveDepartmentIds(semesterId);
 
     expect(result).toBeNull();
     expect(em.find).not.toHaveBeenCalled();

--- a/src/modules/common/services/scope-resolver.service.ts
+++ b/src/modules/common/services/scope-resolver.service.ts
@@ -1,22 +1,23 @@
 import { ForbiddenException, Injectable } from '@nestjs/common';
 import { EntityManager } from '@mikro-orm/postgresql';
-import { User } from 'src/entities/user.entity';
 import { UserRole } from 'src/modules/auth/roles.enum';
 import { UserInstitutionalRole } from 'src/entities/user-institutional-role.entity';
 import { Department } from 'src/entities/department.entity';
+import { CurrentUserService } from '../cls/current-user.service';
 
 @Injectable()
 export class ScopeResolverService {
-  constructor(private readonly em: EntityManager) {}
+  constructor(
+    private readonly em: EntityManager,
+    private readonly currentUserService: CurrentUserService,
+  ) {}
 
   /**
    * Resolves the department IDs the user is allowed to access for a given semester.
    * Returns `null` for unrestricted access (super admin), or `string[]` of department UUIDs.
    */
-  async ResolveDepartmentIds(
-    user: User,
-    semesterId: string,
-  ): Promise<string[] | null> {
+  async ResolveDepartmentIds(semesterId: string): Promise<string[] | null> {
+    const user = this.currentUserService.getOrFail();
     if (user.roles.includes(UserRole.SUPER_ADMIN)) {
       return null;
     }

--- a/src/modules/enrollments/enrollments.controller.ts
+++ b/src/modules/enrollments/enrollments.controller.ts
@@ -1,14 +1,7 @@
-import {
-  Controller,
-  Get,
-  Query,
-  Request,
-  UseInterceptors,
-} from '@nestjs/common';
+import { Controller, Get, Query, UseInterceptors } from '@nestjs/common';
 import { EnrollmentsService } from './enrollments.service';
 import { UseJwtGuard } from 'src/security/decorators';
 import { CurrentUserInterceptor } from '../common/interceptors/current-user.interceptor';
-import type { AuthenticatedRequest } from '../common/interceptors/http/authenticated-request';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { MyEnrollmentsResponseDto } from './dto/responses/my-enrollments.response.dto';
 
@@ -22,12 +15,10 @@ export class EnrollmentsController {
   @Get('me')
   @ApiOperation({ summary: "Get current user's enrolled courses" })
   async getMyEnrollments(
-    @Request() request: AuthenticatedRequest,
     @Query('page') page: number = 1,
     @Query('limit') limit: number = 10,
   ): Promise<MyEnrollmentsResponseDto> {
     return await this.enrollmentsService.getMyEnrollments(
-      request.currentUser!,
       Number(page),
       Number(limit),
     );

--- a/src/modules/enrollments/enrollments.service.spec.ts
+++ b/src/modules/enrollments/enrollments.service.spec.ts
@@ -3,12 +3,20 @@ import { EnrollmentsService } from './enrollments.service';
 import { EntityManager } from '@mikro-orm/core';
 import { User } from 'src/entities/user.entity';
 import { CacheService } from '../common/cache/cache.service';
+import { CurrentUserService } from '../common/cls/current-user.service';
 
 describe('EnrollmentsService', () => {
   let service: EnrollmentsService;
   let em: EntityManager;
+  let currentUserService: { getOrFail: jest.Mock };
+
+  const mockUser = { id: 'user-id' } as User;
 
   beforeEach(async () => {
+    currentUserService = {
+      getOrFail: jest.fn().mockReturnValue(mockUser),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         EnrollmentsService,
@@ -31,6 +39,10 @@ describe('EnrollmentsService', () => {
             invalidateNamespaces: jest.fn(),
           },
         },
+        {
+          provide: CurrentUserService,
+          useValue: currentUserService,
+        },
       ],
     }).compile();
 
@@ -43,7 +55,6 @@ describe('EnrollmentsService', () => {
   });
 
   it('should return paginated enrollments with faculty data', async () => {
-    const mockUser = { id: 'user-id' } as User;
     const mockEnrollments = [
       {
         id: 'e1',
@@ -73,7 +84,7 @@ describe('EnrollmentsService', () => {
     (em.findAndCount as jest.Mock).mockResolvedValue([mockEnrollments, 1]);
     (em.find as jest.Mock).mockResolvedValue(mockFacultyEnrollments);
 
-    const result = await service.getMyEnrollments(mockUser, 1, 10);
+    const result = await service.getMyEnrollments(1, 10);
 
     expect(result.data).toHaveLength(1);
     expect(result.data[0].id).toBe('e1');
@@ -97,7 +108,6 @@ describe('EnrollmentsService', () => {
   });
 
   it('should return null faculty when no faculty enrolled in course', async () => {
-    const mockUser = { id: 'user-id' } as User;
     const mockEnrollments = [
       {
         id: 'e1',
@@ -115,17 +125,15 @@ describe('EnrollmentsService', () => {
     (em.findAndCount as jest.Mock).mockResolvedValue([mockEnrollments, 1]);
     (em.find as jest.Mock).mockResolvedValue([]);
 
-    const result = await service.getMyEnrollments(mockUser, 1, 10);
+    const result = await service.getMyEnrollments(1, 10);
 
     expect(result.data[0].faculty).toBeNull();
   });
 
   it('should not query faculty when no enrollments exist', async () => {
-    const mockUser = { id: 'user-id' } as User;
-
     (em.findAndCount as jest.Mock).mockResolvedValue([[], 0]);
 
-    const result = await service.getMyEnrollments(mockUser, 1, 10);
+    const result = await service.getMyEnrollments(1, 10);
 
     expect(result.data).toHaveLength(0);
     // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/src/modules/enrollments/enrollments.service.ts
+++ b/src/modules/enrollments/enrollments.service.ts
@@ -1,9 +1,9 @@
 import { EntityManager } from '@mikro-orm/core';
 import { Injectable } from '@nestjs/common';
 import { Enrollment } from 'src/entities/enrollment.entity';
-import { User } from 'src/entities/user.entity';
 import { CacheService } from '../common/cache/cache.service';
 import { CacheNamespace } from '../common/cache/cache-namespaces';
+import { CurrentUserService } from '../common/cls/current-user.service';
 import { FacultyShortResponseDto } from './dto/responses/faculty-short.response.dto';
 import { MyEnrollmentsResponseDto } from './dto/responses/my-enrollments.response.dto';
 
@@ -12,29 +12,30 @@ export class EnrollmentsService {
   constructor(
     private readonly em: EntityManager,
     private readonly cacheService: CacheService,
+    private readonly currentUserService: CurrentUserService,
   ) {}
 
   async getMyEnrollments(
-    user: User,
     page: number,
     limit: number,
   ): Promise<MyEnrollmentsResponseDto> {
+    const user = this.currentUserService.getOrFail();
     return this.cacheService.wrap(
       CacheNamespace.ENROLLMENTS_ME,
       `${user.id}:${page}:${limit}`,
-      () => this.fetchMyEnrollments(user, page, limit),
+      () => this.fetchMyEnrollments(user.id, page, limit),
       1800000,
     );
   }
 
   private async fetchMyEnrollments(
-    user: User,
+    userId: string,
     page: number,
     limit: number,
   ): Promise<MyEnrollmentsResponseDto> {
     const [enrollments, totalItems] = await this.em.findAndCount(
       Enrollment,
-      { user: user.id, isActive: true },
+      { user: userId, isActive: true },
       {
         populate: ['course'],
         limit,

--- a/src/modules/faculty/faculty.controller.ts
+++ b/src/modules/faculty/faculty.controller.ts
@@ -1,16 +1,8 @@
-import {
-  Controller,
-  Get,
-  Query,
-  Request,
-  UnauthorizedException,
-  UseInterceptors,
-} from '@nestjs/common';
+import { Controller, Get, Query, UseInterceptors } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { UseJwtGuard } from 'src/security/decorators';
 import { UserRole } from '../auth/roles.enum';
 import { CurrentUserInterceptor } from '../common/interceptors/current-user.interceptor';
-import type { AuthenticatedRequest } from '../common/interceptors/http/authenticated-request';
 import { FacultyService } from './services/faculty.service';
 import { ListFacultyQueryDto } from './dto/requests/list-faculty-query.dto';
 import { FacultyListResponseDto } from './dto/responses/faculty-list.response.dto';
@@ -27,11 +19,7 @@ export class FacultyController {
   @ApiResponse({ status: 200, type: FacultyListResponseDto })
   async findAll(
     @Query() query: ListFacultyQueryDto,
-    @Request() req: AuthenticatedRequest,
   ): Promise<FacultyListResponseDto> {
-    if (!req.currentUser) {
-      throw new UnauthorizedException();
-    }
-    return this.facultyService.ListFaculty(req.currentUser, query);
+    return this.facultyService.ListFaculty(query);
   }
 }

--- a/src/modules/faculty/services/faculty.service.spec.ts
+++ b/src/modules/faculty/services/faculty.service.spec.ts
@@ -7,7 +7,6 @@ import {
 import { EntityManager } from '@mikro-orm/postgresql';
 import { FacultyService } from './faculty.service';
 import { ScopeResolverService } from 'src/modules/common/services/scope-resolver.service';
-import { UserRole } from 'src/modules/auth/roles.enum';
 import { User } from 'src/entities/user.entity';
 import { ListFacultyQueryDto } from '../dto/requests/list-faculty-query.dto';
 
@@ -25,16 +24,6 @@ describe('FacultyService', () => {
   const deptId = 'dept-1';
   const deptId2 = 'dept-2';
   const programId = 'program-1';
-
-  const superAdmin = {
-    id: 'admin-1',
-    roles: [UserRole.SUPER_ADMIN],
-  } as unknown as User;
-
-  const dean = {
-    id: 'dean-1',
-    roles: [UserRole.DEAN],
-  } as unknown as User;
 
   const baseQuery: ListFacultyQueryDto = {
     semesterId,
@@ -120,12 +109,11 @@ describe('FacultyService', () => {
         2,
       );
 
-      const result = await service.ListFaculty(superAdmin, baseQuery);
+      const result = await service.ListFaculty(baseQuery);
 
       expect(result.data).toHaveLength(2);
       expect(result.meta.totalItems).toBe(2);
       expect(scopeResolver.ResolveDepartmentIds).toHaveBeenCalledWith(
-        superAdmin,
         semesterId,
       );
     });
@@ -140,7 +128,7 @@ describe('FacultyService', () => {
 
       setupFacultyResults([user1], [mockEnrollment('u1', 'FREAI')], 1);
 
-      const result = await service.ListFaculty(dean, baseQuery);
+      const result = await service.ListFaculty(baseQuery);
 
       expect(result.data).toHaveLength(1);
       expect(result.data[0].fullName).toBe('John Doe');
@@ -164,7 +152,7 @@ describe('FacultyService', () => {
         .mockResolvedValueOnce(users)
         .mockResolvedValueOnce(users.map((u) => mockEnrollment(u.id, 'CS101')));
 
-      const result = await service.ListFaculty(superAdmin, {
+      const result = await service.ListFaculty({
         ...baseQuery,
         page: 2,
         limit: 5,
@@ -186,7 +174,7 @@ describe('FacultyService', () => {
       scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
       setupEmptyResults();
 
-      await service.ListFaculty(superAdmin, {
+      await service.ListFaculty({
         ...baseQuery,
         search: 'Varst',
       });
@@ -204,7 +192,7 @@ describe('FacultyService', () => {
       scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
 
       await expect(
-        service.ListFaculty(dean, {
+        service.ListFaculty({
           ...baseQuery,
           departmentId: deptId2,
         }),
@@ -224,7 +212,7 @@ describe('FacultyService', () => {
         });
 
       await expect(
-        service.ListFaculty(superAdmin, {
+        service.ListFaculty({
           ...baseQuery,
           departmentId: deptId,
           programId,
@@ -245,7 +233,7 @@ describe('FacultyService', () => {
         });
 
       await expect(
-        service.ListFaculty(dean, {
+        service.ListFaculty({
           ...baseQuery,
           programId,
         }),
@@ -270,7 +258,7 @@ describe('FacultyService', () => {
         1,
       );
 
-      const result = await service.ListFaculty(superAdmin, baseQuery);
+      const result = await service.ListFaculty(baseQuery);
 
       expect(result.data).toHaveLength(1);
       expect(result.data[0].subjects).toEqual(['ELDNET1', 'ELEMSYS', 'FREAI']);
@@ -294,7 +282,7 @@ describe('FacultyService', () => {
         1,
       );
 
-      const result = await service.ListFaculty(superAdmin, baseQuery);
+      const result = await service.ListFaculty(baseQuery);
 
       expect(result.data[0].subjects).toEqual(['ALPHA', 'MIDDLE', 'ZETA']);
     });
@@ -306,7 +294,7 @@ describe('FacultyService', () => {
       scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
       setupEmptyResults();
 
-      const result = await service.ListFaculty(superAdmin, baseQuery);
+      const result = await service.ListFaculty(baseQuery);
 
       expect(result).toEqual({
         data: [],
@@ -327,7 +315,7 @@ describe('FacultyService', () => {
       scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
       setupEmptyResults();
 
-      await service.ListFaculty(superAdmin, {
+      await service.ListFaculty({
         ...baseQuery,
         search: '%admin_test',
       });
@@ -341,7 +329,7 @@ describe('FacultyService', () => {
     it('should return 404', async () => {
       em.findOne.mockResolvedValue(null);
 
-      await expect(service.ListFaculty(superAdmin, baseQuery)).rejects.toThrow(
+      await expect(service.ListFaculty(baseQuery)).rejects.toThrow(
         NotFoundException,
       );
     });
@@ -356,7 +344,7 @@ describe('FacultyService', () => {
 
       setupFacultyResults([user1], [mockEnrollment('u1', 'CS101')], 1);
 
-      const result = await service.ListFaculty(superAdmin, baseQuery);
+      const result = await service.ListFaculty(baseQuery);
 
       expect(result.data[0].fullName).toBe('John Doe');
     });
@@ -373,7 +361,7 @@ describe('FacultyService', () => {
 
       em.find.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
 
-      const result = await service.ListFaculty(superAdmin, {
+      const result = await service.ListFaculty({
         ...baseQuery,
         page: 5,
         limit: 5,
@@ -397,7 +385,7 @@ describe('FacultyService', () => {
 
       executeMock.mockResolvedValueOnce([{ count: '0' }]);
 
-      const result = await service.ListFaculty(dean, baseQuery);
+      const result = await service.ListFaculty(baseQuery);
 
       expect(result.data).toEqual([]);
       expect(result.meta.totalItems).toBe(0);
@@ -413,7 +401,7 @@ describe('FacultyService', () => {
 
       setupFacultyResults([user1], [mockEnrollment('u1', 'CS101')], 1);
 
-      const result = await service.ListFaculty(superAdmin, baseQuery);
+      const result = await service.ListFaculty(baseQuery);
 
       expect(result.data[0].profilePicture).toBeNull();
     });
@@ -426,7 +414,7 @@ describe('FacultyService', () => {
 
       setupFacultyResults([user1], [mockEnrollment('u1', 'CS101')], 1);
 
-      const result = await service.ListFaculty(superAdmin, baseQuery);
+      const result = await service.ListFaculty(baseQuery);
 
       expect(result.data[0].profilePicture).toBe('http://pic.jpg');
     });

--- a/src/modules/faculty/services/faculty.service.ts
+++ b/src/modules/faculty/services/faculty.service.ts
@@ -24,7 +24,6 @@ export class FacultyService {
   ) {}
 
   async ListFaculty(
-    user: User,
     query: ListFacultyQueryDto,
   ): Promise<FacultyListResponseDto> {
     // 1. Validate semester exists
@@ -37,7 +36,6 @@ export class FacultyService {
 
     // 2. Resolve scope
     const departmentIds = await this.scopeResolverService.ResolveDepartmentIds(
-      user,
       query.semesterId,
     );
 

--- a/src/modules/index.module.ts
+++ b/src/modules/index.module.ts
@@ -19,6 +19,7 @@ import { AnalysisModule } from './analysis/analysis.module';
 import { DimensionsModule } from './dimensions/dimensions.module';
 import { FacultyModule } from './faculty/faculty.module';
 import { LoggerModule } from 'nestjs-pino';
+import { ClsModule } from 'nestjs-cls';
 import { v4 } from 'uuid';
 
 export const ApplicationModules = [
@@ -46,6 +47,10 @@ export const InfrastructureModules = [
     signOptions: {
       expiresIn: '300s',
     },
+  }),
+  ClsModule.forRoot({
+    global: true,
+    middleware: { mount: true },
   }),
   ScheduleModule.forRoot(),
   BullModule.forRoot({ connection: { url: env.REDIS_URL } }),

--- a/src/modules/questionnaires/questionnaire.controller.ts
+++ b/src/modules/questionnaires/questionnaire.controller.ts
@@ -7,7 +7,6 @@ import {
   Get,
   Delete,
   Query,
-  Request,
   UseInterceptors,
 } from '@nestjs/common';
 import { QuestionnaireService } from './services/questionnaire.service';
@@ -25,7 +24,6 @@ import { DraftResponse } from './dto/responses/draft-response.dto';
 import { UseJwtGuard } from 'src/security/decorators';
 import { UserRole } from '../auth/roles.enum';
 import { CurrentUserInterceptor } from '../common/interceptors/current-user.interceptor';
-import type { AuthenticatedRequest } from '../common/interceptors/http/authenticated-request';
 
 @ApiTags('Questionnaires')
 @Controller('questionnaires')
@@ -152,14 +150,8 @@ export class QuestionnaireController {
   @ApiResponse({ status: 201, description: 'Draft saved successfully' })
   @ApiResponse({ status: 400, description: 'Invalid data or inactive version' })
   @ApiResponse({ status: 404, description: 'Resource not found' })
-  async saveDraft(
-    @Body() data: SaveDraftRequest,
-    @Request() request: AuthenticatedRequest,
-  ): Promise<DraftResponse> {
-    const draft = await this.questionnaireService.SaveOrUpdateDraft(
-      request.currentUser!.id,
-      data,
-    );
+  async saveDraft(@Body() data: SaveDraftRequest): Promise<DraftResponse> {
+    const draft = await this.questionnaireService.SaveOrUpdateDraft(data);
 
     return {
       id: draft.id,
@@ -183,14 +175,10 @@ export class QuestionnaireController {
   })
   async getDraft(
     @Query() query: GetDraftRequest,
-    @Request() request: AuthenticatedRequest,
   ): Promise<DraftResponse | null> {
     // Security: Always filter by authenticated user's ID to prevent information disclosure
     // Returns null if no draft exists (rather than 404) since "no draft yet" is a valid state
-    const draft = await this.questionnaireService.GetDraft(
-      request.currentUser!.id,
-      query,
-    );
+    const draft = await this.questionnaireService.GetDraft(query);
 
     if (!draft) {
       return null;
@@ -213,12 +201,8 @@ export class QuestionnaireController {
   @UseInterceptors(CurrentUserInterceptor)
   @ApiOperation({ summary: 'List all drafts for the current user' })
   @ApiResponse({ status: 200, description: 'Drafts retrieved successfully' })
-  async listMyDrafts(
-    @Request() request: AuthenticatedRequest,
-  ): Promise<DraftResponse[]> {
-    const drafts = await this.questionnaireService.ListMyDrafts(
-      request.currentUser!.id,
-    );
+  async listMyDrafts(): Promise<DraftResponse[]> {
+    const drafts = await this.questionnaireService.ListMyDrafts();
 
     return drafts.map((draft) => ({
       id: draft.id,
@@ -238,11 +222,8 @@ export class QuestionnaireController {
   @ApiOperation({ summary: 'Delete a draft by ID' })
   @ApiResponse({ status: 200, description: 'Draft deleted successfully' })
   @ApiResponse({ status: 404, description: 'Draft not found' })
-  async deleteDraft(
-    @Param('id') id: string,
-    @Request() request: AuthenticatedRequest,
-  ): Promise<{ message: string }> {
-    await this.questionnaireService.DeleteDraft(request.currentUser!.id, id);
+  async deleteDraft(@Param('id') id: string): Promise<{ message: string }> {
+    await this.questionnaireService.DeleteDraft(id);
     return { message: 'Draft deleted successfully' };
   }
 }

--- a/src/modules/questionnaires/services/__tests__/questionnaire-types.spec.ts
+++ b/src/modules/questionnaires/services/__tests__/questionnaire-types.spec.ts
@@ -17,6 +17,7 @@ import { ScoringService } from '../scoring.service';
 import { EntityManager } from '@mikro-orm/postgresql';
 import { CacheService } from '../../../common/cache/cache.service';
 import { AnalysisService } from '../../../analysis/analysis.service';
+import { CurrentUserService } from '../../../common/cls/current-user.service';
 import {
   QuestionnaireStatus,
   QuestionnaireType,
@@ -85,6 +86,12 @@ describe('QuestionnaireService - Types & Versions', () => {
         {
           provide: AnalysisService,
           useValue: { EnqueueJob: jest.fn() },
+        },
+        {
+          provide: CurrentUserService,
+          useValue: {
+            getOrFail: jest.fn().mockReturnValue({ id: 'test-user' }),
+          },
         },
         {
           provide: CacheService,

--- a/src/modules/questionnaires/services/questionnaire.service.spec.ts
+++ b/src/modules/questionnaires/services/questionnaire.service.spec.ts
@@ -21,6 +21,7 @@ import { ScoringService } from './scoring.service';
 import { EntityManager } from '@mikro-orm/postgresql';
 import { CacheService } from '../../common/cache/cache.service';
 import { AnalysisService } from '../../analysis/analysis.service';
+import { CurrentUserService } from '../../common/cls/current-user.service';
 import {
   BadRequestException,
   ConflictException,
@@ -135,6 +136,12 @@ describe('QuestionnaireService', () => {
           provide: AnalysisService,
           useValue: {
             EnqueueJob: jest.fn().mockResolvedValue('mock-job-id'),
+          },
+        },
+        {
+          provide: CurrentUserService,
+          useValue: {
+            getOrFail: jest.fn().mockReturnValue({ id: RESPONDENT_ID }),
           },
         },
       ],
@@ -648,10 +655,7 @@ describe('QuestionnaireService', () => {
 
       (em.upsert as jest.Mock).mockResolvedValue(mockDraft);
 
-      const result = await service.SaveOrUpdateDraft(
-        RESPONDENT_ID,
-        mockDraftData,
-      );
+      const result = await service.SaveOrUpdateDraft(mockDraftData);
 
       expect(result).toEqual(mockDraft);
       expect(em.upsert).toHaveBeenCalledWith(QuestionnaireDraft, {
@@ -729,10 +733,7 @@ describe('QuestionnaireService', () => {
 
       (em.upsert as jest.Mock).mockResolvedValue(mockDraft);
 
-      const result = await service.SaveOrUpdateDraft(
-        RESPONDENT_ID,
-        dataWithoutCourse,
-      );
+      const result = await service.SaveOrUpdateDraft(dataWithoutCourse);
 
       expect(result.course).toBeNull();
     });
@@ -759,7 +760,7 @@ describe('QuestionnaireService', () => {
 
       draftRepo.findOne.mockResolvedValue(mockDraft as any);
 
-      const result = await service.GetDraft(RESPONDENT_ID, mockQuery);
+      const result = await service.GetDraft(mockQuery);
 
       expect(result).toEqual(mockDraft);
       expect(draftRepo.findOne).toHaveBeenCalledWith({
@@ -774,7 +775,7 @@ describe('QuestionnaireService', () => {
     it('should return null when draft not found', async () => {
       draftRepo.findOne.mockResolvedValue(null);
 
-      const result = await service.GetDraft(RESPONDENT_ID, mockQuery);
+      const result = await service.GetDraft(mockQuery);
 
       expect(result).toBeNull();
     });
@@ -783,7 +784,7 @@ describe('QuestionnaireService', () => {
       const queryWithoutCourse = { ...mockQuery, courseId: undefined };
       draftRepo.findOne.mockResolvedValue(null);
 
-      await service.GetDraft(RESPONDENT_ID, queryWithoutCourse);
+      await service.GetDraft(queryWithoutCourse);
 
       expect(draftRepo.findOne).toHaveBeenCalledWith({
         respondent: RESPONDENT_ID,
@@ -804,7 +805,7 @@ describe('QuestionnaireService', () => {
 
       draftRepo.find.mockResolvedValue(mockDrafts as any);
 
-      const result = await service.ListMyDrafts(RESPONDENT_ID);
+      const result = await service.ListMyDrafts();
 
       expect(result).toEqual(mockDrafts);
       expect(draftRepo.find).toHaveBeenCalledWith(
@@ -816,7 +817,7 @@ describe('QuestionnaireService', () => {
     it('should return empty array if no drafts', async () => {
       draftRepo.find.mockResolvedValue([]);
 
-      const result = await service.ListMyDrafts(RESPONDENT_ID);
+      const result = await service.ListMyDrafts();
 
       expect(result).toEqual([]);
     });
@@ -947,7 +948,7 @@ describe('QuestionnaireService', () => {
 
       draftRepo.findOne.mockResolvedValue(mockDraft as any);
 
-      await service.DeleteDraft(RESPONDENT_ID, 'd1');
+      await service.DeleteDraft('d1');
 
       expect(mockDraft.SoftDelete).toHaveBeenCalled();
       expect(em.flush).toHaveBeenCalled();
@@ -956,7 +957,7 @@ describe('QuestionnaireService', () => {
     it('should throw NotFoundException if draft not found', async () => {
       draftRepo.findOne.mockResolvedValue(null);
 
-      await expect(service.DeleteDraft(RESPONDENT_ID, 'd1')).rejects.toThrow(
+      await expect(service.DeleteDraft('d1')).rejects.toThrow(
         NotFoundException,
       );
     });
@@ -964,7 +965,7 @@ describe('QuestionnaireService', () => {
     it('should throw NotFoundException if draft not owned by respondent', async () => {
       draftRepo.findOne.mockResolvedValue(null);
 
-      await expect(service.DeleteDraft(RESPONDENT_ID, 'd1')).rejects.toThrow(
+      await expect(service.DeleteDraft('d1')).rejects.toThrow(
         NotFoundException,
       );
     });

--- a/src/modules/questionnaires/services/questionnaire.service.ts
+++ b/src/modules/questionnaires/services/questionnaire.service.ts
@@ -43,6 +43,7 @@ import { UserRole } from '../../auth/roles.enum';
 import { CacheService } from '../../common/cache/cache.service';
 import { CacheNamespace } from '../../common/cache/cache-namespaces';
 import { AnalysisService } from '../../analysis/analysis.service';
+import { CurrentUserService } from '../../common/cls/current-user.service';
 import { env } from 'src/configurations/env';
 import { cleanText } from '../utils/clean-text';
 
@@ -66,6 +67,7 @@ export class QuestionnaireService {
     private readonly em: EntityManager,
     private readonly cacheService: CacheService,
     private readonly analysisService: AnalysisService,
+    private readonly currentUserService: CurrentUserService,
   ) {}
 
   async getQuestionnaireTypes(): Promise<QuestionnaireTypeResponse[]> {
@@ -672,17 +674,16 @@ export class QuestionnaireService {
     return null;
   }
 
-  async SaveOrUpdateDraft(
-    respondentId: string,
-    data: {
-      versionId: string;
-      facultyId: string;
-      semesterId: string;
-      courseId?: string;
-      answers: Record<string, number>;
-      qualitativeComment?: string;
-    },
-  ): Promise<QuestionnaireDraft> {
+  async SaveOrUpdateDraft(data: {
+    versionId: string;
+    facultyId: string;
+    semesterId: string;
+    courseId?: string;
+    answers: Record<string, number>;
+    qualitativeComment?: string;
+  }): Promise<QuestionnaireDraft> {
+    const respondentId = this.currentUserService.getOrFail().id;
+
     // Validate version exists and is active
     const version = await this.versionRepo.findOne(data.versionId);
     if (!version) {
@@ -763,15 +764,13 @@ export class QuestionnaireService {
     }
   }
 
-  async GetDraft(
-    respondentId: string,
-    query: {
-      versionId: string;
-      facultyId: string;
-      semesterId: string;
-      courseId?: string;
-    },
-  ): Promise<QuestionnaireDraft | null> {
+  async GetDraft(query: {
+    versionId: string;
+    facultyId: string;
+    semesterId: string;
+    courseId?: string;
+  }): Promise<QuestionnaireDraft | null> {
+    const respondentId = this.currentUserService.getOrFail().id;
     const draft = await this.draftRepo.findOne({
       respondent: respondentId,
       questionnaireVersion: query.versionId,
@@ -783,7 +782,8 @@ export class QuestionnaireService {
     return draft;
   }
 
-  async ListMyDrafts(respondentId: string): Promise<QuestionnaireDraft[]> {
+  async ListMyDrafts(): Promise<QuestionnaireDraft[]> {
+    const respondentId = this.currentUserService.getOrFail().id;
     const drafts = await this.draftRepo.find(
       { respondent: respondentId },
       { orderBy: { updatedAt: 'DESC' } },
@@ -792,7 +792,8 @@ export class QuestionnaireService {
     return drafts;
   }
 
-  async DeleteDraft(respondentId: string, draftId: string): Promise<void> {
+  async DeleteDraft(draftId: string): Promise<void> {
+    const respondentId = this.currentUserService.getOrFail().id;
     const draft = await this.draftRepo.findOne({
       id: draftId,
       respondent: respondentId,


### PR DESCRIPTION
Replace request param-threading with continuation-local storage (nestjs-cls). CurrentUserService and RequestMetadataService write to CLS in interceptors; downstream services read directly, eliminating metaData/currentUser params from controllers and service signatures.