### PR TITLE
FAC-73 feat: environment-aware sync scheduling with observability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,10 +72,15 @@ The app uses a split between **Infrastructure** and **Application** modules (`sr
 - Extend `BaseJob` class which provides startup execution and graceful shutdown
 - Jobs register results in `StartupJobRegistry` for boot summary
 - **Active jobs:**
-  - `CategorySyncJob`: Syncs Moodle categories to local hierarchy
-  - `CourseSyncJob`: Syncs Moodle courses
-  - `EnrollmentSyncJob`: Syncs user-course enrollments
   - `RefreshTokenCleanupJob`: Purges expired refresh tokens every 12 hours (7-day retention)
+
+**Moodle Sync Scheduling** (`src/modules/moodle/schedulers/`):
+
+- Dynamic cron via `SchedulerRegistry` (no static `@Cron()` decorator)
+- Interval resolves: DB (`SystemConfig`) > env var (`MOODLE_SYNC_INTERVAL_MINUTES`) > per-env default
+- Admin-configurable at runtime via `PUT /moodle/sync/schedule` (min 30 minutes)
+- `SyncLog` entity tracks every sync with per-phase metrics (fetched, inserted, updated, deactivated)
+- `SyncLog` does NOT extend `CustomBaseEntity` — queries must use `filters: { softDelete: false }`
 
 ### Analysis Job Queue
 
@@ -164,3 +169,4 @@ Optional:
 - `BULLMQ_HTTP_TIMEOUT_MS`: HTTP request timeout in ms (default: `90000`)
 - `BULLMQ_SENTIMENT_CONCURRENCY`: Sentiment processor concurrency (default: `3`)
 - `SENTIMENT_WORKER_URL`: RunPod/mock worker URL for sentiment analysis
+- `MOODLE_SYNC_INTERVAL_MINUTES`: Sync schedule interval in minutes (min `30`; defaults per env: dev=60, staging=360, prod=180)

--- a/docs/architecture/core-components.md
+++ b/docs/architecture/core-components.md
@@ -139,12 +139,12 @@ Priority ranges: `0-99` core auth, `100-199` external providers, `200+` fallback
 
 Institutional sync (categories, courses, enrollments) uses a BullMQ-based composite job instead of individual cron jobs. See [Institutional Sync Workflow](../workflows/institutional-sync.md) for the full flow.
 
-| Component              | Purpose                                                                             |
-| ---------------------- | ----------------------------------------------------------------------------------- |
-| `MoodleStartupService` | Blocking startup orchestrator — categories always, courses/enrollments gated by env |
-| `MoodleSyncProcessor`  | BullMQ processor — runs categories → courses → enrollments in sequence              |
-| `MoodleSyncScheduler`  | Hourly `@Cron` that enqueues a composite sync job (fixed `jobId` for deduplication) |
-| `MoodleSyncController` | `POST /moodle/sync` (manual trigger), `GET /moodle/sync/status` (queue state)       |
+| Component              | Purpose                                                                                                      |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `MoodleStartupService` | Blocking startup orchestrator — categories always, courses/enrollments gated by env                          |
+| `MoodleSyncProcessor`  | BullMQ processor — runs categories → courses → enrollments; creates/updates `SyncLog` with per-phase metrics |
+| `MoodleSyncScheduler`  | Dynamic `SchedulerRegistry`-based cron (env-aware, admin-configurable via `SystemConfig`)                    |
+| `MoodleSyncController` | Sync trigger, status, paginated history, schedule get/update — all SUPER_ADMIN only                          |
 
 Phase dependency: if categories fail, courses and enrollments are skipped. If courses fail, enrollments are skipped.
 

--- a/docs/decisions/decisions.md
+++ b/docs/decisions/decisions.md
@@ -227,6 +227,16 @@ The `UserInstitutionalRole` entity gains a `source` field (`auto` | `manual`) to
 - **Cleanup:** When a manual DEAN exists at a department, any CHAIRPERSON roles at child programs are automatically removed during hydration to prevent redundant roles.
 - **Trade-off:** Deans require a one-time manual promotion by an admin. This is accepted because Deans are fewer in number and the Moodle API provides no reliable way to auto-detect the distinction.
 
+## 33. Dynamic Sync Scheduling with SyncLog Observability
+
+The `MoodleSyncScheduler` was rewritten from a static `@Cron(CronExpression.EVERY_HOUR)` decorator to a dynamic `SchedulerRegistry`-based approach, paired with a `SyncLog` audit entity.
+
+- **Dynamic scheduling:** The scheduler implements `OnModuleInit` and registers a `CronJob` via `SchedulerRegistry` at startup. The interval resolves from DB (`SystemConfig`) > env var (`MOODLE_SYNC_INTERVAL_MINUTES`) > per-environment default (dev: 60 min, staging: 360 min, production: 180 min). Super admins can update the interval at runtime via `PUT /moodle/sync/schedule`, which persists to `SystemConfig` and replaces the running cron job.
+- **Minimum interval:** 30 minutes, enforced at the DTO validation layer (`@Min(30)`), the Zod env schema (`.min(30)`), and the DB resolution path (values below 30 are ignored).
+- **SyncLog entity:** Does not extend `CustomBaseEntity` (no `deletedAt` — audit records are never soft-deleted). Stores per-phase `SyncPhaseResult` as JSONB (fetched, inserted, updated, deactivated, errors, durationMs). Insert vs update counts use a count-before/after strategy — one extra `COUNT` query per phase, no per-record overhead.
+- **Soft-delete filter bypass:** Since `SyncLog` has no `deletedAt` column, MikroORM's global `softDelete` filter would fail at query time. Queries must use `filters: { softDelete: false }`. The `@Filter` decorator approach (`cond: {}, default: false`) was found to be insufficient at runtime.
+- **Trade-off:** Admin schedule changes don't survive process restarts unless persisted to the database (which they are, via `SystemConfig`). The scheduler reads from DB on init, so restarts pick up the latest admin-configured interval.
+
 ## 30. Semester Code Parsing for Display Labels
 
 The Moodle category sync now parses semester codes (e.g., `S22526`) into human-readable `label` ("Semester 2") and `academicYear` ("2025-2026") fields on the `Semester` entity.

--- a/docs/workflows/institutional-sync.md
+++ b/docs/workflows/institutional-sync.md
@@ -4,11 +4,21 @@ The system synchronizes institutional data (categories, courses, enrollments) fr
 
 ## Trigger Points
 
-| Trigger         | Mechanism                          | Behavior                                                                 |
-| --------------- | ---------------------------------- | ------------------------------------------------------------------------ |
-| **Startup**     | `MoodleStartupService` (blocking)  | Categories always sync; courses + enrollments gated by `SYNC_ON_STARTUP` |
-| **Hourly cron** | `MoodleSyncScheduler` → BullMQ job | Full sync (categories → courses → enrollments)                           |
-| **Manual**      | `POST /moodle/sync` (superadmin)   | Same as cron; returns `{ jobId }` or 409 if already running              |
+| Trigger            | Mechanism                          | Behavior                                                                 |
+| ------------------ | ---------------------------------- | ------------------------------------------------------------------------ |
+| **Startup**        | `MoodleStartupService` (blocking)  | Categories always sync; courses + enrollments gated by `SYNC_ON_STARTUP` |
+| **Scheduled cron** | `MoodleSyncScheduler` → BullMQ job | Full sync (categories → courses → enrollments)                           |
+| **Manual**         | `POST /moodle/sync` (superadmin)   | Same as cron; returns `{ jobId }` or 409 if already running              |
+
+### Schedule Resolution
+
+The scheduler uses dynamic cron via `SchedulerRegistry` (no static `@Cron()` decorator). The interval is resolved at startup in priority order:
+
+1. **Database** — `SystemConfig` key `MOODLE_SYNC_INTERVAL_MINUTES` (admin override via `PUT /moodle/sync/schedule`)
+2. **Environment variable** — `MOODLE_SYNC_INTERVAL_MINUTES`
+3. **Per-environment default** — dev/test: 60 min, staging: 360 min, production: 180 min
+
+Minimum interval is **30 minutes** (enforced at all three layers). The interval is converted to a cron expression internally via `minutesToCron()`.
 
 ## Pipeline Flow
 
@@ -48,12 +58,37 @@ Uses a 3-phase architecture to avoid deadlocks from overlapping user rows:
 
 No additional Moodle API calls are needed for sections — group data is already returned by the enrolled users endpoint.
 
+## Observability — SyncLog
+
+Every sync execution (scheduled, manual, startup) creates a `SyncLog` record in the database. The processor creates it at job start (`status: running`) and updates it after each phase and on completion.
+
+Each phase stores a `SyncPhaseResult` (JSONB) with:
+
+| Field         | Description                                       |
+| ------------- | ------------------------------------------------- |
+| `status`      | `success`, `failed`, or `skipped`                 |
+| `durationMs`  | Wall-clock time for the phase                     |
+| `fetched`     | Remote records received from Moodle               |
+| `inserted`    | New records created (count-before/after strategy) |
+| `updated`     | Existing records updated via upsert               |
+| `deactivated` | Records soft-deactivated (missing from remote)    |
+| `errors`      | Per-item error count within the phase             |
+
+Overall sync status: `completed` (all phases succeeded), `partial` (some failed/skipped), or `failed` (all failed).
+
+Manual syncs record `triggeredBy` (FK to User) via CLS (`CurrentUserService`).
+
+The `SyncLog` entity does **not** extend `CustomBaseEntity` — audit records are never soft-deleted. Queries must use `filters: { softDelete: false }` to bypass the global MikroORM filter.
+
 ## Endpoints
 
-| Method | Path                  | Auth        | Description                                |
-| ------ | --------------------- | ----------- | ------------------------------------------ |
-| POST   | `/moodle/sync`        | SUPER_ADMIN | Trigger sync (409 if already running)      |
-| GET    | `/moodle/sync/status` | SUPER_ADMIN | Queue state: `idle`, `active`, or `queued` |
+| Method | Path                    | Auth        | Description                                               |
+| ------ | ----------------------- | ----------- | --------------------------------------------------------- |
+| POST   | `/moodle/sync`          | SUPER_ADMIN | Trigger sync (409 if already running)                     |
+| GET    | `/moodle/sync/status`   | SUPER_ADMIN | Queue state: `idle`, `active`, or `queued`                |
+| GET    | `/moodle/sync/history`  | SUPER_ADMIN | Paginated sync log history with per-phase metrics         |
+| GET    | `/moodle/sync/schedule` | SUPER_ADMIN | Current interval (minutes), resolved cron, next execution |
+| PUT    | `/moodle/sync/schedule` | SUPER_ADMIN | Update interval in minutes (min 30), persists to DB       |
 
 ## Deduplication
 
@@ -63,8 +98,9 @@ No additional Moodle API calls are needed for sections — group data is already
 
 ## Environment Variables
 
-| Variable                           | Default | Purpose                                 |
-| ---------------------------------- | ------- | --------------------------------------- |
-| `SYNC_ON_STARTUP`                  | `false` | Enable course + enrollment sync at boot |
-| `DISABLE_SYNC_CATEGORY_ON_STARTUP` | `false` | Skip category sync at boot (dev only)   |
-| `MOODLE_SYNC_CONCURRENCY`          | `3`     | Max concurrent Moodle HTTP calls (1-20) |
+| Variable                           | Default | Purpose                                                        |
+| ---------------------------------- | ------- | -------------------------------------------------------------- |
+| `SYNC_ON_STARTUP`                  | `false` | Enable course + enrollment sync at boot                        |
+| `DISABLE_SYNC_CATEGORY_ON_STARTUP` | `false` | Skip category sync at boot (dev only)                          |
+| `MOODLE_SYNC_CONCURRENCY`          | `3`     | Max concurrent Moodle HTTP calls (1-20)                        |
+| `MOODLE_SYNC_INTERVAL_MINUTES`     | —       | Override sync interval (min 30); per-env default used if unset |

--- a/src/configurations/env/moodle.env.ts
+++ b/src/configurations/env/moodle.env.ts
@@ -4,6 +4,7 @@ export const moodleEnvSchema = z.object({
   MOODLE_BASE_URL: z.url(),
   MOODLE_MASTER_KEY: z.string(),
   MOODLE_SYNC_CONCURRENCY: z.coerce.number().min(1).max(20).default(3),
+  MOODLE_SYNC_INTERVAL_MINUTES: z.coerce.number().min(30).optional(),
 });
 
 export type MoodleEnv = z.infer<typeof moodleEnvSchema>;

--- a/src/entities/index.entity.ts
+++ b/src/entities/index.entity.ts
@@ -28,6 +28,7 @@ import { Topic } from './topic.entity';
 import { TopicAssignment } from './topic-assignment.entity';
 import { Section } from './section.entity';
 import { TopicModelRun } from './topic-model-run.entity';
+import { SyncLog } from './sync-log.entity';
 
 export {
   ChatKitThread,
@@ -60,6 +61,7 @@ export {
   Topic,
   TopicAssignment,
   TopicModelRun,
+  SyncLog,
 };
 
 export const entities = [
@@ -93,4 +95,5 @@ export const entities = [
   Topic,
   TopicAssignment,
   TopicModelRun,
+  SyncLog,
 ];

--- a/src/entities/sync-log.entity.ts
+++ b/src/entities/sync-log.entity.ts
@@ -1,0 +1,60 @@
+import {
+  Entity,
+  Index,
+  ManyToOne,
+  Opt,
+  PrimaryKey,
+  Property,
+} from '@mikro-orm/core';
+import { v4 } from 'uuid';
+import { User } from './user.entity';
+import type {
+  SyncPhaseResult,
+  SyncStatus,
+  SyncTrigger,
+} from '../modules/moodle/lib/sync-result.types';
+
+// No deletedAt — audit records are never soft-deleted.
+// Queries must use `filters: { softDelete: false }` to bypass the global filter.
+@Entity()
+export class SyncLog {
+  @PrimaryKey()
+  id: string & Opt = v4();
+
+  @Property()
+  trigger!: SyncTrigger;
+
+  @ManyToOne(() => User, { nullable: true })
+  triggeredBy?: User;
+
+  @Property()
+  status: SyncStatus & Opt = 'running';
+
+  @Index()
+  @Property()
+  startedAt: Date & Opt = new Date();
+
+  @Property({ nullable: true })
+  completedAt?: Date;
+
+  @Property({ nullable: true })
+  durationMs?: number;
+
+  @Property({ type: 'jsonb', nullable: true })
+  categories?: SyncPhaseResult;
+
+  @Property({ type: 'jsonb', nullable: true })
+  courses?: SyncPhaseResult;
+
+  @Property({ type: 'jsonb', nullable: true })
+  enrollments?: SyncPhaseResult;
+
+  @Property({ type: 'text', nullable: true })
+  errorMessage?: string;
+
+  @Property({ nullable: true })
+  jobId?: string;
+
+  @Property({ nullable: true })
+  cronExpression?: string;
+}

--- a/src/migrations/.snapshot-faculytics_db.json
+++ b/src/migrations/.snapshot-faculytics_db.json
@@ -1939,6 +1939,177 @@
           "length": 255,
           "mappedType": "string"
         },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 255,
+          "mappedType": "string"
+        },
+        "triggered_by_id": {
+          "name": "triggered_by_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "length": 255,
+          "mappedType": "string"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 255,
+          "default": "'running'",
+          "mappedType": "string"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 6,
+          "mappedType": "datetime"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "length": 6,
+          "mappedType": "datetime"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "int",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "integer"
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
+        },
+        "courses": {
+          "name": "courses",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
+        },
+        "enrollments": {
+          "name": "enrollments",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "text"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "length": 255,
+          "mappedType": "string"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "length": 255,
+          "mappedType": "string"
+        }
+      },
+      "name": "sync_log",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "started_at"
+          ],
+          "composite": false,
+          "keyName": "sync_log_started_at_index",
+          "constraint": false,
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "sync_log_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "sync_log_triggered_by_id_foreign": {
+          "constraintName": "sync_log_triggered_by_id_foreign",
+          "columnNames": [
+            "triggered_by_id"
+          ],
+          "localTableName": "public.sync_log",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.user",
+          "deleteRule": "set null",
+          "updateRule": "cascade"
+        }
+      },
+      "nativeEnums": {}
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 255,
+          "mappedType": "string"
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamptz",
@@ -2008,7 +2179,8 @@
           "nullable": false,
           "enumItems": [
             "STUDENT",
-            "DEAN"
+            "DEAN",
+            "CHAIRPERSON"
           ],
           "mappedType": "enum"
         },
@@ -5039,6 +5211,17 @@
           "primary": false,
           "nullable": false,
           "length": 255,
+          "mappedType": "string"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 255,
+          "default": "'auto'",
           "mappedType": "string"
         }
       },

--- a/src/migrations/Migration20260325121432.ts
+++ b/src/migrations/Migration20260325121432.ts
@@ -1,0 +1,16 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260325121432 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table "sync_log" ("id" varchar(255) not null, "trigger" varchar(255) not null, "triggered_by_id" varchar(255) null, "status" varchar(255) not null default 'running', "started_at" timestamptz not null, "completed_at" timestamptz null, "duration_ms" int null, "categories" jsonb null, "courses" jsonb null, "enrollments" jsonb null, "error_message" text null, "job_id" varchar(255) null, "cron_expression" varchar(255) null, constraint "sync_log_pkey" primary key ("id"));`);
+    this.addSql(`create index "sync_log_started_at_index" on "sync_log" ("started_at");`);
+
+    this.addSql(`alter table "sync_log" add constraint "sync_log_triggered_by_id_foreign" foreign key ("triggered_by_id") references "user" ("id") on update cascade on delete set null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "sync_log" cascade;`);
+  }
+
+}

