### PR TITLE
FAC-68 fix: replace em.upsert with manual find/create in SaveOrUpdateDraft (#144)

### DIFF
--- a/src/modules/questionnaires/services/questionnaire.service.spec.ts
+++ b/src/modules/questionnaires/services/questionnaire.service.spec.ts
@@ -655,20 +655,49 @@ describe('QuestionnaireService', () => {
         course: mockCourse,
       };
 
-      (em.upsert as jest.Mock).mockResolvedValue(mockDraft);
+      draftRepo.findOne.mockResolvedValue(null);
+      draftRepo.create.mockReturnValue(mockDraft as any);
 
       const result = await service.SaveOrUpdateDraft(mockDraftData);
 
       expect(result).toEqual(mockDraft);
-      expect(em.upsert).toHaveBeenCalledWith(QuestionnaireDraft, {
+      expect(draftRepo.findOne).toHaveBeenCalledWith({
         respondent: mockRespondent,
         questionnaireVersion: mockVersion,
         faculty: mockFaculty,
         semester: mockSemester,
         course: mockCourse,
-        answers: mockDraftData.answers,
-        qualitativeComment: mockDraftData.qualitativeComment,
       });
+      expect(draftRepo.create).toHaveBeenCalled();
+      expect(em.flush).toHaveBeenCalled();
+    });
+
+    it('should update an existing draft', async () => {
+      versionRepo.findOne.mockResolvedValue(mockVersion as any);
+      /* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
+      em.findOne
+        .mockResolvedValueOnce(mockRespondent as any)
+        .mockResolvedValueOnce(mockFaculty as any)
+        .mockResolvedValueOnce(mockSemester as any)
+        .mockResolvedValueOnce(mockCourse as any);
+      /* eslint-enable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
+
+      const existingDraft = {
+        id: 'd1',
+        answers: { q1: 1 },
+        qualitativeComment: 'Old comment',
+      };
+
+      draftRepo.findOne.mockResolvedValue(existingDraft as any);
+
+      await service.SaveOrUpdateDraft(mockDraftData);
+
+      expect(existingDraft.answers).toEqual(mockDraftData.answers);
+      expect(existingDraft.qualitativeComment).toBe(
+        mockDraftData.qualitativeComment,
+      );
+      expect(draftRepo.create).not.toHaveBeenCalled();
+      expect(em.flush).toHaveBeenCalled();
     });
 
     it('should throw NotFoundException if version not found', async () => {
@@ -733,11 +762,18 @@ describe('QuestionnaireService', () => {
         course: null,
       };
 
-      (em.upsert as jest.Mock).mockResolvedValue(mockDraft);
+      draftRepo.findOne.mockResolvedValue(null);
+      draftRepo.create.mockReturnValue(mockDraft as any);
 
       const result = await service.SaveOrUpdateDraft(dataWithoutCourse);
 
       expect(result.course).toBeNull();
+      expect(draftRepo.findOne).toHaveBeenCalledWith({
+        respondent: mockRespondent,
+        questionnaireVersion: mockVersion,
+        faculty: mockFaculty,
+        semester: mockSemester,
+      });
     });
   });
 

--- a/src/modules/questionnaires/services/questionnaire.service.ts
+++ b/src/modules/questionnaires/services/questionnaire.service.ts
@@ -751,9 +751,22 @@ export class QuestionnaireService {
       }
     }
 
-    // Upsert draft using unique constraint
-    try {
-      const draft = await this.em.upsert(QuestionnaireDraft, {
+    // Find existing draft or create a new one
+    // Manual find/create pattern used instead of em.upsert because MikroORM's
+    // upsert does not support partial unique indexes (WHERE clause conditions).
+    let draft = await this.draftRepo.findOne({
+      respondent,
+      questionnaireVersion: version,
+      faculty,
+      semester,
+      ...(course ? { course } : {}),
+    });
+
+    if (draft) {
+      draft.answers = data.answers;
+      draft.qualitativeComment = data.qualitativeComment;
+    } else {
+      draft = this.draftRepo.create({
         respondent,
         questionnaireVersion: version,
         faculty,
@@ -762,17 +775,10 @@ export class QuestionnaireService {
         answers: data.answers,
         qualitativeComment: data.qualitativeComment,
       });
-
-      return draft;
-    } catch (error) {
-      // Handle unique constraint violations gracefully
-      if (error instanceof UniqueConstraintViolationException) {
-        throw new ConflictException(
-          'A draft already exists for this context. Please try again.',
-        );
-      }
-      throw error;
     }
+
+    await this.em.flush();
+    return draft;
   }
 
   async CheckSubmission(query: {


### PR DESCRIPTION
## Summary

- Replace `em.upsert(QuestionnaireDraft, ...)` with a manual `findOne` → create/update → `flush` pattern in `SaveOrUpdateDraft`
- MikroORM's `em.upsert` does not support partial unique indexes (`WHERE deleted_at IS NULL`), causing 500 errors on every draft save attempt
- Add test for the update-existing-draft path; update existing tests to match the new implementation

Closes #144

## Test plan

- [x] All 58 questionnaire service tests pass (`npx jest --testPathPatterns=questionnaire.service.spec`)
- [x] Lint passes (`npm run lint`)
- [ ] Manual: save a new draft via the frontend → verify 200 response
- [ ] Manual: save again for the same context → verify draft is updated, not duplicated