### PR TITLE
FAC-72 fix: questionnaire submission DTO avoid serialization

### DIFF
--- a/src/modules/questionnaires/dto/responses/submit-questionnaire-response.dto.ts
+++ b/src/modules/questionnaires/dto/responses/submit-questionnaire-response.dto.ts
@@ -1,0 +1,46 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { RespondentRole } from '../../lib/questionnaire.types';
+import type { QuestionnaireSubmission } from 'src/entities/questionnaire-submission.entity';
+
+export class SubmitQuestionnaireResponse {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  submittedAt: Date;
+
+  @ApiProperty({ enum: RespondentRole })
+  respondentRole: RespondentRole;
+
+  @ApiProperty({ type: 'number' })
+  totalScore: number;
+
+  @ApiProperty({ type: 'number' })
+  normalizedScore: number;
+
+  @ApiProperty()
+  faculty: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  course?: string;
+
+  @ApiProperty()
+  semester: string;
+
+  @ApiProperty()
+  academicYear: string;
+
+  static Map(submission: QuestionnaireSubmission): SubmitQuestionnaireResponse {
+    return {
+      id: submission.id,
+      submittedAt: submission.submittedAt,
+      respondentRole: submission.respondentRole,
+      totalScore: submission.totalScore,
+      normalizedScore: submission.normalizedScore,
+      faculty: submission.facultyNameSnapshot,
+      course: submission.courseTitleSnapshot,
+      semester: submission.semesterLabelSnapshot,
+      academicYear: submission.academicYearSnapshot,
+    };
+  }
+}

--- a/src/modules/questionnaires/ingestion/services/ingestion-engine.service.ts
+++ b/src/modules/questionnaires/ingestion/services/ingestion-engine.service.ts
@@ -14,7 +14,7 @@ import {
   IngestionResultDto,
   IngestionRecordResult,
 } from '../dto/ingestion-result.dto';
-import { QuestionnaireSubmission } from 'src/entities/questionnaire-submission.entity';
+import { SubmitQuestionnaireResponse } from '../../dto/responses/submit-questionnaire-response.dto';
 
 export class DryRunRollbackError extends Error {
   constructor() {
@@ -171,9 +171,9 @@ export class IngestionEngine {
     em: EntityManager,
     mapped: MappedSubmission,
     dryRun: boolean,
-  ): Promise<QuestionnaireSubmission> {
+  ): Promise<SubmitQuestionnaireResponse> {
     if (dryRun) {
-      let submission: QuestionnaireSubmission | undefined;
+      let submission: SubmitQuestionnaireResponse | undefined;
       try {
         await em.transactional(async () => {
           submission = await this.questionnaireService.submitQuestionnaire(

--- a/src/modules/questionnaires/questionnaire.controller.ts
+++ b/src/modules/questionnaires/questionnaire.controller.ts
@@ -37,6 +37,7 @@ import { QuestionnaireVersionDetailResponse } from './dto/responses/questionnair
 import { DraftResponse } from './dto/responses/draft-response.dto';
 import { CheckSubmissionQuery } from './dto/requests/check-submission-query.dto';
 import { CheckSubmissionResponse } from './dto/responses/check-submission-response.dto';
+import { SubmitQuestionnaireResponse } from './dto/responses/submit-questionnaire-response.dto';
 import { IngestionResultDto } from './ingestion/dto/ingestion-result.dto';
 import { UseJwtGuard } from 'src/security/decorators';
 import { UserRole } from '../auth/roles.enum';
@@ -200,7 +201,9 @@ export class QuestionnaireController {
   @Post('submissions')
   @UseJwtGuard()
   @ApiOperation({ summary: 'Submit a completed questionnaire' })
-  async submitQuestionnaire(@Body() data: SubmitQuestionnaireRequest) {
+  async submitQuestionnaire(
+    @Body() data: SubmitQuestionnaireRequest,
+  ): Promise<SubmitQuestionnaireResponse> {
     return this.questionnaireService.submitQuestionnaire(data);
   }
 

--- a/src/modules/questionnaires/services/questionnaire.service.spec.ts
+++ b/src/modules/questionnaires/services/questionnaire.service.spec.ts
@@ -367,7 +367,7 @@ describe('QuestionnaireService', () => {
       expect(result).toBeDefined();
       expect(em.persist).toHaveBeenCalled();
       expect(em.flush).toHaveBeenCalled();
-      expect(result.facultyEmployeeNumberSnapshot).toBe('fac123');
+      expect(result.faculty).toBe('Faculty Name');
     });
 
     it('should enqueue embedding job when submission has qualitative comment and worker URL is configured', async () => {

--- a/src/modules/questionnaires/services/questionnaire.service.ts
+++ b/src/modules/questionnaires/services/questionnaire.service.ts
@@ -38,6 +38,7 @@ import {
   EnrollmentRole,
 } from '../lib/questionnaire.types';
 import { QuestionnaireTypeResponse } from '../dto/responses/questionnaire-type-response.dto';
+import { SubmitQuestionnaireResponse } from '../dto/responses/submit-questionnaire-response.dto';
 import { QuestionnaireVersionsResponse } from '../dto/responses/questionnaire-version-response.dto';
 import { QuestionnaireSchemaValidator } from './questionnaire-schema.validator';
 import { ScoringService } from './scoring.service';
@@ -638,7 +639,7 @@ export class QuestionnaireService {
       }
     }
 
-    return submission;
+    return SubmitQuestionnaireResponse.Map(submission);
   }
 
   // F6: Iterative traversal to avoid stack overflow


### PR DESCRIPTION
## Summary
- Replace raw `QuestionnaireSubmission` entity return with a lightweight `SubmitQuestionnaireResponse` DTO
- Response includes only `id`, scores, timestamps, and context from snapshot fields (faculty, course, semester, academic year)
- No relation population needed — all mapped fields are scalars on the entity

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] All 161 questionnaire tests pass

Closes #156