### PR TITLE
FAC-63 feat: expose semester in enrollment response

### DIFF
--- a/src/modules/enrollments/dto/responses/enrollment.response.dto.ts
+++ b/src/modules/enrollments/dto/responses/enrollment.response.dto.ts
@@ -1,6 +1,7 @@
 import { IsNumber, IsOptional, IsString } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { FacultyShortResponseDto } from './faculty-short.response.dto';
+import { SemesterShortResponseDto } from './semester-short.response.dto';
 
 export class CourseShortResponseDto {
   @ApiProperty()
@@ -39,4 +40,7 @@ export class EnrollmentResponseDto {
 
   @ApiPropertyOptional({ type: FacultyShortResponseDto, nullable: true })
   faculty: FacultyShortResponseDto | null;
+
+  @ApiPropertyOptional({ type: SemesterShortResponseDto, nullable: true })
+  semester: SemesterShortResponseDto | null;
 }

--- a/src/modules/enrollments/dto/responses/semester-short.response.dto.ts
+++ b/src/modules/enrollments/dto/responses/semester-short.response.dto.ts
@@ -1,0 +1,22 @@
+import { IsOptional, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class SemesterShortResponseDto {
+  @ApiProperty()
+  @IsString()
+  id: string;
+
+  @ApiProperty()
+  @IsString()
+  code: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  label?: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  academicYear?: string;
+}

--- a/src/modules/enrollments/enrollments.service.spec.ts
+++ b/src/modules/enrollments/enrollments.service.spec.ts
@@ -65,6 +65,16 @@ describe('EnrollmentsService', () => {
           shortname: 'CS101',
           fullname: 'Intro to CS',
           courseImage: 'https://example.com/course.jpg',
+          program: {
+            department: {
+              semester: {
+                id: 'sem-1',
+                code: 'S12526',
+                label: '1st Semester',
+                academicYear: '2025-2026',
+              },
+            },
+          },
         },
       },
     ];
@@ -94,6 +104,12 @@ describe('EnrollmentsService', () => {
       employeeNumber: 'EMP001',
       profilePicture: 'https://example.com/pic.jpg',
     });
+    expect(result.data[0].semester).toEqual({
+      id: 'sem-1',
+      code: 'S12526',
+      label: '1st Semester',
+      academicYear: '2025-2026',
+    });
     expect(result.meta.totalItems).toBe(1);
     expect(result.meta.totalPages).toBe(1);
     // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -118,6 +134,16 @@ describe('EnrollmentsService', () => {
           shortname: 'CS101',
           fullname: 'Intro to CS',
           courseImage: null,
+          program: {
+            department: {
+              semester: {
+                id: 'sem-1',
+                code: 'S12526',
+                label: '1st Semester',
+                academicYear: '2025-2026',
+              },
+            },
+          },
         },
       },
     ];
@@ -128,6 +154,30 @@ describe('EnrollmentsService', () => {
     const result = await service.getMyEnrollments(1, 10);
 
     expect(result.data[0].faculty).toBeNull();
+  });
+
+  it('should return null semester when hierarchy is incomplete', async () => {
+    const mockEnrollments = [
+      {
+        id: 'e1',
+        role: 'student',
+        course: {
+          id: 'c1',
+          moodleCourseId: 101,
+          shortname: 'CS101',
+          fullname: 'Intro to CS',
+          courseImage: null,
+          program: undefined,
+        },
+      },
+    ];
+
+    (em.findAndCount as jest.Mock).mockResolvedValue([mockEnrollments, 1]);
+    (em.find as jest.Mock).mockResolvedValue([]);
+
+    const result = await service.getMyEnrollments(1, 10);
+
+    expect(result.data[0].semester).toBeNull();
   });
 
   it('should not query faculty when no enrollments exist', async () => {

--- a/src/modules/enrollments/enrollments.service.ts
+++ b/src/modules/enrollments/enrollments.service.ts
@@ -37,7 +37,7 @@ export class EnrollmentsService {
       Enrollment,
       { user: userId, isActive: true },
       {
-        populate: ['course'],
+        populate: ['course.program.department.semester'],
         limit,
         offset: (page - 1) * limit,
         orderBy: { timeModified: 'DESC' },
@@ -48,18 +48,29 @@ export class EnrollmentsService {
     const facultyMap = await this.getFacultyByCourseIds(courseIds);
 
     return {
-      data: enrollments.map((e) => ({
-        id: e.id,
-        role: e.role,
-        course: {
-          id: e.course.id,
-          moodleCourseId: e.course.moodleCourseId,
-          shortname: e.course.shortname,
-          fullname: e.course.fullname,
-          courseImage: e.course.courseImage ?? undefined,
-        },
-        faculty: facultyMap.get(e.course.id) ?? null,
-      })),
+      data: enrollments.map((e) => {
+        const semester = e.course.program?.department?.semester;
+        return {
+          id: e.id,
+          role: e.role,
+          course: {
+            id: e.course.id,
+            moodleCourseId: e.course.moodleCourseId,
+            shortname: e.course.shortname,
+            fullname: e.course.fullname,
+            courseImage: e.course.courseImage ?? undefined,
+          },
+          faculty: facultyMap.get(e.course.id) ?? null,
+          semester: semester
+            ? {
+                id: semester.id,
+                code: semester.code,
+                label: semester.label,
+                academicYear: semester.academicYear,
+              }
+            : null,
+        };
+      }),
       meta: {
         totalItems,
         itemCount: enrollments.length,


### PR DESCRIPTION
Include semester data (id, code, label, academicYear) in the GET /enrollments/me response by populating the existing Course → Program → Department → Semester chain. This lets the frontend resolve semesterId without additional API calls.