### PR TITLE
FAC-75 fix: dimensions GET endpoint misparses active=false query filter

### DIFF
--- a/src/modules/dimensions/dto/requests/list-dimensions-query.dto.spec.ts
+++ b/src/modules/dimensions/dto/requests/list-dimensions-query.dto.spec.ts
@@ -1,0 +1,25 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { ListDimensionsQueryDto } from './list-dimensions-query.dto';
+
+describe('ListDimensionsQueryDto', () => {
+  const transform = (plain: Record<string, unknown>) =>
+    plainToInstance(ListDimensionsQueryDto, plain, {
+      enableImplicitConversion: true,
+    });
+
+  it('should parse active=true as boolean true', () => {
+    const dto = transform({ active: 'true' });
+    expect(dto.active).toBe(true);
+  });
+
+  it('should parse active=false as boolean false', () => {
+    const dto = transform({ active: 'false' });
+    expect(dto.active).toBe(false);
+  });
+
+  it('should leave active undefined when not provided', () => {
+    const dto = transform({});
+    expect(dto.active).toBeUndefined();
+  });
+});

--- a/src/modules/dimensions/dto/requests/list-dimensions-query.dto.ts
+++ b/src/modules/dimensions/dto/requests/list-dimensions-query.dto.ts
@@ -9,7 +9,9 @@ export class ListDimensionsQueryDto {
   questionnaireType?: QuestionnaireType;
 
   @IsOptional()
-  @Transform(({ value }) => value === 'true' || value === true)
+  @Transform(
+    ({ obj }: { obj: Record<string, unknown> }) => obj.active === 'true',
+  )
   active?: boolean;
 
   @IsInt()

--- a/src/modules/dimensions/services/dimensions.service.spec.ts
+++ b/src/modules/dimensions/services/dimensions.service.spec.ts
@@ -141,13 +141,24 @@ describe('DimensionsService', () => {
       );
     });
 
-    it('should apply active filter', async () => {
+    it('should apply active=true filter', async () => {
       dimensionRepository.findAndCount.mockResolvedValue([[], 0]);
 
       await service.findAll({ active: true, page: 1, limit: 20 });
 
       expect(dimensionRepository.findAndCount).toHaveBeenCalledWith(
         { active: true },
+        expect.anything(),
+      );
+    });
+
+    it('should apply active=false filter', async () => {
+      dimensionRepository.findAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({ active: false, page: 1, limit: 20 });
+
+      expect(dimensionRepository.findAndCount).toHaveBeenCalledWith(
+        { active: false },
         expect.anything(),
       );
     });


### PR DESCRIPTION
## Summary
- Fix `@Transform` on `ListDimensionsQueryDto.active` to read from the raw source object (`obj.active`) instead of the pre-transformed `value`, preventing `enableImplicitConversion` from coercing the string `"false"` to boolean `true`
- Add DTO-level regression test covering `active=true`, `active=false`, and omitted cases
- Add service-level test for `active=false` filter pass-through

## Test plan
- [x] `active=true` query param parses to boolean `true`
- [x] `active=false` query param parses to boolean `false`
- [x] Omitted `active` remains `undefined`
- [x] Service passes `active: false` filter to repository

Closes #166