### PR TITLE
FAC-57 feat: add scoped curriculum query endpoints

### DIFF
--- a/_bmad-output/implementation-artifacts/tech-spec-scoped-curriculum-query-endpoints.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-scoped-curriculum-query-endpoints.md
@@ -1,0 +1,404 @@
+---
+title: 'Scoped Curriculum Query Endpoints'
+slug: 'scoped-curriculum-query-endpoints'
+created: '2026-03-19'
+status: 'completed'
+stepsCompleted: [1, 2, 3, 4]
+tech_stack:
+  [
+    'NestJS v11',
+    'MikroORM v6.6',
+    'PostgreSQL',
+    'Passport/JWT',
+    'class-validator',
+    'class-transformer (used by NestJS validation pipeline)',
+    'Jest v30',
+    'Swagger/OpenAPI',
+    'nestjs-cls',
+  ]
+files_to_modify:
+  - 'src/modules/curriculum/curriculum.module.ts (new)'
+  - 'src/modules/curriculum/curriculum.controller.ts (new)'
+  - 'src/modules/curriculum/services/curriculum.service.ts (new)'
+  - 'src/modules/curriculum/services/curriculum.service.spec.ts (new)'
+  - 'src/modules/curriculum/dto/requests/list-departments-query.dto.ts (new)'
+  - 'src/modules/curriculum/dto/requests/list-programs-query.dto.ts (new)'
+  - 'src/modules/curriculum/dto/requests/list-courses-query.dto.ts (new)'
+  - 'src/modules/curriculum/dto/responses/department-item.response.dto.ts (new)'
+  - 'src/modules/curriculum/dto/responses/program-item.response.dto.ts (new)'
+  - 'src/modules/curriculum/dto/responses/course-item.response.dto.ts (new)'
+  - 'src/modules/index.module.ts (modify — register CurriculumModule)'
+code_patterns:
+  - 'Module structure: module.ts + controller.ts + services/ + dto/requests/ + dto/responses/'
+  - 'Controller: @UseJwtGuard(roles) + @UseInterceptors(CurrentUserInterceptor)'
+  - 'Service: PascalCase public methods, inject EntityManager + ScopeResolverService'
+  - 'Response DTOs: static Map() method, @ApiProperty() decorators'
+  - 'Query DTOs: @IsOptional() + @IsUUID() + @IsString() + @MaxLength() validators'
+  - 'Scope resolution: ScopeResolverService.ResolveDepartmentIds(semesterId) → null | string[]'
+  - 'Filter validation: cascading departmentId → programId validation with 403/400 errors'
+  - 'CLS-based user context: CurrentUserInterceptor → CurrentUserService → ScopeResolverService'
+  - 'Search escaping: EscapeLikeWildcards() for ILIKE queries'
+test_patterns:
+  - 'Jest with NestJS Test.createTestingModule()'
+  - 'Mock EntityManager as plain object with jest.fn() methods (findOne, find)'
+  - 'Mock ScopeResolverService as { ResolveDepartmentIds: jest.fn() }'
+  - 'Tests colocated with source as .spec.ts files'
+  - 'Use npx jest --testPathPatterns=<pattern> to run specific tests'
+---
+
+# Tech-Spec: Scoped Curriculum Query Endpoints
+
+**Created:** 2026-03-19
+
+## Overview
+
+### Problem Statement
+
+Deans and super admins have no way to query the institutional hierarchy (departments, programs, courses) scoped to their role. The frontend needs these to populate filter dropdowns across multiple dashboard pages (faculty list, analytics, submission counts). Currently, the only course-level data available is per-user via `GET /enrollments/me`, which serves faculty — not the administrative lens deans require.
+
+### Solution
+
+Create three new endpoints (`GET /departments`, `GET /programs`, `GET /courses`) in a dedicated `CurriculumModule`, reusing the existing `ScopeResolverService` for role-based scoping. Lightweight DTOs without pagination (small result sets), search support on all three endpoints, and courses include an `isActive` flag for historical visibility into soft-deactivated courses.
+
+### Scope
+
+**In Scope:**
+
+- New `CurriculumModule` with three endpoints:
+  - `GET /departments?semesterId=X` — returns departments within the caller's scope
+  - `GET /programs?semesterId=X&departmentId=Y` — returns programs under scoped departments, optional cascading filter by department
+  - `GET /courses?semesterId=X&programId=Z` — returns courses under scoped programs, includes inactive courses with `isActive` flag. Requires at least one of `programId` or `departmentId` to prevent unbounded queries.
+- Role-based access: DEAN and SUPER_ADMIN only
+- **Mandatory scope enforcement**: all three endpoints always apply `ScopeResolverService` resolved scope filter, regardless of whether explicit filter params are passed. Explicit filters only narrow within the resolved scope — they never bypass it.
+- **Filter validation on programs and courses endpoints**: if `departmentId` or `programId` is provided, validate it falls within the caller's resolved scope (403 if not). The departments endpoint has no filterable ID params — scope is enforced via `ScopeResolverService` directly.
+- `semesterId` as a **required** query parameter on all endpoints
+- Search filtering on all three endpoints (`search` query param)
+- Courses return both `shortname` and `fullname`
+- Reuse `ScopeResolverService` from `CommonModule` for scope resolution
+- Cascading filter validation (same pattern as `FacultyService`)
+
+**Out of Scope:**
+
+- Faculty role access (covered by `GET /enrollments/me`)
+- Pagination (result sets are small — deans have 1-3 departments, 5-15 programs, 20-60 courses)
+- Active semester auto-detection (no `isActive` flag on Semester entity)
+- Nested/aggregated responses (keep endpoints flat and independent)
+- Course-level filtering on the faculty endpoint (separate concern)
+
+## Context for Development
+
+### Codebase Patterns
+
+- **Module structure**: `module.ts` + `controller.ts` + `services/` + `dto/requests/` + `dto/responses/`. Reference: `src/modules/faculty/` (best reference — uses `ScopeResolverService`, `CurrentUserInterceptor`, `CommonModule`, and `DataLoaderModule`).
+- **Module registration**: Add to `ApplicationModules` array in `src/modules/index.module.ts`.
+- **Controller pattern**: `@UseJwtGuard(UserRole.SUPER_ADMIN, UserRole.DEAN)` at class level + `@UseInterceptors(CurrentUserInterceptor)`. The controller does NOT receive `req.currentUser` directly — the `CurrentUserInterceptor` loads the user into CLS via `CurrentUserService.set()`, and downstream services access it via `CurrentUserService.getOrFail()` (injected into `ScopeResolverService`).
+- **Service pattern**: PascalCase public methods. Inject `EntityManager` and `ScopeResolverService`. Use `em.find()` with `FilterQuery<T>` for simple queries (no raw SQL needed — unlike faculty's distinct-count problem, these are straightforward entity queries).
+- **Scope resolution chain**: `CurrentUserInterceptor` → `UserLoader.load()` → `CurrentUserService.set(user)` → CLS store. Then `ScopeResolverService.ResolveDepartmentIds(semesterId)` calls `CurrentUserService.getOrFail()` to get the user from CLS. Returns `null` (unrestricted for super admin) or `string[]` (department UUIDs for dean).
+- **Filter validation**: Cascading validation pattern from `FacultyService` (lines 43-78): if `departmentId` provided and scope is restricted (`departmentIds !== null`), check `departmentIds.includes(query.departmentId)` → 403 if not. If `programId` provided, fetch program with populated `department`, verify `program.department.id` is in scope → 403 if not. If both `departmentId` and `programId` provided, verify `program.department.id === departmentId` → 400 if mismatch.
+- **Response DTOs**: Static `Map()` method to convert entity → DTO. `@ApiProperty()` / `@ApiPropertyOptional()` for Swagger.
+- **Query DTOs**: `@IsUUID()`, `@IsNotEmpty()`, `@IsOptional()`, `@IsString()`, `@MaxLength()`. Follow `ListFacultyQueryDto` pattern.
+- **Course `isActive` semantics**: `isActive = false` means Moodle no longer reports the course during sync (`moodle-course-sync.service.ts:88-95`). Not a semester boundary marker — semester scoping is structural via the hierarchy chain.
+- **Search escaping**: Escape LIKE wildcards (`%`, `_`, `\`) before ILIKE queries. Reuse the `EscapeLikeWildcards()` pattern from `FacultyService` (line 281-286). Note: unlike `FacultyService` which uses raw SQL with an explicit `ESCAPE '\\'` clause, these endpoints use MikroORM's `$ilike` operator which generates bare `ILIKE` without `ESCAPE`. This works correctly because PostgreSQL's default escape character is backslash when `standard_conforming_strings = on` (the default).
+- **Entity field details**:
+  - `Department`: `id`, `moodleCategoryId` (number, unique, indexed), `code` (string), `name` (string, nullable), `semester` (ManyToOne Semester)
+  - `Program`: `id`, `moodleCategoryId` (number, unique, indexed), `code` (string), `name` (string, nullable), `department` (ManyToOne Department)
+  - `Course`: `id`, `moodleCourseId` (number, unique, indexed), `shortname` (string), `fullname` (string), `isActive` (boolean, default true), `isVisible` (boolean), `program` (ManyToOne Program), `startDate`, `endDate`, `courseImage` (nullable)
+  - `Semester`: `id`, `moodleCategoryId` (number, unique), `code` (string), `label` (nullable), `academicYear` (nullable), `campus` (ManyToOne), no `isActive` flag
+- **Soft delete**: Global MikroORM filter auto-applies `deleted_at IS NULL` on all `em.find()` calls. No need to add soft delete conditions manually.
+- **CommonModule is NOT `@Global()`**: Must be explicitly imported by consuming modules to access `ScopeResolverService`.
+- **DataLoaderModule required**: Must be imported because `CurrentUserInterceptor` depends on `UserLoader`.
+
+### Files to Reference
+
+| File                                                             | Purpose                                                                                        |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `src/modules/faculty/faculty.module.ts`                          | Reference module structure — imports CommonModule, DataLoaderModule, MikroOrmModule.forFeature |
+| `src/modules/faculty/faculty.controller.ts`                      | Reference controller pattern — @UseJwtGuard, @UseInterceptors, @Query DTO                      |
+| `src/modules/faculty/services/faculty.service.ts`                | Reference filter validation cascade (lines 43-78), EscapeLikeWildcards (line 281)              |
+| `src/modules/faculty/dto/requests/list-faculty-query.dto.ts`     | Reference query DTO with @IsUUID, @IsOptional, @MaxLength                                      |
+| `src/modules/faculty/dto/responses/faculty-card.response.dto.ts` | Reference response DTO with static Map() method                                                |
+| `src/modules/common/services/scope-resolver.service.ts`          | Core scope resolution — ResolveDepartmentIds(semesterId)                                       |
+| `src/modules/common/cls/current-user.service.ts`                 | CLS-based user context — getOrFail(), set()                                                    |
+| `src/modules/common/interceptors/current-user.interceptor.ts`    | Loads user into CLS from JWT via UserLoader                                                    |
+| `src/modules/common/common.module.ts`                            | Exports UnitOfWork, CacheService, ScopeResolverService, AppClsModule                           |
+| `src/entities/department.entity.ts`                              | Department entity — code, name (nullable), moodleCategoryId, semester ManyToOne                |
+| `src/entities/program.entity.ts`                                 | Program entity — code, name (nullable), moodleCategoryId, department ManyToOne                 |
+| `src/entities/course.entity.ts`                                  | Course entity — shortname, fullname, isActive, isVisible, program ManyToOne                    |
+| `src/entities/semester.entity.ts`                                | Semester entity — code, label, academicYear, no isActive flag                                  |
+| `src/modules/index.module.ts`                                    | ApplicationModules array — where CurriculumModule will be registered                           |
+| `src/modules/common/services/scope-resolver.service.spec.ts`     | Reference test pattern for scope resolver mocks                                                |
+| `src/modules/faculty/services/faculty.service.spec.ts`           | Reference test pattern for service with mocked EM + ScopeResolver                              |
+| `_bmad-output/project-context.md`                                | Project rules: PascalCase methods, strict TypeScript, absolute imports, Swagger decorators     |
+
+### Technical Decisions
+
+- **`CurriculumModule`** — separate from `FacultyModule` since these endpoints serve the institutional hierarchy, not faculty-specific data. Consumed by multiple frontend pages.
+- **No pagination** — result sets are inherently small within a dean's scope. Super admin sees more but still manageable. Simplifies DTOs and service logic.
+- **All courses returned (active + inactive)** — inactive courses may have historical analytics data (submissions, sentiment results). `isActive` flag in response lets frontend decide display behavior (greyed out, badge, etc.).
+- **Three separate endpoints** — RESTful routes (`/departments`, `/programs`, `/courses`). Scoping is a server-side concern, not reflected in URLs.
+- **Single controller** — all three endpoints in one `CurriculumController` since they share the same guard, interceptor, and scoping concern.
+- **Search on all endpoints** — result sets are small enough that search overhead is negligible. Useful for super admins with many results.
+- **Search uses `$or` on all endpoints** — Departments and programs search against both `code` and `name` fields (since `name` is nullable, searching only `name` would miss entries where `name` is null but `code` matches, e.g., searching "CCS"). Courses search against both `shortname` and `fullname`. All use MikroORM `$or` filter with `$ilike`.
+- **Courses require narrowing filter** — at least one of `programId` or `departmentId` must be provided on the courses endpoint. Departments and programs can scale within a dean's scope (small sets), but courses can reach hundreds for super admins without narrowing. This prevents unbounded responses without adding pagination complexity.
+- **Scope is always enforced, never optional** — every endpoint applies `ScopeResolverService.ResolveDepartmentIds()` before querying, even when no explicit filter params are passed. Explicit `departmentId`/`programId` params are validated against the resolved scope (403 if outside). This prevents enumeration attacks where a user guesses IDs outside their scope.
+- **MikroORM `em.find()` sufficient** — unlike the faculty endpoint which needed raw SQL for `COUNT(DISTINCT)` and pagination, these endpoints return all matching entities in a single query. No raw SQL or complex joins needed.
+- **`name` fields are nullable** — `Department.name` and `Program.name` are nullable. DTOs must handle this (return `null`). Search with ILIKE on nullable `name` fields naturally excludes nulls (no match), but search also matches against `code` (always populated) via `$or`.
+- **`departmentId` has no existence check (intentional)** — consistent with the `FacultyService` pattern. If a non-existent `departmentId` is passed, the query returns empty results (no 404). This is asymmetric with `programId` which does get a 404 check — the difference is that `programId` requires a populated `department` relation for cross-filter validation, so a `findOne` is already being performed. Adding an extra `findOne` for `departmentId` existence would be an unnecessary query for a no-harm scenario (empty results).
+- **Results sorted alphabetically** — departments and programs by `name` (nulls last), courses by `shortname`. Deterministic ordering for frontend consistency.
+
+## Implementation Plan
+
+### Tasks
+
+- [x] Task 1: Create `ListDepartmentsQueryDto` request DTO
+  - File: `src/modules/curriculum/dto/requests/list-departments-query.dto.ts` (new)
+  - Action: Create query DTO with:
+    - `semesterId: string` — required, `@IsUUID()`, `@IsNotEmpty()`
+    - `search?: string` — optional, `@IsString()`, `@IsOptional()`, `@MaxLength(100)`
+  - Notes: Follow `ListFacultyQueryDto` pattern. All properties must have `@ApiProperty()` or `@ApiPropertyOptional()` decorators.
+
+- [x] Task 2: Create `ListProgramsQueryDto` request DTO
+  - File: `src/modules/curriculum/dto/requests/list-programs-query.dto.ts` (new)
+  - Action: Create query DTO with:
+    - `semesterId: string` — required, `@IsUUID()`, `@IsNotEmpty()`
+    - `departmentId?: string` — optional, `@IsUUID()`, `@IsOptional()`
+    - `search?: string` — optional, `@IsString()`, `@IsOptional()`, `@MaxLength(100)`
+  - Notes: `departmentId` is optional — when omitted, returns programs across all departments within the caller's scope.
+
+- [x] Task 3: Create `ListCoursesQueryDto` request DTO
+  - File: `src/modules/curriculum/dto/requests/list-courses-query.dto.ts` (new)
+  - Action: Create query DTO with:
+    - `semesterId: string` — required, `@IsUUID()`, `@IsNotEmpty()`
+    - `departmentId?: string` — optional, `@IsUUID()`, `@IsOptional()`
+    - `programId?: string` — optional, `@IsUUID()`, `@IsOptional()`
+    - `search?: string` — optional, `@IsString()`, `@IsOptional()`, `@MaxLength(100)`
+  - Notes: At least one of `programId` or `departmentId` must be provided — this validation happens in the service, not the DTO (cross-field validation is more readable there). The DTO itself marks both as optional.
+
+- [x] Task 4: Create `DepartmentItemResponseDto` response DTO
+  - File: `src/modules/curriculum/dto/responses/department-item.response.dto.ts` (new)
+  - Action: Create response DTO with:
+    - `id: string` — department UUID
+    - `code: string` — e.g., "CCS"
+    - `name: string | null` — department name (nullable in entity)
+  - Notes: Include a static `Map(department: Department): DepartmentItemResponseDto` method.
+
+- [x] Task 5: Create `ProgramItemResponseDto` response DTO
+  - File: `src/modules/curriculum/dto/responses/program-item.response.dto.ts` (new)
+  - Action: Create response DTO with:
+    - `id: string` — program UUID
+    - `code: string` — e.g., "BSCS", "BSIT"
+    - `name: string | null` — program name (nullable in entity)
+    - `departmentId: string` — parent department UUID (for client-side re-filtering)
+  - Notes: Include a static `Map(program: Program): ProgramItemResponseDto` method. The `departmentId` comes from `program.department.id` — requires `department` to be populated when querying.
+
+- [x] Task 6: Create `CourseItemResponseDto` response DTO
+  - File: `src/modules/curriculum/dto/responses/course-item.response.dto.ts` (new)
+  - Action: Create response DTO with:
+    - `id: string` — course UUID
+    - `shortname: string` — e.g., "FREAI", "ELDNET1"
+    - `fullname: string` — e.g., "Free Elective AI"
+    - `programId: string` — parent program UUID (for client-side re-filtering)
+    - `isActive: boolean` — whether the course is active in Moodle
+  - Notes: Include a static `Map(course: Course): CourseItemResponseDto` method. The `programId` comes from `course.program.id` — requires `program` to be populated when querying.
+
+- [x] Task 7: Create `CurriculumService`
+  - File: `src/modules/curriculum/services/curriculum.service.ts` (new)
+  - Action: Create injectable service with three public methods:
+
+    **`ListDepartments(query: ListDepartmentsQueryDto): Promise<DepartmentItemResponseDto[]>`**
+    1. Validate semester — `em.findOne(Semester, { id: query.semesterId })` → throw `NotFoundException` if not found.
+    2. Resolve scope — call `ScopeResolverService.ResolveDepartmentIds(query.semesterId)`.
+    3. Build filter — `FilterQuery<Department>`:
+       - Base: `{ semester: query.semesterId }`
+       - If scope restricted (`departmentIds !== null`): add `{ id: { $in: departmentIds } }`. If `departmentIds` is empty array, return `[]` immediately (dean has no departments in this semester).
+       - If `search` provided: add `{ $or: [{ code: { $ilike: '%' + escapedSearch + '%' } }, { name: { $ilike: '%' + escapedSearch + '%' } }] }` (escape LIKE wildcards first). This ensures departments with null `name` but matching `code` (e.g., "CCS") are found.
+    4. Query — `em.find(Department, filter, { orderBy: { name: QueryOrder.ASC_NULLS_LAST } })`.
+    5. Map — `departments.map(DepartmentItemResponseDto.Map)`.
+
+    **`ListPrograms(query: ListProgramsQueryDto): Promise<ProgramItemResponseDto[]>`**
+    1. Validate semester — same as above.
+    2. Resolve scope — same as above.
+    3. Validate departmentId — if provided and scope restricted, check `departmentIds.includes(query.departmentId)` → throw `ForbiddenException` if not.
+    4. Build filter — `FilterQuery<Program>`:
+       - Base: `{ department: { semester: query.semesterId } }`
+       - If scope restricted and no explicit `departmentId`: add `{ department: { id: { $in: departmentIds } } }`. If empty, return `[]`.
+       - If `departmentId` provided: add `{ department: { id: query.departmentId } }` (already validated in scope).
+       - If `search` provided: add `{ $or: [{ code: { $ilike: '%' + escapedSearch + '%' } }, { name: { $ilike: '%' + escapedSearch + '%' } }] }`. Same rationale as departments — `name` is nullable, `code` always populated.
+    5. Query — `em.find(Program, filter, { populate: ['department'], orderBy: { name: QueryOrder.ASC_NULLS_LAST } })`.
+    6. Map — `programs.map(ProgramItemResponseDto.Map)`.
+
+    **`ListCourses(query: ListCoursesQueryDto): Promise<CourseItemResponseDto[]>`**
+    1. Validate narrowing filter — if neither `programId` nor `departmentId` is provided, throw `BadRequestException('At least one of programId or departmentId is required.')`.
+    2. Validate semester — same as above.
+    3. Resolve scope — same as above.
+    4. Validate filters — same cascading pattern as `FacultyService` (lines 43-78):
+       - If `departmentId` provided and scope restricted: check in scope → 403.
+       - If `programId` provided: fetch program with populated `department`. If not found → 404. If `departmentId` also provided, verify `program.department.id === departmentId` → 400 if mismatch. If scope restricted, verify `program.department.id` in scope → 403.
+    5. Build filter — `FilterQuery<Course>`:
+       - Base: `{ program: { department: { semester: query.semesterId } } }`
+       - Apply the most specific department constraint (same logic as `FacultyService.BuildCourseFilter`):
+         - If `departmentId` provided: `{ program: { department: { id: query.departmentId } } }`
+         - Else if scope restricted: `{ program: { department: { id: { $in: departmentIds } } } }`
+       - If `programId` provided: add `{ program: { id: query.programId } }`
+       - If `search` provided: add `{ $or: [{ shortname: { $ilike: '%' + escaped + '%' } }, { fullname: { $ilike: '%' + escaped + '%' } }] }`
+       - **Do NOT filter by `isActive`** — return both active and inactive courses.
+    6. Query — `em.find(Course, filter, { populate: ['program'], orderBy: { shortname: QueryOrder.ASC } })`.
+    7. Map — `courses.map(CourseItemResponseDto.Map)`.
+
+  - Notes: Inject `EntityManager` and `ScopeResolverService`. Add a private `EscapeLikeWildcards(input: string): string` helper (same implementation as `FacultyService` line 281-286: escapes `\`, `%`, `_`). This duplicates the 3-line function — acceptable tradeoff vs extracting a shared utility for such a small helper. Use `QueryOrder` from `@mikro-orm/core` for ordering.
+
+- [x] Task 8: Create `CurriculumController`
+  - File: `src/modules/curriculum/curriculum.controller.ts` (new)
+  - Action: Create controller:
+    - `@ApiTags('Curriculum')`
+    - `@Controller('curriculum')`
+    - `@UseJwtGuard(UserRole.SUPER_ADMIN, UserRole.DEAN)`
+    - `@UseInterceptors(CurrentUserInterceptor)`
+    - Three endpoints:
+      - `@Get('departments')` with `@Query() query: ListDepartmentsQueryDto` → delegates to `CurriculumService.ListDepartments(query)`
+      - `@Get('programs')` with `@Query() query: ListProgramsQueryDto` → delegates to `CurriculumService.ListPrograms(query)`
+      - `@Get('courses')` with `@Query() query: ListCoursesQueryDto` → delegates to `CurriculumService.ListCourses(query)`
+    - Each endpoint: `@ApiOperation()` with summary + `@ApiResponse({ status: 200 })` with the array type.
+  - Notes: Return type is the DTO array directly (e.g., `Promise<DepartmentItemResponseDto[]>`), no wrapper object since there's no pagination.
+
+- [x] Task 9: Create `CurriculumModule`
+  - File: `src/modules/curriculum/curriculum.module.ts` (new)
+  - Action: Create module:
+    - `imports: [MikroOrmModule.forFeature([Department, Program, Course, Semester]), CommonModule, DataLoaderModule]`
+    - `controllers: [CurriculumController]`
+    - `providers: [CurriculumService]`
+    - `exports: [CurriculumService]`
+  - Notes: `CommonModule` must be explicitly imported (NOT `@Global()`) to access `ScopeResolverService`. `DataLoaderModule` must be imported because `CurrentUserInterceptor` depends on `UserLoader`. `Semester` entity included for existence validation. No `User` or `Enrollment` entities needed — scope resolution is handled by `ScopeResolverService` internally.
+
+- [x] Task 10: Register `CurriculumModule` in application modules
+  - File: `src/modules/index.module.ts` (modify)
+  - Action: Import `CurriculumModule` and add it to the `ApplicationModules` array.
+
+- [x] Task 11: Write unit tests for `CurriculumService`
+  - File: `src/modules/curriculum/services/curriculum.service.spec.ts` (new)
+  - Action: Test cases organized by endpoint:
+
+    **ListDepartments:**
+    - Super admin sees all departments for semester (scope returns `null`, no `id` filter applied)
+    - Dean sees only departments in their scope
+    - Dean with empty scope (no institutional roles for semester) returns `[]`
+    - Search filters by department code and name (OR, ILIKE)
+    - LIKE wildcards in search are escaped (`%`, `_`)
+    - Non-existent `semesterId` returns 404
+    - Empty result returns `[]`
+
+    **ListPrograms:**
+    - Super admin sees all programs for semester
+    - Super admin with non-existent `departmentId` returns `[]` (no existence check, intentional)
+    - Dean sees only programs under their scoped departments
+    - `departmentId` within scope narrows results
+    - `departmentId` outside dean's scope returns 403
+    - Search filters by program code and name (OR)
+    - Empty result returns `[]`
+
+    **ListCourses:**
+    - Missing both `programId` and `departmentId` returns 400
+    - Super admin with `departmentId` sees all courses under that department
+    - Dean with `programId` within scope returns courses
+    - Dean with `programId` outside scope returns 403
+    - `departmentId` + `programId` mismatch returns 400
+    - `programId` not found returns 404
+    - Search filters by both shortname and fullname (OR)
+    - Inactive courses (`isActive: false`) ARE included in results
+    - Results include `isActive` flag in response DTO
+    - `departmentId` outside dean's scope returns 403
+    - Only `programId` provided, program's department outside scope → 403
+    - Empty result returns `[]`
+
+  - Notes: Mock `EntityManager` as `{ findOne: jest.fn(), find: jest.fn() }` and `ScopeResolverService` as `{ ResolveDepartmentIds: jest.fn() }`. Follow `faculty.service.spec.ts` patterns. Use `Test.createTestingModule()` in `beforeEach`.
+
+### Acceptance Criteria
+
+- [ ] AC 1: Given a super admin with a valid `semesterId`, when `GET /curriculum/departments?semesterId=X`, then return all departments for that semester sorted by name.
+
+- [ ] AC 2: Given a dean assigned to department CCS, when `GET /curriculum/departments?semesterId=X`, then return only CCS (and any other departments the dean is assigned to).
+
+- [ ] AC 3: Given a super admin, when `GET /curriculum/programs?semesterId=X`, then return all programs across all departments for that semester.
+
+- [ ] AC 4: Given a dean assigned to CCS, when `GET /curriculum/programs?semesterId=X&departmentId=CCS_ID`, then return only programs under CCS.
+
+- [ ] AC 5: Given a dean assigned to CCS, when `GET /curriculum/programs?semesterId=X&departmentId=CBA_ID`, then return 403 Forbidden.
+
+- [ ] AC 6: Given a valid `departmentId` and `semesterId`, when `GET /curriculum/courses?semesterId=X&departmentId=Y`, then return all courses (active and inactive) under programs in that department, each with `isActive` flag.
+
+- [ ] AC 7: Given a valid `programId`, when `GET /curriculum/courses?semesterId=X&programId=Z`, then return all courses under that program sorted by shortname.
+
+- [ ] AC 8: Given neither `programId` nor `departmentId`, when `GET /curriculum/courses?semesterId=X`, then return 400 Bad Request with message "At least one of programId or departmentId is required."
+
+- [ ] AC 9: Given a dean scoped to CCS and a `programId` belonging to CBA, when `GET /curriculum/courses?semesterId=X&programId=CBA_PROGRAM_ID`, then return 403 Forbidden.
+
+- [ ] AC 10: Given `departmentId=CCS_ID` and `programId=BSBA_ID` where BSBA belongs to CBA (not CCS), when `GET /curriculum/courses?semesterId=X&departmentId=CCS_ID&programId=BSBA_ID`, then return 400 Bad Request.
+
+- [ ] AC 11: Given a search term `search=Comp`, when `GET /curriculum/departments?semesterId=X&search=Comp`, then return only departments whose `code` or `name` contains "Comp" (case-insensitive).
+
+- [ ] AC 12: Given a search term `search=NET`, when `GET /curriculum/courses?semesterId=X&departmentId=Y&search=NET`, then return courses where shortname OR fullname contains "NET" (case-insensitive).
+
+- [ ] AC 13: Given a search term containing LIKE wildcard `search=%admin`, when the query executes, then `%` is escaped and treated as a literal character.
+
+- [ ] AC 14: Given a `semesterId` that does not exist, when any curriculum endpoint is called, then return 404 Not Found.
+
+- [ ] AC 15: Given a user with role STUDENT or FACULTY, when any curriculum endpoint is called, then return 403 Forbidden.
+
+- [ ] AC 16: Given an inactive course (`isActive: false`) within the scope, when `GET /curriculum/courses?semesterId=X&departmentId=Y`, then the course appears in results with `isActive: false`.
+
+- [ ] AC 17: Given a semester with no departments, when `GET /curriculum/departments?semesterId=X`, then return `[]`.
+
+- [ ] AC 18: Given a dean assigned to multiple departments (CCS and CBA), when `GET /curriculum/programs?semesterId=X`, then return programs from both departments.
+
+- [ ] AC 19: Given a dean with no departments assigned for semester X (empty scope), when any curriculum endpoint is called with `semesterId=X`, then return `[]`.
+
+- [ ] AC 20: Given a search term `search=CCS` and a department with `name = null` but `code = 'CCS'`, when `GET /curriculum/departments?semesterId=X&search=CCS`, then the department is found (search matches `code` via OR condition).
+
+## Additional Context
+
+### Dependencies
+
+- `ScopeResolverService` must exist in `CommonModule` (already implemented in FAC-53).
+- `CurrentUserInterceptor` and `UserLoader` must exist in `DataLoaderModule` (already implemented).
+- `CurrentUserService` and `AppClsModule` must exist in `CommonModule` (already implemented in FAC-56).
+- Department → Program → Course hierarchy must be synced from Moodle (`CategorySyncJob` + `CourseSyncJob`).
+- `UserInstitutionalRole` must be populated for deans (populated by `MoodleUserHydrationService` during login/sync).
+- No new external libraries required — all functionality uses existing NestJS, MikroORM, and class-validator packages.
+
+### Testing Strategy
+
+**Unit Tests:**
+
+- `CurriculumService` — test all three methods with scope variations (super admin unrestricted, dean restricted, dean empty scope), filter validation (403/400 errors), search escaping, inactive course inclusion, empty results. Mock `EntityManager` and `ScopeResolverService`.
+
+**Manual Testing:**
+
+- Use Swagger UI (`OPENAPI_MODE=true`) to test the three endpoints with different user tokens.
+- Verify dean scoping with a real dean account (check that only their department's programs and courses appear).
+- Verify super admin sees all hierarchy data.
+- Test cascading filter flow: select department → load programs → select program → load courses.
+- Test search with special characters.
+
+### Notes
+
+- This is FAC-57 on the project board.
+- The `ScopeResolverService` was intentionally placed in `CommonModule` during FAC-53 to support exactly this use case.
+- The faculty endpoint (FAC-53) excludes inactive courses in its results (`isActive: true` filter) — different concern. Faculty list cares about current teaching assignments. Curriculum list cares about historical visibility for analytics.
+- `Department.name` and `Program.name` are nullable — synced from Moodle category names. The DTOs return `null` when name is not set. Frontend should handle null names gracefully (e.g., fall back to displaying `code`).
+- The controller uses `/curriculum/departments`, `/curriculum/programs`, `/curriculum/courses` routes (under the `curriculum` controller prefix). This groups them logically while keeping individual resource names RESTful.
+- **Red Team hardening applied**: mandatory scope enforcement on all endpoints, filter validation against resolved scope, courses require narrowing filter. See Technical Decisions for details.
+
+## Review Notes
+
+- Adversarial review completed
+- Findings: 15 total — 7 fixed, 4 acknowledged (Low/accepted), 2 undecided (accepted risk), 2 noise
+- **Fixed**: F2 (search on code+name), F3 (removed cache claim), F6 (scope text correction), F7/F8 (documented departmentId behavior), F9 (added test case), F10 (acknowledged duplication), F12 (added AC 19), F1 (documented ESCAPE assumption), F5/F14 (cleaned up frontmatter)
+- **Accepted**: F4 (entity summary omissions — minor, non-blocking), F13 (cross-campus returns empty — correct behavior), F11 (noise — logic is sound), F15 (ILIKE null behavior — now covered by $or on code)
+
+## Implementation Review Notes
+
+- Implementation adversarial review completed
+- Findings: 13 total — 7 fixed, 5 acknowledged (accepted), 1 noise
+- Resolution approach: auto-fix
+- **Fixed**: F2 (wrapped search $or in $and for safe filter composition), F3 (mockResolvedValueOnce in test), F4 (reordered ListCourses validation — semester before business rules), F5 (added test: empty scope + programId), F7 (added test: scope + search combined), F12 (strengthened filter assertion in test), F13 (added happy-path test: both departmentId + programId)
+- **Acknowledged**: F1 ($ilike ESCAPE — accepted per tech spec), F6 (Map() assumes populated relations — consistent with codebase pattern), F8/F9/F10/F11 (accepted by design or consistent with patterns)

--- a/docs/architecture/core-components.md
+++ b/docs/architecture/core-components.md
@@ -51,6 +51,9 @@ classDiagram
         ChatKitModule
         QuestionnaireModule
         AnalysisModule
+        DimensionsModule
+        FacultyModule
+        CurriculumModule
     }
 
     AppModule --> InfrastructureModules : "imports"
@@ -62,6 +65,8 @@ classDiagram
     EnrollmentsModule --> MoodleModule : "uses MoodleService"
     QuestionnaireModule --> CommonModule : "uses UnitOfWork"
     AnalysisModule --> BullModule : "uses BullMQ queues"
+    FacultyModule --> CommonModule : "uses ScopeResolverService"
+    CurriculumModule --> CommonModule : "uses ScopeResolverService"
 
     class AnalysisModule {
         +AnalysisService
@@ -210,7 +215,45 @@ The `HealthModule` uses `@nestjs/terminus` to provide structured health checks a
 
 Returns HTTP 200 with `status: 'ok'` when healthy, HTTP 503 with `status: 'error'` and per-indicator details when unhealthy.
 
-## 9. Startup & Initialization Flow
+## 9. Scoped Query Pattern (Faculty & Curriculum)
+
+The `FacultyModule` and `CurriculumModule` use a shared role-based scoping pattern for administrative queries. This ensures deans only see data within their assigned departments while super admins see everything.
+
+### Scope Resolution Chain
+
+```
+Request → JwtAuthGuard → RolesGuard → CurrentUserInterceptor → CLS Store → ScopeResolverService
+```
+
+1. `@UseJwtGuard(SUPER_ADMIN, DEAN)` validates JWT and checks role membership via `RolesGuard`
+2. `CurrentUserInterceptor` loads the full `User` entity via `UserLoader` and stores it in CLS (`CurrentUserService.set()`)
+3. `ScopeResolverService.ResolveDepartmentIds(semesterId)` reads the user from CLS and returns:
+   - `null` — unrestricted (super admin)
+   - `string[]` — department UUIDs the dean is assigned to for that semester
+
+### Filter Validation Cascade
+
+When explicit filter params (`departmentId`, `programId`) are provided, they are validated against the resolved scope:
+
+| Scenario                              | Result            |
+| ------------------------------------- | ----------------- |
+| `departmentId` outside scope          | `403 Forbidden`   |
+| `programId` not found                 | `404 Not Found`   |
+| `programId` department outside scope  | `403 Forbidden`   |
+| `departmentId` + `programId` mismatch | `400 Bad Request` |
+
+### Modules
+
+| Module             | Endpoints                                              | Purpose                                        |
+| ------------------ | ------------------------------------------------------ | ---------------------------------------------- |
+| `FacultyModule`    | `GET /faculty`                                         | Paginated faculty list with course assignments |
+| `CurriculumModule` | `GET /curriculum/departments`, `/programs`, `/courses` | Institutional hierarchy for filter dropdowns   |
+
+Both modules import `CommonModule` (for `ScopeResolverService`) and `DataLoaderModule` (for `CurrentUserInterceptor` → `UserLoader`).
+
+The `CurriculumModule` endpoints return flat arrays (no pagination) since result sets are small within a dean's scope. All three endpoints require `semesterId`; the courses endpoint additionally requires at least one of `programId` or `departmentId` to prevent unbounded queries.
+
+## 10. Startup & Initialization Flow
 
 The application enforces a strict initialization sequence in `InitializeDatabase` before it begins accepting traffic. This ensures that the database schema and required infrastructure state are always synchronized with the code.
 

--- a/docs/decisions/decisions.md
+++ b/docs/decisions/decisions.md
@@ -126,6 +126,21 @@ Recommendations were originally designed as an external HTTP worker (like sentim
 - **Structured output:** Uses OpenAI's `zodResponseFormat` for type-safe responses — the LLM returns JSON validated against the `llmRecommendationsResponseSchema` (category, headline, description, actionPlan, priority, topicReference).
 - **Trade-off:** Recommendation generation now runs in the API process, consuming memory and an OpenAI API call slot. Acceptable because one call per pipeline run is negligible load, and the alternative (an HTTP worker with replicated DB queries) adds complexity without benefit.
 
+## 21. CLS-Based Scope Resolution
+
+Role-based scoping uses NestJS CLS (Continuation-Local Storage) via `nestjs-cls` to propagate the authenticated user through the request lifecycle without passing it as a parameter.
+
+- **Flow:** `CurrentUserInterceptor` loads the user into CLS, then `ScopeResolverService` reads it via `CurrentUserService.getOrFail()`. Services never receive the user directly — they call `ScopeResolverService.ResolveDepartmentIds(semesterId)` which returns `null` (unrestricted) or `string[]` (restricted department IDs).
+- **Rationale:** Avoids threading the user through every controller → service method signature. The interceptor + CLS pattern is a single integration point that all scoped modules reuse.
+- **Trade-off:** CLS adds an implicit dependency that isn't visible in constructor injection. Mitigated by the `getOrFail()` method which throws immediately if the user isn't set.
+
+## 22. Curriculum Endpoints Without Pagination
+
+The `CurriculumModule` returns flat arrays instead of paginated responses for departments, programs, and courses.
+
+- **Rationale:** Result sets are inherently small within a dean's scope (1-3 departments, 5-15 programs, 20-60 courses). Super admins see more but still manageable for a single university. Pagination would add DTO and service complexity for no practical benefit.
+- **Trade-off:** If the system scales to multi-university, super admin result sets could grow. Acceptable risk — pagination can be added later without breaking the API contract (response would change from `T[]` to `{ data: T[], meta: ... }`).
+
 ## 20. Confidence-Scored Supporting Evidence
 
 Each recommendation includes a `supportingEvidence` object with computed confidence levels and structured data sources, rather than freeform text justification.

--- a/src/modules/curriculum/curriculum.controller.ts
+++ b/src/modules/curriculum/curriculum.controller.ts
@@ -1,0 +1,47 @@
+import { Controller, Get, Query, UseInterceptors } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { UseJwtGuard } from 'src/security/decorators';
+import { UserRole } from '../auth/roles.enum';
+import { CurrentUserInterceptor } from '../common/interceptors/current-user.interceptor';
+import { CurriculumService } from './services/curriculum.service';
+import { ListDepartmentsQueryDto } from './dto/requests/list-departments-query.dto';
+import { ListProgramsQueryDto } from './dto/requests/list-programs-query.dto';
+import { ListCoursesQueryDto } from './dto/requests/list-courses-query.dto';
+import { DepartmentItemResponseDto } from './dto/responses/department-item.response.dto';
+import { ProgramItemResponseDto } from './dto/responses/program-item.response.dto';
+import { CourseItemResponseDto } from './dto/responses/course-item.response.dto';
+
+@ApiTags('Curriculum')
+@Controller('curriculum')
+@UseJwtGuard(UserRole.SUPER_ADMIN, UserRole.DEAN)
+@UseInterceptors(CurrentUserInterceptor)
+export class CurriculumController {
+  constructor(private readonly curriculumService: CurriculumService) {}
+
+  @Get('departments')
+  @ApiOperation({ summary: 'List departments scoped to caller role' })
+  @ApiResponse({ status: 200, type: [DepartmentItemResponseDto] })
+  async ListDepartments(
+    @Query() query: ListDepartmentsQueryDto,
+  ): Promise<DepartmentItemResponseDto[]> {
+    return this.curriculumService.ListDepartments(query);
+  }
+
+  @Get('programs')
+  @ApiOperation({ summary: 'List programs scoped to caller role' })
+  @ApiResponse({ status: 200, type: [ProgramItemResponseDto] })
+  async ListPrograms(
+    @Query() query: ListProgramsQueryDto,
+  ): Promise<ProgramItemResponseDto[]> {
+    return this.curriculumService.ListPrograms(query);
+  }
+
+  @Get('courses')
+  @ApiOperation({ summary: 'List courses scoped to caller role' })
+  @ApiResponse({ status: 200, type: [CourseItemResponseDto] })
+  async ListCourses(
+    @Query() query: ListCoursesQueryDto,
+  ): Promise<CourseItemResponseDto[]> {
+    return this.curriculumService.ListCourses(query);
+  }
+}

--- a/src/modules/curriculum/curriculum.module.ts
+++ b/src/modules/curriculum/curriculum.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { MikroOrmModule } from '@mikro-orm/nestjs';
+import { Department } from 'src/entities/department.entity';
+import { Program } from 'src/entities/program.entity';
+import { Course } from 'src/entities/course.entity';
+import { Semester } from 'src/entities/semester.entity';
+import { User } from 'src/entities/user.entity';
+import { CommonModule } from '../common/common.module';
+import DataLoaderModule from '../common/data-loaders/index.module';
+import { CurriculumController } from './curriculum.controller';
+import { CurriculumService } from './services/curriculum.service';
+
+@Module({
+  imports: [
+    MikroOrmModule.forFeature([Department, Program, Course, Semester, User]),
+    CommonModule,
+    DataLoaderModule,
+  ],
+  controllers: [CurriculumController],
+  providers: [CurriculumService],
+  exports: [CurriculumService],
+})
+export class CurriculumModule {}

--- a/src/modules/curriculum/dto/requests/list-courses-query.dto.ts
+++ b/src/modules/curriculum/dto/requests/list-courses-query.dto.ts
@@ -1,0 +1,33 @@
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ListCoursesQueryDto {
+  @ApiProperty({ description: 'Semester UUID to scope course list' })
+  @IsUUID()
+  @IsNotEmpty()
+  semesterId: string;
+
+  @ApiPropertyOptional({ description: 'Filter by department UUID' })
+  @IsUUID()
+  @IsOptional()
+  departmentId?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by program UUID' })
+  @IsUUID()
+  @IsOptional()
+  programId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Search by course shortname or fullname',
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  search?: string;
+}

--- a/src/modules/curriculum/dto/requests/list-departments-query.dto.ts
+++ b/src/modules/curriculum/dto/requests/list-departments-query.dto.ts
@@ -1,0 +1,21 @@
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ListDepartmentsQueryDto {
+  @ApiProperty({ description: 'Semester UUID to scope department list' })
+  @IsUUID()
+  @IsNotEmpty()
+  semesterId: string;
+
+  @ApiPropertyOptional({ description: 'Search by department code or name' })
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  search?: string;
+}

--- a/src/modules/curriculum/dto/requests/list-programs-query.dto.ts
+++ b/src/modules/curriculum/dto/requests/list-programs-query.dto.ts
@@ -1,0 +1,26 @@
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ListProgramsQueryDto {
+  @ApiProperty({ description: 'Semester UUID to scope program list' })
+  @IsUUID()
+  @IsNotEmpty()
+  semesterId: string;
+
+  @ApiPropertyOptional({ description: 'Filter by department UUID' })
+  @IsUUID()
+  @IsOptional()
+  departmentId?: string;
+
+  @ApiPropertyOptional({ description: 'Search by program code or name' })
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  search?: string;
+}

--- a/src/modules/curriculum/dto/responses/course-item.response.dto.ts
+++ b/src/modules/curriculum/dto/responses/course-item.response.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Course } from 'src/entities/course.entity';
+
+export class CourseItemResponseDto {
+  @ApiProperty({ description: 'Course UUID' })
+  id: string;
+
+  @ApiProperty({ description: 'Course shortname (e.g., "FREAI", "ELDNET1")' })
+  shortname: string;
+
+  @ApiProperty({
+    description: 'Course fullname (e.g., "Free Elective AI")',
+  })
+  fullname: string;
+
+  @ApiProperty({ description: 'Parent program UUID' })
+  programId: string;
+
+  @ApiProperty({ description: 'Whether the course is active in Moodle' })
+  isActive: boolean;
+
+  static Map(course: Course): CourseItemResponseDto {
+    const dto = new CourseItemResponseDto();
+    dto.id = course.id;
+    dto.shortname = course.shortname;
+    dto.fullname = course.fullname;
+    dto.programId = course.program.id;
+    dto.isActive = course.isActive;
+    return dto;
+  }
+}

--- a/src/modules/curriculum/dto/responses/department-item.response.dto.ts
+++ b/src/modules/curriculum/dto/responses/department-item.response.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Department } from 'src/entities/department.entity';
+
+export class DepartmentItemResponseDto {
+  @ApiProperty({ description: 'Department UUID' })
+  id: string;
+
+  @ApiProperty({ description: 'Department code (e.g., "CCS")' })
+  code: string;
+
+  @ApiPropertyOptional({
+    description: 'Department name',
+    nullable: true,
+  })
+  name: string | null;
+
+  static Map(department: Department): DepartmentItemResponseDto {
+    const dto = new DepartmentItemResponseDto();
+    dto.id = department.id;
+    dto.code = department.code;
+    dto.name = department.name ?? null;
+    return dto;
+  }
+}

--- a/src/modules/curriculum/dto/responses/program-item.response.dto.ts
+++ b/src/modules/curriculum/dto/responses/program-item.response.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Program } from 'src/entities/program.entity';
+
+export class ProgramItemResponseDto {
+  @ApiProperty({ description: 'Program UUID' })
+  id: string;
+
+  @ApiProperty({ description: 'Program code (e.g., "BSCS", "BSIT")' })
+  code: string;
+
+  @ApiPropertyOptional({
+    description: 'Program name',
+    nullable: true,
+  })
+  name: string | null;
+
+  @ApiProperty({ description: 'Parent department UUID' })
+  departmentId: string;
+
+  static Map(program: Program): ProgramItemResponseDto {
+    const dto = new ProgramItemResponseDto();
+    dto.id = program.id;
+    dto.code = program.code;
+    dto.name = program.name ?? null;
+    dto.departmentId = program.department.id;
+    return dto;
+  }
+}

--- a/src/modules/curriculum/services/curriculum.service.spec.ts
+++ b/src/modules/curriculum/services/curriculum.service.spec.ts
@@ -1,0 +1,612 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { EntityManager } from '@mikro-orm/postgresql';
+import { CurriculumService } from './curriculum.service';
+import { ScopeResolverService } from 'src/modules/common/services/scope-resolver.service';
+
+describe('CurriculumService', () => {
+  let service: CurriculumService;
+  let em: { findOne: jest.Mock; find: jest.Mock };
+  let scopeResolver: { ResolveDepartmentIds: jest.Mock };
+
+  const semesterId = 'semester-1';
+  const deptId = 'dept-1';
+  const deptId2 = 'dept-2';
+  const programId = 'program-1';
+  const programId2 = 'program-2';
+
+  beforeEach(async () => {
+    em = {
+      findOne: jest.fn(),
+      find: jest.fn(),
+    };
+
+    scopeResolver = {
+      ResolveDepartmentIds: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CurriculumService,
+        { provide: EntityManager, useValue: em },
+        { provide: ScopeResolverService, useValue: scopeResolver },
+      ],
+    }).compile();
+
+    service = module.get(CurriculumService);
+  });
+
+  function setupSemesterFound() {
+    em.findOne.mockResolvedValueOnce({ id: semesterId });
+  }
+
+  // ─── ListDepartments ──────────────────────────────────────────────
+
+  describe('ListDepartments', () => {
+    it('should return all departments for super admin (unrestricted scope)', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
+
+      const departments = [
+        { id: deptId, code: 'CCS', name: 'College of Computer Studies' },
+        { id: deptId2, code: 'CBA', name: 'College of Business Admin' },
+      ];
+      em.find.mockResolvedValue(departments);
+
+      const result = await service.ListDepartments({ semesterId });
+
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe(deptId);
+      expect(result[0].code).toBe('CCS');
+      expect(result[0].name).toBe('College of Computer Studies');
+      expect(scopeResolver.ResolveDepartmentIds).toHaveBeenCalledWith(
+        semesterId,
+      );
+    });
+
+    it('should return only scoped departments for dean', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
+
+      const departments = [
+        { id: deptId, code: 'CCS', name: 'College of Computer Studies' },
+      ];
+      em.find.mockResolvedValue(departments);
+
+      const result = await service.ListDepartments({ semesterId });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].code).toBe('CCS');
+      // Verify scope filter was applied
+      const findCall = em.find.mock.calls[0] as unknown[];
+      expect(findCall[1]).toEqual(
+        expect.objectContaining({ id: { $in: [deptId] } }),
+      );
+    });
+
+    it('should return [] when dean has empty scope', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue([]);
+
+      const result = await service.ListDepartments({ semesterId });
+
+      expect(result).toEqual([]);
+      expect(em.find).not.toHaveBeenCalled();
+    });
+
+    it('should filter by search on code and name (OR, ILIKE)', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
+      em.find.mockResolvedValue([]);
+
+      await service.ListDepartments({ semesterId, search: 'Comp' });
+
+      const findCall = em.find.mock.calls[0] as unknown[];
+      expect(findCall[1]).toEqual(
+        expect.objectContaining({
+          $and: [
+            {
+              $or: [
+                { code: { $ilike: '%Comp%' } },
+                { name: { $ilike: '%Comp%' } },
+              ],
+            },
+          ],
+        }),
+      );
+    });
+
+    it('should escape LIKE wildcards in search', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
+      em.find.mockResolvedValue([]);
+
+      await service.ListDepartments({ semesterId, search: '%admin_test' });
+
+      const findCall = em.find.mock.calls[0] as unknown[];
+      expect(findCall[1]).toEqual(
+        expect.objectContaining({
+          $and: [
+            {
+              $or: [
+                { code: { $ilike: '%\\%admin\\_test%' } },
+                { name: { $ilike: '%\\%admin\\_test%' } },
+              ],
+            },
+          ],
+        }),
+      );
+    });
+
+    it('should throw 404 for non-existent semesterId', async () => {
+      em.findOne.mockResolvedValue(null);
+
+      await expect(service.ListDepartments({ semesterId })).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should return [] when no departments match', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
+      em.find.mockResolvedValue([]);
+
+      const result = await service.ListDepartments({ semesterId });
+
+      expect(result).toEqual([]);
+    });
+
+    it('should apply both scope restriction and search simultaneously', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
+      em.find.mockResolvedValue([]);
+
+      await service.ListDepartments({ semesterId, search: 'CCS' });
+
+      const findCall = em.find.mock.calls[0] as unknown[];
+      expect(findCall[1]).toEqual(
+        expect.objectContaining({
+          id: { $in: [deptId] },
+          $and: [
+            {
+              $or: [
+                { code: { $ilike: '%CCS%' } },
+                { name: { $ilike: '%CCS%' } },
+              ],
+            },
+          ],
+        }),
+      );
+    });
+
+    it('should handle department with null name', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
+      em.find.mockResolvedValue([{ id: deptId, code: 'CCS', name: undefined }]);
+
+      const result = await service.ListDepartments({ semesterId });
+
+      expect(result[0].name).toBeNull();
+    });
+  });
+
+  // ─── ListPrograms ─────────────────────────────────────────────────
+
+  describe('ListPrograms', () => {
+    it('should return all programs for super admin', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
+
+      const programs = [
+        {
+          id: programId,
+          code: 'BSCS',
+          name: 'BS Computer Science',
+          department: { id: deptId },
+        },
+        {
+          id: programId2,
+          code: 'BSIT',
+          name: 'BS Information Technology',
+          department: { id: deptId },
+        },
+      ];
+      em.find.mockResolvedValue(programs);
+
+      const result = await service.ListPrograms({ semesterId });
+
+      expect(result).toHaveLength(2);
+      expect(result[0].departmentId).toBe(deptId);
+    });
+
+    it('should return [] for super admin with non-existent departmentId', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
+      em.find.mockResolvedValue([]);
+
+      const result = await service.ListPrograms({
+        semesterId,
+        departmentId: 'non-existent',
+      });
+
+      expect(result).toEqual([]);
+      // Verify filter includes the departmentId
+      const findCall = em.find.mock.calls[0] as unknown[];
+      expect(findCall[1]).toEqual(
+        expect.objectContaining({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          department: expect.objectContaining({ id: 'non-existent' }),
+        }),
+      );
+    });
+
+    it('should return only scoped programs for dean', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
+
+      const programs = [
+        {
+          id: programId,
+          code: 'BSCS',
+          name: 'BS Computer Science',
+          department: { id: deptId },
+        },
+      ];
+      em.find.mockResolvedValue(programs);
+
+      const result = await service.ListPrograms({ semesterId });
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('should narrow results with departmentId within scope', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId, deptId2]);
+      em.find.mockResolvedValue([]);
+
+      await service.ListPrograms({ semesterId, departmentId: deptId });
+
+      const findCall = em.find.mock.calls[0] as unknown[];
+      expect(findCall[1]).toEqual(
+        expect.objectContaining({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          department: expect.objectContaining({ id: deptId }),
+        }),
+      );
+    });
+
+    it('should throw 403 when departmentId is outside dean scope', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
+
+      await expect(
+        service.ListPrograms({ semesterId, departmentId: deptId2 }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should filter by search on code and name (OR)', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
+      em.find.mockResolvedValue([]);
+
+      await service.ListPrograms({ semesterId, search: 'BS' });
+
+      const findCall = em.find.mock.calls[0] as unknown[];
+      expect(findCall[1]).toEqual(
+        expect.objectContaining({
+          $and: [
+            {
+              $or: [{ code: { $ilike: '%BS%' } }, { name: { $ilike: '%BS%' } }],
+            },
+          ],
+        }),
+      );
+    });
+
+    it('should return [] when no programs match', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
+      em.find.mockResolvedValue([]);
+
+      const result = await service.ListPrograms({ semesterId });
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return [] when dean has empty scope and no departmentId', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue([]);
+
+      const result = await service.ListPrograms({ semesterId });
+
+      expect(result).toEqual([]);
+      expect(em.find).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── ListCourses ──────────────────────────────────────────────────
+
+  describe('ListCourses', () => {
+    it('should throw 400 when neither programId nor departmentId is provided', async () => {
+      setupSemesterFound();
+
+      await expect(service.ListCourses({ semesterId })).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should return courses for super admin with departmentId', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
+
+      const courses = [
+        {
+          id: 'c1',
+          shortname: 'FREAI',
+          fullname: 'Free Elective AI',
+          program: { id: programId },
+          isActive: true,
+        },
+        {
+          id: 'c2',
+          shortname: 'ELDNET1',
+          fullname: 'Elective Data Networks 1',
+          program: { id: programId },
+          isActive: false,
+        },
+      ];
+      em.find.mockResolvedValue(courses);
+
+      const result = await service.ListCourses({
+        semesterId,
+        departmentId: deptId,
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result[0].programId).toBe(programId);
+    });
+
+    it('should return courses for dean with programId within scope', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
+
+      em.findOne.mockResolvedValueOnce({
+        id: programId,
+        department: { id: deptId },
+      });
+
+      const courses = [
+        {
+          id: 'c1',
+          shortname: 'FREAI',
+          fullname: 'Free Elective AI',
+          program: { id: programId },
+          isActive: true,
+        },
+      ];
+      em.find.mockResolvedValue(courses);
+
+      const result = await service.ListCourses({
+        semesterId,
+        programId,
+      });
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('should throw 403 when dean provides programId outside scope', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
+
+      em.findOne.mockResolvedValueOnce({
+        id: programId,
+        department: { id: deptId2 },
+      });
+
+      await expect(
+        service.ListCourses({ semesterId, programId }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw 400 when departmentId + programId mismatch', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
+
+      em.findOne.mockResolvedValueOnce({
+        id: programId,
+        department: { id: deptId2 },
+      });
+
+      await expect(
+        service.ListCourses({
+          semesterId,
+          departmentId: deptId,
+          programId,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw 404 when programId not found', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
+
+      em.findOne.mockResolvedValueOnce(null);
+
+      await expect(
+        service.ListCourses({ semesterId, programId }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should filter by search on shortname and fullname (OR)', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
+      em.find.mockResolvedValue([]);
+
+      await service.ListCourses({
+        semesterId,
+        departmentId: deptId,
+        search: 'NET',
+      });
+
+      const findCall = em.find.mock.calls[0] as unknown[];
+      expect(findCall[1]).toEqual(
+        expect.objectContaining({
+          $and: [
+            {
+              $or: [
+                { shortname: { $ilike: '%NET%' } },
+                { fullname: { $ilike: '%NET%' } },
+              ],
+            },
+          ],
+        }),
+      );
+    });
+
+    it('should include inactive courses (isActive: false) in results', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
+
+      const courses = [
+        {
+          id: 'c1',
+          shortname: 'ACTIVE',
+          fullname: 'Active Course',
+          program: { id: programId },
+          isActive: true,
+        },
+        {
+          id: 'c2',
+          shortname: 'INACTIVE',
+          fullname: 'Inactive Course',
+          program: { id: programId },
+          isActive: false,
+        },
+      ];
+      em.find.mockResolvedValue(courses);
+
+      const result = await service.ListCourses({
+        semesterId,
+        departmentId: deptId,
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result[0].isActive).toBe(true);
+      expect(result[1].isActive).toBe(false);
+
+      // Verify no isActive filter was applied
+      const findCall = em.find.mock.calls[0] as unknown[];
+      expect(findCall[1]).not.toHaveProperty('isActive');
+    });
+
+    it('should throw 403 when departmentId is outside dean scope', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
+
+      await expect(
+        service.ListCourses({ semesterId, departmentId: deptId2 }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw 403 when only programId provided and program department is outside scope', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
+
+      em.findOne.mockResolvedValueOnce({
+        id: programId,
+        department: { id: deptId2 },
+      });
+
+      await expect(
+        service.ListCourses({ semesterId, programId }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should return [] when no courses match', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
+      em.find.mockResolvedValue([]);
+
+      const result = await service.ListCourses({
+        semesterId,
+        departmentId: deptId,
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it('should throw 404 for non-existent semesterId', async () => {
+      em.findOne.mockResolvedValueOnce(null);
+
+      await expect(
+        service.ListCourses({ semesterId, departmentId: deptId }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should return [] when dean has empty scope with departmentId', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue([]);
+
+      await expect(
+        service.ListCourses({ semesterId, departmentId: deptId }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw 403 when dean has empty scope with programId only', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue([]);
+
+      em.findOne.mockResolvedValueOnce({
+        id: programId,
+        department: { id: deptId },
+      });
+
+      await expect(
+        service.ListCourses({ semesterId, programId }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should return courses when both departmentId and programId are valid and match', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
+
+      em.findOne.mockResolvedValueOnce({
+        id: programId,
+        department: { id: deptId },
+      });
+
+      const courses = [
+        {
+          id: 'c1',
+          shortname: 'FREAI',
+          fullname: 'Free Elective AI',
+          program: { id: programId },
+          isActive: true,
+        },
+      ];
+      em.find.mockResolvedValue(courses);
+
+      const result = await service.ListCourses({
+        semesterId,
+        departmentId: deptId,
+        programId,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].shortname).toBe('FREAI');
+
+      // Verify filter includes both constraints
+      const findCall = em.find.mock.calls[0] as unknown[];
+      expect(findCall[1]).toEqual(
+        expect.objectContaining({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          program: expect.objectContaining({ id: programId }),
+        }),
+      );
+    });
+  });
+});

--- a/src/modules/curriculum/services/curriculum.service.ts
+++ b/src/modules/curriculum/services/curriculum.service.ts
@@ -1,0 +1,242 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { EntityManager } from '@mikro-orm/postgresql';
+import { FilterQuery, QueryOrder } from '@mikro-orm/core';
+import { Department } from 'src/entities/department.entity';
+import { Program } from 'src/entities/program.entity';
+import { Course } from 'src/entities/course.entity';
+import { Semester } from 'src/entities/semester.entity';
+import { ScopeResolverService } from 'src/modules/common/services/scope-resolver.service';
+import { ListDepartmentsQueryDto } from '../dto/requests/list-departments-query.dto';
+import { ListProgramsQueryDto } from '../dto/requests/list-programs-query.dto';
+import { ListCoursesQueryDto } from '../dto/requests/list-courses-query.dto';
+import { DepartmentItemResponseDto } from '../dto/responses/department-item.response.dto';
+import { ProgramItemResponseDto } from '../dto/responses/program-item.response.dto';
+import { CourseItemResponseDto } from '../dto/responses/course-item.response.dto';
+
+@Injectable()
+export class CurriculumService {
+  constructor(
+    private readonly em: EntityManager,
+    private readonly scopeResolverService: ScopeResolverService,
+  ) {}
+
+  async ListDepartments(
+    query: ListDepartmentsQueryDto,
+  ): Promise<DepartmentItemResponseDto[]> {
+    await this.ValidateSemester(query.semesterId);
+
+    const departmentIds = await this.scopeResolverService.ResolveDepartmentIds(
+      query.semesterId,
+    );
+
+    const filter: FilterQuery<Department> = {
+      semester: query.semesterId,
+    };
+
+    if (departmentIds !== null) {
+      if (departmentIds.length === 0) {
+        return [];
+      }
+      Object.assign(filter, { id: { $in: departmentIds } });
+    }
+
+    if (query.search) {
+      const escaped = this.EscapeLikeWildcards(query.search);
+      Object.assign(filter, {
+        $and: [
+          {
+            $or: [
+              { code: { $ilike: `%${escaped}%` } },
+              { name: { $ilike: `%${escaped}%` } },
+            ],
+          },
+        ],
+      });
+    }
+
+    const departments = await this.em.find(Department, filter, {
+      orderBy: { name: QueryOrder.ASC_NULLS_LAST },
+    });
+
+    return departments.map((d) => DepartmentItemResponseDto.Map(d));
+  }
+
+  async ListPrograms(
+    query: ListProgramsQueryDto,
+  ): Promise<ProgramItemResponseDto[]> {
+    await this.ValidateSemester(query.semesterId);
+
+    const departmentIds = await this.scopeResolverService.ResolveDepartmentIds(
+      query.semesterId,
+    );
+
+    if (query.departmentId && departmentIds !== null) {
+      if (!departmentIds.includes(query.departmentId)) {
+        throw new ForbiddenException(
+          'Department is outside your authorized scope.',
+        );
+      }
+    }
+
+    const departmentFilter: Record<string, unknown> = {
+      semester: query.semesterId,
+    };
+
+    if (query.departmentId) {
+      departmentFilter.id = query.departmentId;
+    } else if (departmentIds !== null) {
+      if (departmentIds.length === 0) {
+        return [];
+      }
+      departmentFilter.id = { $in: departmentIds };
+    }
+
+    const filter: FilterQuery<Program> = {
+      department: departmentFilter,
+    } as FilterQuery<Program>;
+
+    if (query.search) {
+      const escaped = this.EscapeLikeWildcards(query.search);
+      Object.assign(filter, {
+        $and: [
+          {
+            $or: [
+              { code: { $ilike: `%${escaped}%` } },
+              { name: { $ilike: `%${escaped}%` } },
+            ],
+          },
+        ],
+      });
+    }
+
+    const programs = await this.em.find(Program, filter, {
+      populate: ['department'],
+      orderBy: { name: QueryOrder.ASC_NULLS_LAST },
+    });
+
+    return programs.map((p) => ProgramItemResponseDto.Map(p));
+  }
+
+  async ListCourses(
+    query: ListCoursesQueryDto,
+  ): Promise<CourseItemResponseDto[]> {
+    await this.ValidateSemester(query.semesterId);
+
+    if (!query.programId && !query.departmentId) {
+      throw new BadRequestException(
+        'At least one of programId or departmentId is required.',
+      );
+    }
+
+    const departmentIds = await this.scopeResolverService.ResolveDepartmentIds(
+      query.semesterId,
+    );
+
+    // Validate departmentId in scope
+    if (query.departmentId && departmentIds !== null) {
+      if (!departmentIds.includes(query.departmentId)) {
+        throw new ForbiddenException(
+          'Department is outside your authorized scope.',
+        );
+      }
+    }
+
+    // Validate programId
+    if (query.programId) {
+      const program = await this.em.findOne(
+        Program,
+        { id: query.programId },
+        { populate: ['department'] },
+      );
+
+      if (!program) {
+        throw new NotFoundException(
+          `Program with id '${query.programId}' not found.`,
+        );
+      }
+
+      if (query.departmentId && program.department.id !== query.departmentId) {
+        throw new BadRequestException(
+          'Program does not belong to the specified department.',
+        );
+      }
+
+      if (
+        departmentIds !== null &&
+        !departmentIds.includes(program.department.id)
+      ) {
+        throw new ForbiddenException(
+          'Program is outside your authorized scope.',
+        );
+      }
+    }
+
+    // Build filter
+    const departmentFilter: Record<string, unknown> = {
+      semester: query.semesterId,
+    };
+
+    if (query.departmentId) {
+      departmentFilter.id = query.departmentId;
+    } else if (departmentIds !== null) {
+      if (departmentIds.length === 0) {
+        return [];
+      }
+      departmentFilter.id = { $in: departmentIds };
+    }
+
+    const programFilter: Record<string, unknown> = {
+      department: departmentFilter,
+    };
+
+    if (query.programId) {
+      programFilter.id = query.programId;
+    }
+
+    const filter: FilterQuery<Course> = {
+      program: programFilter,
+    } as FilterQuery<Course>;
+
+    if (query.search) {
+      const escaped = this.EscapeLikeWildcards(query.search);
+      Object.assign(filter, {
+        $and: [
+          {
+            $or: [
+              { shortname: { $ilike: `%${escaped}%` } },
+              { fullname: { $ilike: `%${escaped}%` } },
+            ],
+          },
+        ],
+      });
+    }
+
+    const courses = await this.em.find(Course, filter, {
+      populate: ['program'],
+      orderBy: { shortname: QueryOrder.ASC },
+    });
+
+    return courses.map((c) => CourseItemResponseDto.Map(c));
+  }
+
+  private async ValidateSemester(semesterId: string): Promise<void> {
+    const semester = await this.em.findOne(Semester, { id: semesterId });
+    if (!semester) {
+      throw new NotFoundException(
+        `Semester with id '${semesterId}' not found.`,
+      );
+    }
+  }
+
+  private EscapeLikeWildcards(input: string): string {
+    return input
+      .replace(/\\/g, '\\\\')
+      .replace(/%/g, '\\%')
+      .replace(/_/g, '\\_');
+  }
+}

--- a/src/modules/index.module.ts
+++ b/src/modules/index.module.ts
@@ -18,6 +18,7 @@ import { QuestionnaireModule } from './questionnaires/questionnaires.module';
 import { AnalysisModule } from './analysis/analysis.module';
 import { DimensionsModule } from './dimensions/dimensions.module';
 import { FacultyModule } from './faculty/faculty.module';
+import { CurriculumModule } from './curriculum/curriculum.module';
 import { LoggerModule } from 'nestjs-pino';
 import { ClsModule } from 'nestjs-cls';
 import { v4 } from 'uuid';
@@ -32,6 +33,7 @@ export const ApplicationModules = [
   AnalysisModule,
   DimensionsModule,
   FacultyModule,
+  CurriculumModule,
 ];
 
 export const InfrastructureModules = [


### PR DESCRIPTION
Add CurriculumModule with three endpoints for querying the institutional hierarchy (departments, programs, courses) scoped to the caller's role via ScopeResolverService. Deans see only their assigned departments; super admins see everything. Includes cascading filter validation, search with ILIKE wildcard escaping, and inactive course visibility.