--- a/src/modules/moodle/controllers/moodle-sync.controller.spec.ts
+++ b/src/modules/moodle/controllers/moodle-sync.controller.spec.ts
@@ -1,0 +1,267 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { getQueueToken } from '@nestjs/bullmq';
+import { EntityManager } from '@mikro-orm/core';
+import { QueueName } from 'src/configurations/common/queue-names';
+import { RolesGuard } from 'src/security/guards/roles.guard';
+import { CurrentUserService } from 'src/modules/common/cls/current-user.service';
+import { CurrentUserInterceptor } from 'src/modules/common/interceptors/current-user.interceptor';
+import { validate } from 'class-validator';
+import { MoodleSyncController } from './moodle-sync.controller';
+import { MoodleSyncScheduler } from '../schedulers/moodle-sync.scheduler';
+import { SyncState } from '../dto/responses/sync-status.response.dto';
+import { UpdateSyncScheduleDto } from '../dto/requests/update-sync-schedule.request.dto';
+import { MOODLE_SYNC_MIN_INTERVAL_MINUTES } from '../schedulers/moodle-sync.constants';
+
+describe('MoodleSyncController', () => {
+  let controller: MoodleSyncController;
+  let mockQueue: {
+    add: jest.Mock;
+    getActive: jest.Mock;
+    getActiveCount: jest.Mock;
+    getWaitingCount: jest.Mock;
+    getFailedCount: jest.Mock;
+  };
+  let mockScheduler: {
+    getSchedule: jest.Mock;
+    updateSchedule: jest.Mock;
+  };
+  let mockEm: {
+    fork: jest.Mock;
+    findAndCount: jest.Mock;
+  };
+  let mockCurrentUserService: {
+    getOrFail: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    mockQueue = {
+      add: jest.fn().mockResolvedValue({ id: 'job-1' }),
+      getActive: jest.fn().mockResolvedValue([]),
+      getActiveCount: jest.fn().mockResolvedValue(0),
+      getWaitingCount: jest.fn().mockResolvedValue(0),
+      getFailedCount: jest.fn().mockResolvedValue(0),
+    };
+    mockScheduler = {
+      getSchedule: jest.fn().mockReturnValue({
+        intervalMinutes: 60,
+        cronExpression: '0 * * * *',
+        nextExecution: '2026-03-25T21:00:00.000Z',
+      }),
+      updateSchedule: jest.fn().mockResolvedValue(undefined),
+    };
+    mockEm = {
+      findAndCount: jest.fn().mockResolvedValue([[], 0]),
+      fork: jest.fn(),
+    };
+    mockEm.fork.mockReturnValue(mockEm);
+    mockCurrentUserService = {
+      getOrFail: jest.fn().mockReturnValue({ id: 'user-1' }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MoodleSyncController],
+      providers: [
+        {
+          provide: getQueueToken(QueueName.MOODLE_SYNC),
+          useValue: mockQueue,
+        },
+        {
+          provide: MoodleSyncScheduler,
+          useValue: mockScheduler,
+        },
+        {
+          provide: EntityManager,
+          useValue: mockEm,
+        },
+        {
+          provide: CurrentUserService,
+          useValue: mockCurrentUserService,
+        },
+      ],
+    })
+      .overrideGuard(AuthGuard('jwt'))
+      .useValue({ canActivate: () => true })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .overrideInterceptor(CurrentUserInterceptor)
+      .useValue({
+        intercept: (_ctx: unknown, next: { handle: () => unknown }) =>
+          next.handle(),
+      })
+      .compile();
+
+    controller = module.get(MoodleSyncController);
+  });
+
+  describe('GetSyncStatus', () => {
+    it('should return IDLE when no jobs are active or queued', async () => {
+      const result = await controller.GetSyncStatus();
+
+      expect(result.state).toBe(SyncState.IDLE);
+      expect(result.waitingCount).toBe(0);
+    });
+
+    it('should return ACTIVE when a job is processing', async () => {
+      mockQueue.getActive.mockResolvedValue([
+        { id: 'job-1', data: { trigger: 'manual' }, processedOn: 1000 },
+      ]);
+
+      const result = await controller.GetSyncStatus();
+
+      expect(result.state).toBe(SyncState.ACTIVE);
+      expect(result.jobId).toBe('job-1');
+      expect(result.trigger).toBe('manual');
+    });
+
+    it('should return QUEUED when jobs are waiting but none active', async () => {
+      mockQueue.getWaitingCount.mockResolvedValue(2);
+
+      const result = await controller.GetSyncStatus();
+
+      expect(result.state).toBe(SyncState.QUEUED);
+      expect(result.waitingCount).toBe(2);
+    });
+  });
+
+  describe('TriggerSync', () => {
+    it('should enqueue a manual sync job with triggeredById from CLS', async () => {
+      const result = await controller.TriggerSync();
+
+      expect(result.jobId).toBe('job-1');
+      expect(mockCurrentUserService.getOrFail).toHaveBeenCalled();
+      expect(mockQueue.add).toHaveBeenCalledWith(
+        QueueName.MOODLE_SYNC,
+        expect.objectContaining({
+          trigger: 'manual',
+          triggeredById: 'user-1',
+        }),
+        expect.objectContaining({
+          removeOnComplete: true,
+          removeOnFail: 50,
+        }),
+      );
+    });
+
+    it('should throw 409 when a sync is already in progress', async () => {
+      mockQueue.getActiveCount.mockResolvedValue(1);
+
+      await expect(controller.TriggerSync()).rejects.toThrow(
+        new HttpException(
+          { error: 'Sync already in progress or queued' },
+          HttpStatus.CONFLICT,
+        ),
+      );
+    });
+
+    it('should throw 503 when the queue is unavailable', async () => {
+      mockQueue.add.mockRejectedValue(new Error('Redis down'));
+
+      await expect(controller.TriggerSync()).rejects.toThrow(HttpException);
+    });
+  });
+
+  describe('GetSyncHistory', () => {
+    it('should return paginated sync logs', async () => {
+      const mockLog = {
+        id: 'log-1',
+        trigger: 'manual',
+        triggeredBy: { id: 'user-1' },
+        status: 'completed',
+        startedAt: new Date(),
+        completedAt: new Date(),
+        durationMs: 5000,
+        categories: {
+          status: 'success',
+          fetched: 10,
+          inserted: 2,
+          updated: 8,
+          deactivated: 0,
+          errors: 0,
+          durationMs: 100,
+        },
+        courses: null,
+        enrollments: null,
+      };
+      mockEm.findAndCount.mockResolvedValue([[mockLog], 1]);
+
+      const result = await controller.GetSyncHistory(1, 20);
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].id).toBe('log-1');
+      expect(result.data[0].triggeredById).toBe('user-1');
+      expect(result.meta.totalItems).toBe(1);
+      expect(result.meta.currentPage).toBe(1);
+    });
+
+    it('should pass softDelete: false filter to bypass global filter', async () => {
+      await controller.GetSyncHistory(1, 20);
+
+      expect(mockEm.findAndCount).toHaveBeenCalledWith(
+        expect.anything(),
+        {},
+        expect.objectContaining({
+          filters: { softDelete: false },
+        }),
+      );
+    });
+
+    it('should clamp limit to max 100', async () => {
+      await controller.GetSyncHistory(1, 200);
+
+      expect(mockEm.findAndCount).toHaveBeenCalledWith(
+        expect.anything(),
+        {},
+        expect.objectContaining({ limit: 100 }),
+      );
+    });
+  });
+
+  describe('GetSyncSchedule', () => {
+    it('should return current schedule from scheduler', () => {
+      const result = controller.GetSyncSchedule();
+
+      expect(result.intervalMinutes).toBe(60);
+      expect(result.cronExpression).toBe('0 * * * *');
+      expect(result.nextExecution).toBe('2026-03-25T21:00:00.000Z');
+    });
+  });
+
+  describe('UpdateSyncSchedule', () => {
+    it('should update the schedule and return new values', async () => {
+      mockScheduler.getSchedule.mockReturnValue({
+        intervalMinutes: 180,
+        cronExpression: '0 */3 * * *',
+        nextExecution: '2026-03-26T00:00:00.000Z',
+      });
+
+      const result = await controller.UpdateSyncSchedule({
+        intervalMinutes: 180,
+      });
+
+      expect(mockScheduler.updateSchedule).toHaveBeenCalledWith(180);
+      expect(result.intervalMinutes).toBe(180);
+      expect(result.cronExpression).toBe('0 */3 * * *');
+    });
+
+    it('should reject interval below minimum via DTO validation', async () => {
+      const dto = new UpdateSyncScheduleDto();
+      dto.intervalMinutes = 10;
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+
+    it('should accept interval at minimum via DTO validation', async () => {
+      const dto = new UpdateSyncScheduleDto();
+      dto.intervalMinutes = MOODLE_SYNC_MIN_INTERVAL_MINUTES;
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+    });
+  });
+});

