### PR TITLE
FAC-74 feat: return submission status in enrollments endpoint

### DIFF
--- a/src/modules/enrollments/dto/responses/enrollment.response.dto.ts
+++ b/src/modules/enrollments/dto/responses/enrollment.response.dto.ts
@@ -36,6 +36,14 @@ export class SectionShortResponseDto {
   name: string;
 }
 
+export class SubmissionStatusDto {
+  @ApiProperty()
+  submitted: boolean;
+
+  @ApiPropertyOptional()
+  submittedAt?: Date;
+}
+
 export class EnrollmentResponseDto {
   @ApiProperty()
   @IsString()
@@ -56,4 +64,7 @@ export class EnrollmentResponseDto {
 
   @ApiPropertyOptional({ type: SectionShortResponseDto, nullable: true })
   section: SectionShortResponseDto | null;
+
+  @ApiProperty({ type: SubmissionStatusDto })
+  submission: SubmissionStatusDto;
 }

--- a/src/modules/enrollments/enrollments.module.ts
+++ b/src/modules/enrollments/enrollments.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { Enrollment } from 'src/entities/enrollment.entity';
 import { Course } from 'src/entities/course.entity';
+import { QuestionnaireSubmission } from 'src/entities/questionnaire-submission.entity';
 import { EnrollmentsController } from './enrollments.controller';
 import { EnrollmentsService } from './enrollments.service';
 import { CommonModule } from '../common/common.module';
@@ -9,7 +10,7 @@ import DataLoaderModule from '../common/data-loaders/index.module';
 
 @Module({
   imports: [
-    MikroOrmModule.forFeature([Enrollment, Course]),
+    MikroOrmModule.forFeature([Enrollment, Course, QuestionnaireSubmission]),
     CommonModule,
     DataLoaderModule,
   ],

--- a/src/modules/enrollments/enrollments.service.spec.ts
+++ b/src/modules/enrollments/enrollments.service.spec.ts
@@ -92,7 +92,10 @@ describe('EnrollmentsService', () => {
     ];
 
     (em.findAndCount as jest.Mock).mockResolvedValue([mockEnrollments, 1]);
-    (em.find as jest.Mock).mockResolvedValue(mockFacultyEnrollments);
+    // Promise.all order: getFacultyByCourseIds first, getSubmissionStatusByCourseIds second
+    (em.find as jest.Mock)
+      .mockResolvedValueOnce(mockFacultyEnrollments)
+      .mockResolvedValueOnce([]);
 
     const result = await service.getMyEnrollments(1, 10);
 
@@ -110,6 +113,7 @@ describe('EnrollmentsService', () => {
       label: '1st Semester',
       academicYear: '2025-2026',
     });
+    expect(result.data[0].submission).toEqual({ submitted: false });
     expect(result.meta.totalItems).toBe(1);
     expect(result.meta.totalPages).toBe(1);
     // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -121,6 +125,47 @@ describe('EnrollmentsService', () => {
         offset: 0,
       }),
     );
+  });
+
+  it('should return submission status when submissions exist', async () => {
+    const submittedAt = new Date('2026-03-20T10:00:00Z');
+    const mockEnrollments = [
+      {
+        id: 'e1',
+        role: 'student',
+        course: {
+          id: 'c1',
+          moodleCourseId: 101,
+          shortname: 'CS101',
+          fullname: 'Intro to CS',
+          courseImage: null,
+          program: {
+            department: {
+              semester: {
+                id: 'sem-1',
+                code: 'S12526',
+                label: '1st Semester',
+                academicYear: '2025-2026',
+              },
+            },
+          },
+        },
+      },
+    ];
+
+    const mockSubmissions = [{ course: { id: 'c1' }, submittedAt }];
+
+    (em.findAndCount as jest.Mock).mockResolvedValue([mockEnrollments, 1]);
+    (em.find as jest.Mock)
+      .mockResolvedValueOnce([]) // faculty
+      .mockResolvedValueOnce(mockSubmissions); // submissions
+
+    const result = await service.getMyEnrollments(1, 10);
+
+    expect(result.data[0].submission).toEqual({
+      submitted: true,
+      submittedAt,
+    });
   });
 
   it('should return null faculty when no faculty enrolled in course', async () => {
@@ -180,7 +225,7 @@ describe('EnrollmentsService', () => {
     expect(result.data[0].semester).toBeNull();
   });
 
-  it('should not query faculty when no enrollments exist', async () => {
+  it('should not query faculty or submissions when no enrollments exist', async () => {
     (em.findAndCount as jest.Mock).mockResolvedValue([[], 0]);
 
     const result = await service.getMyEnrollments(1, 10);

--- a/src/modules/enrollments/enrollments.service.ts
+++ b/src/modules/enrollments/enrollments.service.ts
@@ -1,6 +1,7 @@
 import { EntityManager } from '@mikro-orm/core';
 import { Injectable } from '@nestjs/common';
 import { Enrollment } from 'src/entities/enrollment.entity';
+import { QuestionnaireSubmission } from 'src/entities/questionnaire-submission.entity';
 import { CacheService } from '../common/cache/cache.service';
 import { CacheNamespace } from '../common/cache/cache-namespaces';
 import { CurrentUserService } from '../common/cls/current-user.service';
@@ -45,7 +46,10 @@ export class EnrollmentsService {
     );
 
     const courseIds = [...new Set(enrollments.map((e) => e.course.id))];
-    const facultyMap = await this.getFacultyByCourseIds(courseIds);
+    const [facultyMap, submissionMap] = await Promise.all([
+      this.getFacultyByCourseIds(courseIds),
+      this.getSubmissionStatusByCourseIds(userId, courseIds),
+    ]);
 
     return {
       data: enrollments.map((e) => {
@@ -72,6 +76,10 @@ export class EnrollmentsService {
           section: e.section
             ? { id: e.section.id, name: e.section.name }
             : null,
+          submission: {
+            submitted: submissionMap.has(e.course.id),
+            submittedAt: submissionMap.get(e.course.id),
+          },
         };
       }),
       meta: {
@@ -82,6 +90,29 @@ export class EnrollmentsService {
         currentPage: page,
       },
     };
+  }
+
+  private async getSubmissionStatusByCourseIds(
+    userId: string,
+    courseIds: string[],
+  ): Promise<Map<string, Date>> {
+    const map = new Map<string, Date>();
+    if (courseIds.length === 0) return map;
+
+    const submissions = await this.em.find(
+      QuestionnaireSubmission,
+      { respondent: userId, course: { $in: courseIds } },
+      { fields: ['course', 'submittedAt'], orderBy: { submittedAt: 'DESC' } },
+    );
+
+    for (const submission of submissions) {
+      const courseId = submission.course?.id;
+      if (courseId && !map.has(courseId)) {
+        map.set(courseId, submission.submittedAt);
+      }
+    }
+
+    return map;
   }
 
   private async getFacultyByCourseIds(

--- a/src/modules/questionnaires/services/questionnaire.service.spec.ts
+++ b/src/modules/questionnaires/services/questionnaire.service.spec.ts
@@ -20,6 +20,7 @@ import { QuestionnaireSchemaValidator } from './questionnaire-schema.validator';
 import { ScoringService } from './scoring.service';
 import { EntityManager } from '@mikro-orm/postgresql';
 import { CacheService } from '../../common/cache/cache.service';
+import { CacheNamespace } from '../../common/cache/cache-namespaces';
 import { AnalysisService } from '../../analysis/analysis.service';
 import { CurrentUserService } from '../../common/cls/current-user.service';
 import {
@@ -43,6 +44,10 @@ describe('QuestionnaireService', () => {
   let versionRepo: jest.Mocked<EntityRepository<QuestionnaireVersion>>;
   let questionnaireRepo: jest.Mocked<EntityRepository<Questionnaire>>;
   let analysisService: { EnqueueJob: jest.Mock };
+  let cacheService: {
+    invalidateNamespace: jest.Mock;
+    invalidateNamespaces: jest.Mock;
+  };
 
   const RESPONDENT_ID = 'r1';
   const FACULTY_ID = 'f1';
@@ -157,6 +162,7 @@ describe('QuestionnaireService', () => {
     versionRepo = module.get(getRepositoryToken(QuestionnaireVersion));
     questionnaireRepo = module.get(getRepositoryToken(Questionnaire));
     analysisService = module.get(AnalysisService);
+    cacheService = module.get(CacheService);
   });
 
   it('should be defined', () => {
@@ -368,6 +374,9 @@ describe('QuestionnaireService', () => {
       expect(em.persist).toHaveBeenCalled();
       expect(em.flush).toHaveBeenCalled();
       expect(result.faculty).toBe('Faculty Name');
+      expect(cacheService.invalidateNamespace).toHaveBeenCalledWith(
+        CacheNamespace.ENROLLMENTS_ME,
+      );
     });
 
     it('should enqueue embedding job when submission has qualitative comment and worker URL is configured', async () => {

--- a/src/modules/questionnaires/services/questionnaire.service.ts
+++ b/src/modules/questionnaires/services/questionnaire.service.ts
@@ -616,6 +616,8 @@ export class QuestionnaireService {
       throw e;
     }
 
+    await this.cacheService.invalidateNamespace(CacheNamespace.ENROLLMENTS_ME);
+
     // Fire-and-forget embedding dispatch (uses cleaned text for alignment with topic modeling)
     if (
       !options?.skipAnalysis &&


### PR DESCRIPTION
## Summary
- Adds a `submission` field (`{ submitted: boolean, submittedAt?: Date }`) to each enrollment in the `GET /enrollments/me` response, allowing the frontend to determine if the current user has already submitted a questionnaire for a given course
- Uses a single batch query against `QuestionnaireSubmission` (respondent + course IDs) run in parallel with the existing faculty lookup via `Promise.all`
- Adds `ENROLLMENTS_ME` cache invalidation after successful questionnaire submission to prevent stale status

Closes #157

## Test plan
- [x] Enrollment service unit tests pass (6/6) including new submission status tests
- [x] Questionnaire service unit tests pass (58/58) including cache invalidation assertion
- [x] Lint passes
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)