### PR TITLE
FAC-66 fix: GetLatestActiveVersion returns unmapped entity missing questionnaire relation data

### DIFF
--- a/src/modules/questionnaires/questionnaire.controller.ts
+++ b/src/modules/questionnaires/questionnaire.controller.ts
@@ -115,8 +115,11 @@ export class QuestionnaireController {
     description: 'Active version found or null if none exists',
   })
   @ApiResponse({ status: 404, description: 'Questionnaire not found' })
-  async getLatestActiveVersion(@Param('id') id: string) {
-    return this.questionnaireService.GetLatestActiveVersion(id);
+  async getLatestActiveVersion(
+    @Param('id') id: string,
+  ): Promise<QuestionnaireVersionDetailResponse | null> {
+    const version = await this.questionnaireService.GetLatestActiveVersion(id);
+    return version ? QuestionnaireVersionDetailResponse.Map(version) : null;
   }
 
   @Patch('versions/:versionId/publish')

--- a/src/modules/questionnaires/services/questionnaire.service.ts
+++ b/src/modules/questionnaires/services/questionnaire.service.ts
@@ -352,10 +352,10 @@ export class QuestionnaireService {
       );
     }
 
-    const activeVersion = await this.versionRepo.findOne({
-      questionnaire,
-      isActive: true,
-    });
+    const activeVersion = await this.versionRepo.findOne(
+      { questionnaire, isActive: true },
+      { populate: ['questionnaire'] },
+    );
 
     return activeVersion;
   }


### PR DESCRIPTION
## Summary

- Populated the `questionnaire` relation in `GetLatestActiveVersion` service query
- Mapped the response through `QuestionnaireVersionDetailResponse.Map()` in the controller, consistent with all other version endpoints
- Ensures `questionnaireId`, `questionnaireTitle`, and `questionnaireType` are present in the response

Closes #140

## Test plan

- [x] All 160 questionnaire tests pass
- [x] Build succeeds
- [ ] Verify `GET /api/v1/questionnaires/:id/latest-active-version` returns the full DTO shape with questionnaire fields