--- a/src/modules/moodle/controllers/moodle-sync.controller.ts
+++ b/src/modules/moodle/controllers/moodle-sync.controller.ts
@@ -1,4 +1,5 @@
 import {
+  Body,
   Controller,
   Get,
   HttpCode,
@@ -6,23 +7,36 @@ import {
   HttpStatus,
   Logger,
   Post,
+  Put,
+  Query,
+  UseInterceptors,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOperation,
+  ApiQuery,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
+import { EntityManager } from '@mikro-orm/core';
 import { QueueName } from 'src/configurations/common/queue-names';
 import { UseJwtGuard } from 'src/security/decorators';
 import { UserRole } from 'src/modules/auth/roles.enum';
+import { CurrentUserService } from 'src/modules/common/cls/current-user.service';
+import { CurrentUserInterceptor } from 'src/modules/common/interceptors/current-user.interceptor';
+import { SyncLog } from 'src/entities/sync-log.entity';
 import { TriggerSyncResponseDto } from '../dto/responses/trigger-sync.response.dto';
 import {
   SyncState,
   SyncStatusResponseDto,
 } from '../dto/responses/sync-status.response.dto';
+import { SyncLogResponseDto } from '../dto/responses/sync-log.response.dto';
+import { SyncHistoryResponseDto } from '../dto/responses/sync-history.response.dto';
+import { SyncScheduleResponseDto } from '../dto/responses/sync-schedule.response.dto';
+import { UpdateSyncScheduleDto } from '../dto/requests/update-sync-schedule.request.dto';
+import { MoodleSyncScheduler } from '../schedulers/moodle-sync.scheduler';
 
 @ApiTags('Moodle')
 @Controller('moodle')
@@ -31,6 +45,9 @@ export class MoodleSyncController {
 
   constructor(
     @InjectQueue(QueueName.MOODLE_SYNC) private readonly syncQueue: Queue,
+    private readonly syncScheduler: MoodleSyncScheduler,
+    private readonly em: EntityManager,
+    private readonly currentUserService: CurrentUserService,
   ) {}
 
   @Get('sync/status')
@@ -88,6 +105,7 @@ export class MoodleSyncController {
     description: 'Sync already in progress or queued',
   })
   @ApiResponse({ status: 503, description: 'Sync queue unavailable' })
+  @UseInterceptors(CurrentUserInterceptor)
   async TriggerSync(): Promise<TriggerSyncResponseDto> {
     try {
       const [activeCount, waitingCount] = await Promise.all([
@@ -102,9 +120,11 @@ export class MoodleSyncController {
         );
       }
 
+      const user = this.currentUserService.getOrFail();
+
       const job = await this.syncQueue.add(
         QueueName.MOODLE_SYNC,
-        { trigger: 'manual' },
+        { trigger: 'manual', triggeredById: user.id },
         {
           jobId: `moodle-sync-manual-${Date.now()}`,
           removeOnComplete: true,
@@ -125,5 +145,66 @@ export class MoodleSyncController {
         HttpStatus.SERVICE_UNAVAILABLE,
       );
     }
+  }
+
+  @Get('sync/history')
+  @UseJwtGuard(UserRole.SUPER_ADMIN)
+  @ApiOperation({ summary: 'Get paginated Moodle sync history' })
+  @ApiBearerAuth()
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiResponse({ status: 200, type: SyncHistoryResponseDto })
+  async GetSyncHistory(
+    @Query('page') page = 1,
+    @Query('limit') limit = 20,
+  ): Promise<SyncHistoryResponseDto> {
+    const fork = this.em.fork();
+    const currentPage = Math.max(1, Number(page));
+    const itemsPerPage = Math.min(100, Math.max(1, Number(limit)));
+    const offset = (currentPage - 1) * itemsPerPage;
+
+    const [logs, totalItems] = await fork.findAndCount(
+      SyncLog,
+      {},
+      {
+        orderBy: { startedAt: 'desc' },
+        limit: itemsPerPage,
+        offset,
+        populate: ['triggeredBy'],
+        filters: { softDelete: false },
+      },
+    );
+
+    return {
+      data: logs.map((log) => SyncLogResponseDto.Map(log)),
+      meta: {
+        totalItems,
+        itemCount: logs.length,
+        itemsPerPage,
+        totalPages: Math.ceil(totalItems / itemsPerPage),
+        currentPage,
+      },
+    };
+  }
+
+  @Get('sync/schedule')
+  @UseJwtGuard(UserRole.SUPER_ADMIN)
+  @ApiOperation({ summary: 'Get current sync schedule' })
+  @ApiBearerAuth()
+  @ApiResponse({ status: 200, type: SyncScheduleResponseDto })
+  GetSyncSchedule(): SyncScheduleResponseDto {
+    return this.syncScheduler.getSchedule();
+  }
+
+  @Put('sync/schedule')
+  @UseJwtGuard(UserRole.SUPER_ADMIN)
+  @ApiOperation({ summary: 'Update sync schedule interval' })
+  @ApiBearerAuth()
+  @ApiResponse({ status: 200, type: SyncScheduleResponseDto })
+  async UpdateSyncSchedule(
+    @Body() dto: UpdateSyncScheduleDto,
+  ): Promise<SyncScheduleResponseDto> {
+    await this.syncScheduler.updateSchedule(dto.intervalMinutes);
+    return this.syncScheduler.getSchedule();
   }
 }

--- a/src/modules/moodle/dto/requests/update-sync-schedule.request.dto.ts
+++ b/src/modules/moodle/dto/requests/update-sync-schedule.request.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, Min } from 'class-validator';
+import { MOODLE_SYNC_MIN_INTERVAL_MINUTES } from '../../schedulers/moodle-sync.constants';
+
+export class UpdateSyncScheduleDto {
+  @ApiProperty({
+    description: `Sync interval in minutes (minimum ${MOODLE_SYNC_MIN_INTERVAL_MINUTES})`,
+    example: 60,
+    minimum: MOODLE_SYNC_MIN_INTERVAL_MINUTES,
+  })
+  @IsInt()
+  @Min(MOODLE_SYNC_MIN_INTERVAL_MINUTES)
+  intervalMinutes: number;
+}

--- a/src/modules/moodle/dto/responses/sync-history.response.dto.ts
+++ b/src/modules/moodle/dto/responses/sync-history.response.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PaginationMeta } from 'src/modules/common/dto/pagination.dto';
+import { SyncLogResponseDto } from './sync-log.response.dto';
+
+export class SyncHistoryResponseDto {
+  @ApiProperty({ type: [SyncLogResponseDto] })
+  data: SyncLogResponseDto[];
+
+  @ApiProperty({ type: PaginationMeta })
+  meta: PaginationMeta;
+}

--- a/src/modules/moodle/dto/responses/sync-log.response.dto.ts
+++ b/src/modules/moodle/dto/responses/sync-log.response.dto.ts
@@ -1,0 +1,88 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import type { SyncPhaseResult } from '../../lib/sync-result.types';
+import { SyncLog } from 'src/entities/sync-log.entity';
+
+class SyncPhaseResultDto implements SyncPhaseResult {
+  @ApiProperty()
+  status: 'success' | 'failed' | 'skipped';
+
+  @ApiProperty()
+  durationMs: number;
+
+  @ApiProperty()
+  fetched: number;
+
+  @ApiProperty()
+  inserted: number;
+
+  @ApiProperty()
+  updated: number;
+
+  @ApiProperty()
+  deactivated: number;
+
+  @ApiProperty()
+  errors: number;
+
+  @ApiPropertyOptional()
+  errorMessage?: string;
+}
+
+export class SyncLogResponseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  trigger: string;
+
+  @ApiPropertyOptional()
+  triggeredById?: string;
+
+  @ApiProperty()
+  status: string;
+
+  @ApiProperty()
+  startedAt: Date;
+
+  @ApiPropertyOptional()
+  completedAt?: Date;
+
+  @ApiPropertyOptional()
+  durationMs?: number;
+
+  @ApiPropertyOptional({ type: SyncPhaseResultDto })
+  categories?: SyncPhaseResult;
+
+  @ApiPropertyOptional({ type: SyncPhaseResultDto })
+  courses?: SyncPhaseResult;
+
+  @ApiPropertyOptional({ type: SyncPhaseResultDto })
+  enrollments?: SyncPhaseResult;
+
+  @ApiPropertyOptional()
+  errorMessage?: string;
+
+  @ApiPropertyOptional()
+  jobId?: string;
+
+  @ApiPropertyOptional()
+  cronExpression?: string;
+
+  static Map(entity: SyncLog): SyncLogResponseDto {
+    return {
+      id: entity.id,
+      trigger: entity.trigger,
+      triggeredById: entity.triggeredBy?.id,
+      status: entity.status,
+      startedAt: entity.startedAt,
+      completedAt: entity.completedAt,
+      durationMs: entity.durationMs,
+      categories: entity.categories,
+      courses: entity.courses,
+      enrollments: entity.enrollments,
+      errorMessage: entity.errorMessage,
+      jobId: entity.jobId,
+      cronExpression: entity.cronExpression,
+    };
+  }
+}

--- a/src/modules/moodle/dto/responses/sync-schedule.response.dto.ts
+++ b/src/modules/moodle/dto/responses/sync-schedule.response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class SyncScheduleResponseDto {
+  @ApiProperty()
+  intervalMinutes: number;
+
+  @ApiProperty()
+  cronExpression: string;
+
+  @ApiPropertyOptional()
+  nextExecution: string | null;
+}

--- a/src/modules/moodle/lib/sync-result.types.ts
+++ b/src/modules/moodle/lib/sync-result.types.ts
@@ -1,0 +1,19 @@
+export interface SyncPhaseResult {
+  status: 'success' | 'failed' | 'skipped';
+  durationMs: number;
+  fetched: number;
+  inserted: number;
+  updated: number;
+  deactivated: number;
+  errors: number;
+  errorMessage?: string;
+}
+
+export type SyncTrigger = 'scheduled' | 'manual' | 'startup';
+
+export type SyncStatus = 'running' | 'completed' | 'partial' | 'failed';
+
+export interface MoodleSyncJobData {
+  trigger: SyncTrigger;
+  triggeredById?: string;
+}

--- a/src/modules/moodle/moodle.module.ts
+++ b/src/modules/moodle/moodle.module.ts
@@ -15,12 +15,15 @@ import { EnrollmentSyncService } from './services/moodle-enrollment-sync.service
 import { Enrollment } from 'src/entities/enrollment.entity';
 import { Course } from 'src/entities/course.entity';
 import { Section } from 'src/entities/section.entity';
+import { SyncLog } from 'src/entities/sync-log.entity';
+import { SystemConfig } from 'src/entities/system-config.entity';
 import { MoodleCourseSyncService } from './services/moodle-course-sync.service';
 import { MoodleUserHydrationService } from './services/moodle-user-hydration.service';
 import { MoodleSyncProcessor } from './processors/moodle-sync.processor';
 import { MoodleSyncScheduler } from './schedulers/moodle-sync.scheduler';
 import { MoodleStartupService } from './services/moodle-startup.service';
 import { MoodleSyncController } from './controllers/moodle-sync.controller';
+import DataLoaderModule from '../common/data-loaders/index.module';
 
 @Module({
   imports: [
@@ -34,8 +37,11 @@ import { MoodleSyncController } from './controllers/moodle-sync.controller';
       Enrollment,
       Course,
       Section,
+      SyncLog,
+      SystemConfig,
     ]),
     CommonModule,
+    DataLoaderModule,
   ],
   controllers: [MoodleSyncController],
   providers: [

--- a/src/modules/moodle/processors/moodle-sync.processor.spec.ts
+++ b/src/modules/moodle/processors/moodle-sync.processor.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Test, TestingModule } from '@nestjs/testing';
 import { Job } from 'bullmq';
+import { EntityManager } from '@mikro-orm/core';
 import { MoodleSyncProcessor } from './moodle-sync.processor';
 import { MoodleCategorySyncService } from '../services/moodle-category-sync.service';
 import { MoodleCourseSyncService } from '../services/moodle-course-sync.service';
@@ -8,6 +9,34 @@ import { EnrollmentSyncService } from '../services/moodle-enrollment-sync.servic
 import { CacheService } from 'src/modules/common/cache/cache.service';
 import { CacheNamespace } from 'src/modules/common/cache/cache-namespaces';
 import { QueueName } from 'src/configurations/common/queue-names';
+import type {
+  MoodleSyncJobData,
+  SyncPhaseResult,
+} from '../lib/sync-result.types';
+
+const successPhase = (
+  overrides?: Partial<SyncPhaseResult>,
+): SyncPhaseResult => ({
+  status: 'success',
+  durationMs: 100,
+  fetched: 10,
+  inserted: 2,
+  updated: 8,
+  deactivated: 0,
+  errors: 0,
+  ...overrides,
+});
+
+const failedPhase = (errorMessage: string): SyncPhaseResult => ({
+  status: 'failed',
+  durationMs: 50,
+  fetched: 0,
+  inserted: 0,
+  updated: 0,
+  deactivated: 0,
+  errors: 1,
+  errorMessage,
+});
 
 describe('MoodleSyncProcessor', () => {
   let processor: MoodleSyncProcessor;
@@ -15,37 +44,63 @@ describe('MoodleSyncProcessor', () => {
   let courseSyncService: jest.Mocked<MoodleCourseSyncService>;
   let enrollmentSyncService: jest.Mocked<EnrollmentSyncService>;
   let cacheService: jest.Mocked<CacheService>;
+  let mockEm: {
+    fork: jest.Mock;
+    create: jest.Mock;
+    persistAndFlush: jest.Mock;
+    flush: jest.Mock;
+    getReference: jest.Mock;
+  };
 
   const mockJob = {
     id: 'test-job-1',
-    data: { trigger: 'manual' },
+    data: { trigger: 'manual' } as MoodleSyncJobData,
     queueName: QueueName.MOODLE_SYNC,
     attemptsMade: 1,
-  } as Job<{ trigger?: string }>;
+  } as Job<MoodleSyncJobData>;
 
   beforeEach(async () => {
+    mockEm = {
+      create: jest.fn().mockReturnValue({ id: 'sync-log-1' }),
+      persistAndFlush: jest.fn().mockResolvedValue(undefined),
+      flush: jest.fn().mockResolvedValue(undefined),
+      getReference: jest.fn().mockReturnValue({ id: 'user-1' }),
+      fork: jest.fn(),
+    };
+    mockEm.fork.mockReturnValue(mockEm);
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         MoodleSyncProcessor,
         {
           provide: MoodleCategorySyncService,
           useValue: {
-            SyncAndRebuildHierarchy: jest.fn().mockResolvedValue(undefined),
+            SyncAndRebuildHierarchy: jest
+              .fn()
+              .mockResolvedValue(successPhase()),
           },
         },
         {
           provide: MoodleCourseSyncService,
-          useValue: { SyncAllPrograms: jest.fn().mockResolvedValue(undefined) },
+          useValue: {
+            SyncAllPrograms: jest.fn().mockResolvedValue(successPhase()),
+          },
         },
         {
           provide: EnrollmentSyncService,
-          useValue: { SyncAllCourses: jest.fn().mockResolvedValue(undefined) },
+          useValue: {
+            SyncAllCourses: jest.fn().mockResolvedValue(successPhase()),
+          },
         },
         {
           provide: CacheService,
           useValue: {
             invalidateNamespace: jest.fn().mockResolvedValue(undefined),
           },
+        },
+        {
+          provide: EntityManager,
+          useValue: mockEm,
         },
       ],
     }).compile();
@@ -63,11 +118,7 @@ describe('MoodleSyncProcessor', () => {
     expect(categorySyncService.SyncAndRebuildHierarchy).toHaveBeenCalled();
     expect(courseSyncService.SyncAllPrograms).toHaveBeenCalled();
     expect(enrollmentSyncService.SyncAllCourses).toHaveBeenCalled();
-    expect(result).toEqual({
-      categories: true,
-      courses: true,
-      enrollments: true,
-    });
+    expect(result.status).toBe('completed');
   });
 
   it('should invalidate enrollment cache after successful enrollment sync', async () => {
@@ -79,47 +130,49 @@ describe('MoodleSyncProcessor', () => {
   });
 
   it('should abort courses and enrollments when category sync fails', async () => {
-    categorySyncService.SyncAndRebuildHierarchy.mockRejectedValue(
-      new Error('Moodle down'),
+    categorySyncService.SyncAndRebuildHierarchy.mockResolvedValue(
+      failedPhase('Moodle down'),
     );
 
     const result = await processor.process(mockJob);
 
     expect(courseSyncService.SyncAllPrograms).not.toHaveBeenCalled();
     expect(enrollmentSyncService.SyncAllCourses).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      categories: false,
-      courses: false,
-      enrollments: false,
-    });
+    expect(result.status).toBe('failed');
   });
 
   it('should abort enrollments when course sync fails', async () => {
-    courseSyncService.SyncAllPrograms.mockRejectedValue(new Error('timeout'));
+    courseSyncService.SyncAllPrograms.mockResolvedValue(failedPhase('timeout'));
 
     const result = await processor.process(mockJob);
 
     expect(categorySyncService.SyncAndRebuildHierarchy).toHaveBeenCalled();
     expect(enrollmentSyncService.SyncAllCourses).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      categories: true,
-      courses: false,
-      enrollments: false,
-    });
+    expect(result.status).toBe('partial');
   });
 
   it('should handle enrollment sync failure without crashing', async () => {
-    enrollmentSyncService.SyncAllCourses.mockRejectedValue(
-      new Error('deadlock'),
+    enrollmentSyncService.SyncAllCourses.mockResolvedValue(
+      failedPhase('deadlock'),
     );
 
     const result = await processor.process(mockJob);
 
-    expect(result).toEqual({
-      categories: true,
-      courses: true,
-      enrollments: false,
-    });
+    expect(result.status).toBe('partial');
     expect(cacheService.invalidateNamespace).not.toHaveBeenCalled();
+  });
+
+  it('should create a SyncLog entry on job start', async () => {
+    await processor.process(mockJob);
+
+    expect(mockEm.create).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        trigger: 'manual',
+        status: 'running',
+        jobId: 'test-job-1',
+      }),
+    );
+    expect(mockEm.persistAndFlush).toHaveBeenCalled();
   });
 });

