### PR TITLE
FAC-67 fix: handle null course.program chain for Moodle-synced courses

### DIFF
--- a/src/modules/questionnaires/services/questionnaire.service.ts
+++ b/src/modules/questionnaires/services/questionnaire.service.ts
@@ -427,7 +427,7 @@ export class QuestionnaireService {
 
       // F1: Safe hierarchy traversal
       const courseSemesterId = course.program?.department?.semester?.id;
-      if (!courseSemesterId || courseSemesterId !== data.semesterId) {
+      if (courseSemesterId && courseSemesterId !== data.semesterId) {
         throw new BadRequestException(
           `Course ${course.shortname} does not belong to the provided semester context.`,
         );
@@ -524,8 +524,8 @@ export class QuestionnaireService {
     let campus: Campus | null = null;
 
     if (course) {
-      program = course.program;
-      department = program?.department || null; // Safe navigation
+      program = course.program ?? faculty.program ?? null;
+      department = program?.department ?? faculty.department ?? null;
     } else {
       department = faculty.department || null;
       program = faculty.program || null;
@@ -744,7 +744,7 @@ export class QuestionnaireService {
 
       // Validate course belongs to semester
       const courseSemesterId = course.program?.department?.semester?.id;
-      if (!courseSemesterId || courseSemesterId !== data.semesterId) {
+      if (courseSemesterId && courseSemesterId !== data.semesterId) {
         throw new BadRequestException(
           `Course does not belong to the provided semester context.`,
         );


### PR DESCRIPTION
## Summary
- Skip semester validation when course lacks institutional hierarchy (`program → department → semester`) since enrollment already proves the course-semester relationship
- Fall back to faculty's `program`/`department` for institutional context resolution when the course hierarchy is null
- Fixes 500 on draft save and "Department or Program context not found" on submission for Moodle-synced courses

Closes #141

## Test plan
- [x] All 57 existing questionnaire service tests pass
- [x] Existing semester-mismatch test still correctly throws when hierarchy exists but doesn't match
- [ ] Manual: sign in as student, evaluate a Moodle-synced course — draft save and submission should succeed