--- a/src/modules/moodle/processors/moodle-sync.processor.ts
+++ b/src/modules/moodle/processors/moodle-sync.processor.ts
@@ -1,19 +1,21 @@
 import { Logger } from '@nestjs/common';
 import { Processor, WorkerHost, OnWorkerEvent } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
+import { EntityManager } from '@mikro-orm/core';
 import { env } from 'src/configurations/env';
 import { QueueName } from 'src/configurations/common/queue-names';
+import { SyncLog } from 'src/entities/sync-log.entity';
+import { User } from 'src/entities/user.entity';
 import { MoodleCategorySyncService } from '../services/moodle-category-sync.service';
 import { MoodleCourseSyncService } from '../services/moodle-course-sync.service';
 import { EnrollmentSyncService } from '../services/moodle-enrollment-sync.service';
 import { CacheService } from 'src/modules/common/cache/cache.service';
 import { CacheNamespace } from 'src/modules/common/cache/cache-namespaces';
-
-interface MoodleSyncResult {
-  categories: boolean;
-  courses: boolean;
-  enrollments: boolean;
-}
+import {
+  MoodleSyncJobData,
+  SyncPhaseResult,
+  SyncStatus,
+} from '../lib/sync-result.types';
 
 @Processor(QueueName.MOODLE_SYNC, {
   concurrency: 1,
@@ -28,62 +30,132 @@ export class MoodleSyncProcessor extends WorkerHost {
     private readonly courseSyncService: MoodleCourseSyncService,
     private readonly enrollmentSyncService: EnrollmentSyncService,
     private readonly cacheService: CacheService,
+    private readonly em: EntityManager,
   ) {
     super();
   }
 
-  async process(job: Job<{ trigger?: string }>): Promise<MoodleSyncResult> {
+  async process(job: Job<MoodleSyncJobData>): Promise<SyncLog> {
+    const fork = this.em.fork();
+    const startedAt = new Date();
+
     this.logger.log(
       `Processing moodle-sync job ${job.id} (trigger: ${job.data?.trigger ?? 'unknown'})`,
     );
 
-    const result: MoodleSyncResult = {
-      categories: false,
-      courses: false,
-      enrollments: false,
-    };
+    const syncLog = fork.create(SyncLog, {
+      trigger: job.data?.trigger ?? 'scheduled',
+      triggeredBy: job.data?.triggeredById
+        ? fork.getReference(User, job.data.triggeredById)
+        : undefined,
+      status: 'running',
+      startedAt,
+      jobId: job.id,
+    });
+    await fork.persistAndFlush(syncLog);
+
+    let coursesResult: SyncPhaseResult | undefined;
+    let enrollmentsResult: SyncPhaseResult | undefined;
 
     // Phase 1: Categories (required — courses/enrollments depend on hierarchy)
-    try {
+    const categoriesResult =
       await this.categorySyncService.SyncAndRebuildHierarchy();
-      result.categories = true;
+    syncLog.categories = categoriesResult;
+    await fork.flush();
+
+    if (categoriesResult.status === 'failed') {
+      this.logger.error(
+        `Category sync failed — aborting remaining phases: ${categoriesResult.errorMessage}`,
+      );
+      coursesResult = {
+        status: 'skipped',
+        durationMs: 0,
+        fetched: 0,
+        inserted: 0,
+        updated: 0,
+        deactivated: 0,
+        errors: 0,
+      };
+      enrollmentsResult = {
+        status: 'skipped',
+        durationMs: 0,
+        fetched: 0,
+        inserted: 0,
+        updated: 0,
+        deactivated: 0,
+        errors: 0,
+      };
+    } else {
       this.logger.log('Category sync completed');
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      this.logger.error(
-        `Category sync failed — aborting remaining phases: ${message}`,
-      );
-      return result;
+
+      // Phase 2: Courses (required — enrollments depend on courses)
+      coursesResult = await this.courseSyncService.SyncAllPrograms();
+      syncLog.courses = coursesResult;
+      await fork.flush();
+
+      if (coursesResult.status === 'failed') {
+        this.logger.error(
+          `Course sync failed — skipping enrollment sync: ${coursesResult.errorMessage}`,
+        );
+        enrollmentsResult = {
+          status: 'skipped',
+          durationMs: 0,
+          fetched: 0,
+          inserted: 0,
+          updated: 0,
+          deactivated: 0,
+          errors: 0,
+        };
+      } else {
+        this.logger.log('Course sync completed');
+
+        // Phase 3: Enrollments
+        enrollmentsResult = await this.enrollmentSyncService.SyncAllCourses();
+        syncLog.enrollments = enrollmentsResult;
+
+        if (enrollmentsResult.status !== 'failed') {
+          this.logger.log('Enrollment sync completed');
+          await this.cacheService.invalidateNamespace(
+            CacheNamespace.ENROLLMENTS_ME,
+          );
+        } else {
+          this.logger.error(
+            `Enrollment sync failed: ${enrollmentsResult.errorMessage}`,
+          );
+        }
+      }
     }
 
-    // Phase 2: Courses (required — enrollments depend on courses)
-    try {
-      await this.courseSyncService.SyncAllPrograms();
-      result.courses = true;
-      this.logger.log('Course sync completed');
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      this.logger.error(
-        `Course sync failed — skipping enrollment sync: ${message}`,
-      );
-      return result;
-    }
+    // Finalize sync log
+    const completedAt = new Date();
+    syncLog.courses = coursesResult;
+    syncLog.enrollments = enrollmentsResult;
+    syncLog.completedAt = completedAt;
+    syncLog.durationMs = completedAt.getTime() - startedAt.getTime();
+    syncLog.status = this.resolveOverallStatus(
+      categoriesResult,
+      coursesResult,
+      enrollmentsResult,
+    );
+    await fork.flush();
 
-    // Phase 3: Enrollments
-    try {
-      await this.enrollmentSyncService.SyncAllCourses();
-      result.enrollments = true;
-      this.logger.log('Enrollment sync completed');
+    return syncLog;
+  }
 
-      await this.cacheService.invalidateNamespace(
-        CacheNamespace.ENROLLMENTS_ME,
-      );
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      this.logger.error(`Enrollment sync failed: ${message}`);
-    }
+  private resolveOverallStatus(
+    categories: SyncPhaseResult,
+    courses: SyncPhaseResult,
+    enrollments: SyncPhaseResult,
+  ): SyncStatus {
+    const phases = [categories, courses, enrollments];
+    const allFailed = phases.every(
+      (p) => p.status === 'failed' || p.status === 'skipped',
+    );
+    const allSuccess = phases.every((p) => p.status === 'success');
 
-    return result;
+    if (allFailed) return 'failed';
+    if (allSuccess) return 'completed';
+    return 'partial';
   }
 
   @OnWorkerEvent('failed')

--- a/src/modules/moodle/schedulers/moodle-sync.constants.spec.ts
+++ b/src/modules/moodle/schedulers/moodle-sync.constants.spec.ts
@@ -1,0 +1,26 @@
+import { minutesToCron } from './moodle-sync.constants';
+
+describe('minutesToCron', () => {
+  it('should convert 1 minute to every-minute cron', () => {
+    expect(minutesToCron(1)).toBe('* * * * *');
+  });
+
+  it('should convert sub-hour minutes to minute-based cron', () => {
+    expect(minutesToCron(15)).toBe('*/15 * * * *');
+    expect(minutesToCron(30)).toBe('*/30 * * * *');
+  });
+
+  it('should convert 60 minutes to hourly cron', () => {
+    expect(minutesToCron(60)).toBe('0 * * * *');
+  });
+
+  it('should convert multiples of 60 to hour-based cron', () => {
+    expect(minutesToCron(120)).toBe('0 */2 * * *');
+    expect(minutesToCron(180)).toBe('0 */3 * * *');
+    expect(minutesToCron(360)).toBe('0 */6 * * *');
+  });
+
+  it('should treat non-multiple-of-60 values above 60 as minute-based', () => {
+    expect(minutesToCron(90)).toBe('*/90 * * * *');
+  });
+});

--- a/src/modules/moodle/schedulers/moodle-sync.constants.ts
+++ b/src/modules/moodle/schedulers/moodle-sync.constants.ts
@@ -1,0 +1,20 @@
+export const MOODLE_SYNC_JOB_NAME = 'moodle-sync-cron';
+
+export const MOODLE_SYNC_CONFIG_KEY = 'MOODLE_SYNC_INTERVAL_MINUTES';
+
+export const MOODLE_SYNC_MIN_INTERVAL_MINUTES = 30;
+
+export const MOODLE_SYNC_INTERVAL_DEFAULTS: Record<string, number> = {
+  development: 60,
+  test: 60,
+  staging: 360,
+  production: 180,
+};
+
+export function minutesToCron(minutes: number): string {
+  if (minutes >= 60 && minutes % 60 === 0) {
+    const hours = minutes / 60;
+    return hours === 1 ? '0 * * * *' : `0 */${hours} * * *`;
+  }
+  return minutes === 1 ? '* * * * *' : `*/${minutes} * * * *`;
+}

--- a/src/modules/moodle/schedulers/moodle-sync.scheduler.spec.ts
+++ b/src/modules/moodle/schedulers/moodle-sync.scheduler.spec.ts
@@ -1,14 +1,42 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getQueueToken } from '@nestjs/bullmq';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { EntityManager } from '@mikro-orm/core';
+import { CronJob } from 'cron';
 import { QueueName } from 'src/configurations/common/queue-names';
 import { MoodleSyncScheduler } from './moodle-sync.scheduler';
 
 describe('MoodleSyncScheduler', () => {
   let scheduler: MoodleSyncScheduler;
   let mockQueue: { add: jest.Mock };
+  let capturedCronJobs: CronJob[];
+  let mockSchedulerRegistry: {
+    addCronJob: jest.Mock;
+    deleteCronJob: jest.Mock;
+    getCronJob: jest.Mock;
+  };
+  let mockEm: { fork: jest.Mock; findOne: jest.Mock; flush: jest.Mock };
 
   beforeEach(async () => {
+    capturedCronJobs = [];
     mockQueue = { add: jest.fn().mockResolvedValue({ id: 'test-job-id' }) };
+    mockSchedulerRegistry = {
+      addCronJob: jest
+        .fn()
+        .mockImplementation((_name: string, job: CronJob) => {
+          capturedCronJobs.push(job);
+        }),
+      deleteCronJob: jest.fn(),
+      getCronJob: jest.fn().mockReturnValue({
+        nextDate: () => ({ toISO: () => '2026-03-25T21:00:00.000Z' }),
+      }),
+    };
+    mockEm = {
+      findOne: jest.fn().mockResolvedValue(null),
+      flush: jest.fn().mockResolvedValue(undefined),
+      fork: jest.fn(),
+    };
+    mockEm.fork.mockReturnValue(mockEm);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -17,34 +45,65 @@ describe('MoodleSyncScheduler', () => {
           provide: getQueueToken(QueueName.MOODLE_SYNC),
           useValue: mockQueue,
         },
+        {
+          provide: SchedulerRegistry,
+          useValue: mockSchedulerRegistry,
+        },
+        {
+          provide: EntityManager,
+          useValue: mockEm,
+        },
       ],
     }).compile();
 
     scheduler = module.get(MoodleSyncScheduler);
   });
 
-  it('should enqueue a moodle-sync job with correct options', async () => {
-    await scheduler.HandleScheduledSync();
+  afterEach(() => {
+    for (const job of capturedCronJobs) {
+      void job.stop();
+    }
+  });
 
-    expect(mockQueue.add).toHaveBeenCalledWith(
-      QueueName.MOODLE_SYNC,
-      { trigger: 'scheduled' },
-      {
-        jobId: 'moodle-sync-scheduled',
-        removeOnComplete: true,
-        removeOnFail: 50,
-      },
+  it('should register a cron job on module init', async () => {
+    await scheduler.onModuleInit();
+
+    expect(mockSchedulerRegistry.addCronJob).toHaveBeenCalledWith(
+      'moodle-sync-cron',
+      expect.anything(),
     );
   });
 
-  it('should catch and log error when Redis is unavailable', async () => {
-    mockQueue.add.mockRejectedValue(new Error('Redis connection refused'));
-    const errorSpy = jest.spyOn(scheduler['logger'], 'error');
+  it('should return schedule info after init', async () => {
+    await scheduler.onModuleInit();
 
-    await scheduler.HandleScheduledSync();
+    const schedule = scheduler.getSchedule();
+    expect(schedule.intervalMinutes).toBeDefined();
+    expect(schedule.cronExpression).toBeDefined();
+  });
 
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to enqueue scheduled sync'),
-    );
+  it('should use database config when available', async () => {
+    mockEm.findOne.mockResolvedValue({
+      key: 'MOODLE_SYNC_INTERVAL_MINUTES',
+      value: '120',
+    });
+
+    await scheduler.onModuleInit();
+
+    const schedule = scheduler.getSchedule();
+    expect(schedule.intervalMinutes).toBe(120);
+    expect(schedule.cronExpression).toBe('0 */2 * * *');
+  });
+
+  it('should ignore database config below minimum (30 minutes) and fall back to default', async () => {
+    mockEm.findOne.mockResolvedValue({
+      key: 'MOODLE_SYNC_INTERVAL_MINUTES',
+      value: '10',
+    });
+
+    await scheduler.onModuleInit();
+
+    const schedule = scheduler.getSchedule();
+    expect(schedule.intervalMinutes).toBeGreaterThanOrEqual(30);
   });
 });

--- a/src/modules/moodle/schedulers/moodle-sync.scheduler.ts
+++ b/src/modules/moodle/schedulers/moodle-sync.scheduler.ts
@@ -1,19 +1,106 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { SchedulerRegistry } from '@nestjs/schedule';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
+import { CronJob } from 'cron';
+import { EntityManager } from '@mikro-orm/core';
 import { QueueName } from 'src/configurations/common/queue-names';
+import { SystemConfig } from 'src/entities/system-config.entity';
+import { env } from 'src/configurations/env';
+import {
+  MOODLE_SYNC_JOB_NAME,
+  MOODLE_SYNC_CONFIG_KEY,
+  MOODLE_SYNC_INTERVAL_DEFAULTS,
+  MOODLE_SYNC_MIN_INTERVAL_MINUTES,
+  minutesToCron,
+} from './moodle-sync.constants';
 
 @Injectable()
-export class MoodleSyncScheduler {
+export class MoodleSyncScheduler implements OnModuleInit {
   private readonly logger = new Logger(MoodleSyncScheduler.name);
+  private currentIntervalMinutes: number;
+  private currentCronExpression: string;
 
   constructor(
     @InjectQueue(QueueName.MOODLE_SYNC) private readonly syncQueue: Queue,
+    private readonly schedulerRegistry: SchedulerRegistry,
+    private readonly em: EntityManager,
   ) {}
 
-  @Cron(CronExpression.EVERY_HOUR)
-  async HandleScheduledSync() {
+  async onModuleInit() {
+    const interval = await this.resolveInterval();
+    this.currentIntervalMinutes = interval;
+    this.currentCronExpression = minutesToCron(interval);
+
+    const job = CronJob.from({
+      cronTime: this.currentCronExpression,
+      onTick: () => this.handleScheduledSync(),
+      start: true,
+    });
+
+    this.schedulerRegistry.addCronJob(MOODLE_SYNC_JOB_NAME, job);
+    this.logger.log(
+      `Sync scheduler initialized: every ${interval}min (${this.currentCronExpression})`,
+    );
+  }
+
+  async updateSchedule(intervalMinutes: number): Promise<void> {
+    const cronExpression = minutesToCron(intervalMinutes);
+
+    // Validate by constructing — throws if invalid
+    CronJob.from({ cronTime: cronExpression, onTick: () => {} });
+
+    // Replace the running job
+    this.schedulerRegistry.deleteCronJob(MOODLE_SYNC_JOB_NAME);
+
+    const job = CronJob.from({
+      cronTime: cronExpression,
+      onTick: () => this.handleScheduledSync(),
+      start: true,
+    });
+
+    this.schedulerRegistry.addCronJob(MOODLE_SYNC_JOB_NAME, job);
+
+    // Persist to SystemConfig
+    const fork = this.em.fork();
+    const config = await fork.findOne(SystemConfig, {
+      key: MOODLE_SYNC_CONFIG_KEY,
+    });
+
+    if (config) {
+      config.value = String(intervalMinutes);
+    } else {
+      fork.create(SystemConfig, {
+        key: MOODLE_SYNC_CONFIG_KEY,
+        value: String(intervalMinutes),
+        description: 'Moodle sync interval in minutes',
+      });
+    }
+    await fork.flush();
+
+    this.currentIntervalMinutes = intervalMinutes;
+    this.currentCronExpression = cronExpression;
+    this.logger.log(
+      `Sync schedule updated: every ${intervalMinutes}min (${cronExpression})`,
+    );
+  }
+
+  getSchedule(): {
+    intervalMinutes: number;
+    cronExpression: string;
+    nextExecution: string | null;
+  } {
+    const job = this.schedulerRegistry.getCronJob(MOODLE_SYNC_JOB_NAME);
+    const nextDate = job.nextDate();
+
+    return {
+      intervalMinutes: this.currentIntervalMinutes,
+      cronExpression: this.currentCronExpression,
+      nextExecution: nextDate?.toISO() ?? null,
+    };
+  }
+
+  private async handleScheduledSync() {
     try {
       await this.syncQueue.add(
         QueueName.MOODLE_SYNC,
@@ -36,5 +123,45 @@ export class MoodleSyncScheduler {
         this.logger.error(`Failed to enqueue scheduled sync: ${message}`);
       }
     }
+  }
+
+  private async resolveInterval(): Promise<number> {
+    // Priority 1: Database config (admin override)
+    try {
+      const fork = this.em.fork();
+      const config = await fork.findOne(SystemConfig, {
+        key: MOODLE_SYNC_CONFIG_KEY,
+      });
+      if (config?.value) {
+        const parsed = parseInt(config.value, 10);
+        if (!isNaN(parsed) && parsed >= MOODLE_SYNC_MIN_INTERVAL_MINUTES) {
+          this.logger.log(
+            `Using sync interval from database: ${parsed} minutes`,
+          );
+          return parsed;
+        }
+      }
+    } catch {
+      this.logger.warn(
+        'Could not read sync interval from database, falling back to env/default',
+      );
+    }
+
+    // Priority 2: Environment variable
+    if (env.MOODLE_SYNC_INTERVAL_MINUTES) {
+      this.logger.log(
+        `Using sync interval from env: ${env.MOODLE_SYNC_INTERVAL_MINUTES} minutes`,
+      );
+      return env.MOODLE_SYNC_INTERVAL_MINUTES;
+    }
+
+    // Priority 3: Per-environment default
+    const defaultInterval =
+      MOODLE_SYNC_INTERVAL_DEFAULTS[env.NODE_ENV] ??
+      MOODLE_SYNC_INTERVAL_DEFAULTS.development;
+    this.logger.log(
+      `Using default sync interval for ${env.NODE_ENV}: ${defaultInterval} minutes`,
+    );
+    return defaultInterval;
   }
 }

--- a/src/modules/moodle/services/moodle-category-sync.service.ts
+++ b/src/modules/moodle/services/moodle-category-sync.service.ts
@@ -9,6 +9,7 @@ import { Program } from 'src/entities/program.entity';
 import { MoodleCategoryResponse } from '../lib/moodle.types';
 import { MoodleService } from '../moodle.service';
 import UnitOfWork from 'src/modules/common/unit-of-work';
+import { SyncPhaseResult } from '../lib/sync-result.types';
 
 @Injectable()
 export class MoodleCategorySyncService {
@@ -17,18 +18,53 @@ export class MoodleCategorySyncService {
     private readonly unitOfWork: UnitOfWork,
   ) {}
 
-  async SyncAndRebuildHierarchy(): Promise<void> {
-    return await this.unitOfWork.runInTransaction(async (tx) => {
-      const remoteCategories = await this.moodleService.GetCategories({
-        token: env.MOODLE_MASTER_KEY,
+  async SyncAndRebuildHierarchy(): Promise<SyncPhaseResult> {
+    const startTime = Date.now();
+    try {
+      const result = await this.unitOfWork.runInTransaction(async (tx) => {
+        const countBefore = await tx.count(MoodleCategory);
+
+        const remoteCategories = await this.moodleService.GetCategories({
+          token: env.MOODLE_MASTER_KEY,
+        });
+
+        // Phase 1: Raw mirror sync
+        await this.syncRawCategories(tx, remoteCategories);
+
+        // Phase 2: Rebuild normalized hierarchy
+        await this.rebuildHierarchy(tx);
+
+        const upserted = remoteCategories.length;
+        const inserted = Math.max(0, upserted - countBefore);
+
+        return {
+          fetched: remoteCategories.length,
+          inserted,
+          updated: upserted - inserted,
+        };
       });
 
-      // Phase 1: Raw mirror sync
-      await this.syncRawCategories(tx, remoteCategories);
-
-      // Phase 2: Rebuild normalized hierarchy
-      await this.rebuildHierarchy(tx);
-    });
+      return {
+        status: 'success',
+        durationMs: Date.now() - startTime,
+        fetched: result.fetched,
+        inserted: result.inserted,
+        updated: result.updated,
+        deactivated: 0,
+        errors: 0,
+      };
+    } catch (error: unknown) {
+      return {
+        status: 'failed',
+        durationMs: Date.now() - startTime,
+        fetched: 0,
+        inserted: 0,
+        updated: 0,
+        deactivated: 0,
+        errors: 1,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      };
+    }
   }
 
   private async syncRawCategories(

--- a/src/modules/moodle/services/moodle-course-sync.service.ts
+++ b/src/modules/moodle/services/moodle-course-sync.service.ts
@@ -6,6 +6,7 @@ import { Program } from 'src/entities/program.entity';
 import { Course } from 'src/entities/course.entity';
 import { MoodleService } from '../moodle.service';
 import UnitOfWork from 'src/modules/common/unit-of-work';
+import { SyncPhaseResult } from '../lib/sync-result.types';
 
 @Injectable()
 export class MoodleCourseSyncService {
@@ -17,17 +18,28 @@ export class MoodleCourseSyncService {
     private readonly unitOfWork: UnitOfWork,
   ) {}
 
-  async SyncAllPrograms(): Promise<void> {
+  async SyncAllPrograms(): Promise<SyncPhaseResult> {
+    const startTime = Date.now();
     const em = this.em.fork();
+    const countBefore = await em.count(Course);
     const programs = await em.find(Program, {});
     const limit = pLimit(env.MOODLE_SYNC_CONCURRENCY);
+
+    let fetched = 0;
+    let upserted = 0;
+    let deactivated = 0;
+    let errors = 0;
 
     await Promise.all(
       programs.map((program) =>
         limit(async () => {
           try {
-            await this.syncProgramCourses(program);
+            const metrics = await this.syncProgramCourses(program);
+            fetched += metrics.fetched;
+            upserted += metrics.upserted;
+            deactivated += metrics.deactivated;
           } catch (error: unknown) {
+            errors++;
             const message =
               error instanceof Error ? error.message : String(error);
             this.logger.error(
@@ -37,15 +49,30 @@ export class MoodleCourseSyncService {
         }),
       ),
     );
+
+    const inserted = Math.max(0, upserted - countBefore);
+
+    return {
+      status: errors > 0 && upserted === 0 ? 'failed' : 'success',
+      durationMs: Date.now() - startTime,
+      fetched,
+      inserted,
+      updated: upserted - inserted,
+      deactivated,
+      errors,
+    };
   }
 
-  private async syncProgramCourses(program: Program) {
+  private async syncProgramCourses(
+    program: Program,
+  ): Promise<{ fetched: number; upserted: number; deactivated: number }> {
     const remoteData = await this.moodleService.GetCoursesByCategory(
       env.MOODLE_MASTER_KEY,
       program.moodleCategoryId,
     );
 
     const remoteCourses = remoteData.courses;
+    let deactivated = 0;
 
     await this.unitOfWork.runInTransaction(async (tx) => {
       const existing = await tx.find(Course, {
@@ -98,8 +125,15 @@ export class MoodleCourseSyncService {
           course.isActive = false;
           course.isVisible = false;
           tx.persist(course);
+          deactivated++;
         }
       }
     });
+
+    return {
+      fetched: remoteCourses.length,
+      upserted: remoteCourses.length,
+      deactivated,
+    };
   }
 }

--- a/src/modules/moodle/services/moodle-enrollment-sync.service.ts
+++ b/src/modules/moodle/services/moodle-enrollment-sync.service.ts
@@ -9,6 +9,7 @@ import { User } from 'src/entities/user.entity';
 import { MoodleEnrolledUser } from '../lib/moodle.types';
 import { MoodleService } from '../moodle.service';
 import UnitOfWork from 'src/modules/common/unit-of-work';
+import { SyncPhaseResult } from '../lib/sync-result.types';
 
 @Injectable()
 export class EnrollmentSyncService {
@@ -20,10 +21,15 @@ export class EnrollmentSyncService {
     private readonly unitOfWork: UnitOfWork,
   ) {}
 
-  async SyncAllCourses() {
+  async SyncAllCourses(): Promise<SyncPhaseResult> {
+    const startTime = Date.now();
     const em = this.em.fork();
+    const enrollmentCountBefore = await em.count(Enrollment);
     const courses = await em.find(Course, { isVisible: true });
     const limit = pLimit(env.MOODLE_SYNC_CONCURRENCY);
+
+    let totalFetched = 0;
+    let fetchErrors = 0;
 
     // Phase 1: Concurrent HTTP fetch
     const results = await Promise.all(
@@ -35,8 +41,10 @@ export class EnrollmentSyncService {
                 token: env.MOODLE_MASTER_KEY,
                 courseId: course.moodleCourseId,
               });
+            totalFetched += remoteUsers.length;
             return { course, remoteUsers };
           } catch (error: unknown) {
+            fetchErrors++;
             const message =
               error instanceof Error ? error.message : String(error);
             this.logger.error(
@@ -56,16 +64,38 @@ export class EnrollmentSyncService {
     await this.syncAllUsers(fetched);
 
     // Phase 3: Sequential per-course enrollment upsert
+    let enrollmentUpserts = 0;
+    let deactivated = 0;
+    let enrollmentErrors = 0;
+
     for (const { course, remoteUsers } of fetched) {
       try {
-        await this.syncCourseEnrollments(course, remoteUsers);
+        const metrics = await this.syncCourseEnrollments(course, remoteUsers);
+        enrollmentUpserts += metrics.upserted;
+        deactivated += metrics.deactivated;
       } catch (error: unknown) {
+        enrollmentErrors++;
         const message = error instanceof Error ? error.message : String(error);
         this.logger.error(
           `Failed to sync enrollments for course ${course.moodleCourseId}: ${message}`,
         );
       }
     }
+
+    const inserted = Math.max(0, enrollmentUpserts - enrollmentCountBefore);
+
+    return {
+      status:
+        fetchErrors + enrollmentErrors > 0 && enrollmentUpserts === 0
+          ? 'failed'
+          : 'success',
+      durationMs: Date.now() - startTime,
+      fetched: totalFetched,
+      inserted,
+      updated: enrollmentUpserts - inserted,
+      deactivated,
+      errors: fetchErrors + enrollmentErrors,
+    };
   }
 
   private async syncAllUsers(
@@ -153,7 +183,10 @@ export class EnrollmentSyncService {
   private async syncCourseEnrollments(
     course: Course,
     remoteUsers: MoodleEnrolledUser[],
-  ) {
+  ): Promise<{ upserted: number; deactivated: number }> {
+    let upserted = 0;
+    let deactivated = 0;
+
     await this.unitOfWork.runInTransaction(async (tx) => {
       const existing = await tx.find(
         Enrollment,
@@ -221,6 +254,7 @@ export class EnrollmentSyncService {
             'updatedAt',
           ],
         });
+        upserted++;
       }
 
       // Soft deactivate users missing from remote
@@ -231,9 +265,12 @@ export class EnrollmentSyncService {
         ) {
           enrollment.isActive = false;
           tx.persist(enrollment);
+          deactivated++;
         }
       }
     });
+
+    return { upserted, deactivated };
   }
 
   private async upsertSectionsFromGroups(

--- a/src/modules/moodle/services/moodle-startup.service.ts
+++ b/src/modules/moodle/services/moodle-startup.service.ts
@@ -99,7 +99,7 @@ export class MoodleStartupService {
 
   private async RunPhase(
     name: string,
-    fn: () => Promise<void>,
+    fn: () => Promise<unknown>,
   ): Promise<JobRecordType> {
     const start = Date.now();
     try {


### PR DESCRIPTION
## Summary

- Rewrite `MoodleSyncScheduler` from static `@Cron(EVERY_HOUR)` to dynamic `SchedulerRegistry`-based scheduling with environment-aware defaults (dev: 60min, staging: 360min, prod: 180min)
- Add `SyncLog` entity tracking every sync execution with per-phase metrics (fetched, inserted, updated, deactivated counts) and who triggered it
- Add admin endpoints for sync history, schedule viewing, and runtime schedule updates (min 30 minutes)

## Changes

### New files
- `src/entities/sync-log.entity.ts` — Audit entity (no soft delete, own PK)
- `src/modules/moodle/lib/sync-result.types.ts` — `SyncPhaseResult`, `MoodleSyncJobData` types
- `src/modules/moodle/schedulers/moodle-sync.constants.ts` — Per-env defaults, `minutesToCron()` helper
- `src/modules/moodle/dto/requests/update-sync-schedule.request.dto.ts`
- `src/modules/moodle/dto/responses/sync-log.response.dto.ts`
- `src/modules/moodle/dto/responses/sync-schedule.response.dto.ts`
- `src/modules/moodle/dto/responses/sync-history.response.dto.ts`
- `src/migrations/Migration20260325121432.ts` — Creates `sync_log` table

### Modified files
- `moodle-sync.scheduler.ts` — Rewritten to use `SchedulerRegistry` + `OnModuleInit`
- `moodle-sync.processor.ts` — Creates/updates `SyncLog` per job, consumes `SyncPhaseResult`
- `moodle-category-sync.service.ts` — Returns `SyncPhaseResult` with count-before/after metrics
- `moodle-course-sync.service.ts` — Returns `SyncPhaseResult` with metrics
- `moodle-enrollment-sync.service.ts` — Returns `SyncPhaseResult` with metrics
- `moodle-sync.controller.ts` — 3 new endpoints, CLS-based user context via `CurrentUserInterceptor`
- `moodle.module.ts` — Added `SyncLog`, `SystemConfig`, `DataLoaderModule` imports
- `moodle-startup.service.ts` — `RunPhase` accepts `Promise<unknown>` for compatibility

### New endpoints (all SUPER_ADMIN)
| Method | Path | Description |
|--------|------|-------------|
| GET | `/moodle/sync/history` | Paginated sync log history with per-phase metrics |
| GET | `/moodle/sync/schedule` | Current interval, cron expression, next execution |
| PUT | `/moodle/sync/schedule` | Update interval (min 30 minutes), persists to SystemConfig |

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] All 475 tests pass (19 new tests added)
- [x] New controller tests: status, trigger with CLS, history pagination, schedule CRUD, DTO validation
- [x] New scheduler tests: init, DB config, minimum interval enforcement
- [x] New `minutesToCron` helper tests: edge cases for 1min, sub-hour, hourly, multi-hour
- [ ] Manual: start dev server, verify scheduler logs resolved cron expression
- [ ] Manual: `POST /moodle/sync` → verify `SyncLog` created with `triggeredBy`
- [ ] Manual: `GET /moodle/sync/history` → verify paginated results
- [ ] Manual: `PUT /moodle/sync/schedule` with `{ intervalMinutes: 180 }` → verify cron updates

Closes #158