### PR TITLE
FAC-76 fix: questionnaire mutation endpoints return raw entities instead of DTOs (#169)

### DIFF
--- a/src/modules/questionnaires/dto/responses/questionnaire-response.dto.ts
+++ b/src/modules/questionnaires/dto/responses/questionnaire-response.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  QuestionnaireStatus,
+  QuestionnaireType,
+} from '../../lib/questionnaire.types';
+import type { Questionnaire } from 'src/entities/questionnaire.entity';
+
+export class QuestionnaireResponseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  title: string;
+
+  @ApiProperty({ enum: QuestionnaireType })
+  type: QuestionnaireType;
+
+  @ApiProperty({ enum: QuestionnaireStatus })
+  status: QuestionnaireStatus;
+
+  static Map(entity: Questionnaire): QuestionnaireResponseDto {
+    return {
+      id: entity.id,
+      title: entity.title,
+      type: entity.type,
+      status: entity.status,
+    };
+  }
+}

--- a/src/modules/questionnaires/questionnaire.controller.spec.ts
+++ b/src/modules/questionnaires/questionnaire.controller.spec.ts
@@ -11,7 +11,11 @@ import { QuestionnaireService } from './services/questionnaire.service';
 import { IngestionEngine } from './ingestion/services/ingestion-engine.service';
 import { CSVAdapter } from './ingestion/adapters/csv.adapter';
 import { IngestionResultDto } from './ingestion/dto/ingestion-result.dto';
-import { QuestionnaireSchemaSnapshot } from './lib/questionnaire.types';
+import {
+  QuestionnaireSchemaSnapshot,
+  QuestionnaireStatus,
+  QuestionnaireType,
+} from './lib/questionnaire.types';
 import { RolesGuard } from 'src/security/guards/roles.guard';
 import { CurrentUserInterceptor } from '../common/interceptors/current-user.interceptor';
 import { AuthGuard } from '@nestjs/passport';
@@ -688,5 +692,198 @@ describe('QuestionnaireController - GetCsvTemplate', () => {
     const [headerRow, dataRow] = csv.split('\n');
 
     expect(headerRow.split(',').length).toBe(dataRow.split(',').length);
+  });
+});
+
+describe('QuestionnaireController - mutation DTO mapping', () => {
+  let controller: QuestionnaireController;
+  let questionnaireService: jest.Mocked<QuestionnaireService>;
+
+  const mockSchema: QuestionnaireSchemaSnapshot = {
+    meta: {
+      questionnaireType: 'FACULTY_IN_CLASSROOM',
+      scoringModel: 'SECTION_WEIGHTED',
+      version: 1,
+      maxScore: 5,
+    },
+    sections: [],
+  };
+
+  const mockQuestionnaire = {
+    id: 'q-1',
+    title: 'Test Questionnaire',
+    type: QuestionnaireType.FACULTY_IN_CLASSROOM,
+    status: QuestionnaireStatus.DRAFT,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+    versions: { isInitialized: () => false },
+  };
+
+  const mockVersion = {
+    id: 'v-1',
+    questionnaire: mockQuestionnaire,
+    versionNumber: 1,
+    schemaSnapshot: mockSchema,
+    isActive: false,
+    status: QuestionnaireStatus.DRAFT,
+    publishedAt: undefined,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [QuestionnaireController],
+      providers: [
+        {
+          provide: QuestionnaireService,
+          useValue: {
+            GetVersionById: jest.fn(),
+            GetAllQuestions: jest.fn(),
+            getQuestionnaireTypes: jest.fn(),
+            getVersionsByType: jest.fn(),
+            createQuestionnaire: jest.fn(),
+            CreateVersion: jest.fn(),
+            GetLatestActiveVersion: jest.fn(),
+            PublishVersion: jest.fn(),
+            DeprecateVersion: jest.fn(),
+            UpdateDraftVersion: jest.fn(),
+            submitQuestionnaire: jest.fn(),
+            CheckSubmission: jest.fn(),
+            SaveOrUpdateDraft: jest.fn(),
+            GetDraft: jest.fn(),
+            ListMyDrafts: jest.fn(),
+            DeleteDraft: jest.fn(),
+            WipeSubmissions: jest.fn(),
+          },
+        },
+        {
+          provide: IngestionEngine,
+          useValue: { processStream: jest.fn() },
+        },
+        {
+          provide: CSVAdapter,
+          useValue: new CSVAdapter(),
+        },
+      ],
+    })
+      .overrideGuard(AuthGuard('jwt'))
+      .useValue({ canActivate: () => true })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .overrideInterceptor(CurrentUserInterceptor)
+      .useValue({
+        intercept: (_ctx: ExecutionContext, next: CallHandler) => next.handle(),
+      })
+      .compile();
+
+    controller = module.get(QuestionnaireController);
+    questionnaireService = module.get(QuestionnaireService);
+  });
+
+  it('createQuestionnaire should return QuestionnaireResponseDto', async () => {
+    questionnaireService.createQuestionnaire.mockResolvedValue(
+      mockQuestionnaire as any,
+    );
+
+    const result = await controller.createQuestionnaire({
+      title: 'Test Questionnaire',
+      type: QuestionnaireType.FACULTY_IN_CLASSROOM,
+    });
+
+    expect(result).toEqual({
+      id: 'q-1',
+      title: 'Test Questionnaire',
+      type: QuestionnaireType.FACULTY_IN_CLASSROOM,
+      status: QuestionnaireStatus.DRAFT,
+    });
+    expect(result).not.toHaveProperty('createdAt');
+    expect(result).not.toHaveProperty('updatedAt');
+    expect(result).not.toHaveProperty('deletedAt');
+  });
+
+  it('createVersion should return QuestionnaireVersionDetailResponse', async () => {
+    questionnaireService.CreateVersion.mockResolvedValue(mockVersion as any);
+
+    const result = await controller.createVersion('q-1', {
+      schema: mockSchema,
+    });
+
+    expect(result).toEqual({
+      id: 'v-1',
+      questionnaireId: 'q-1',
+      questionnaireTitle: 'Test Questionnaire',
+      questionnaireType: QuestionnaireType.FACULTY_IN_CLASSROOM,
+      versionNumber: 1,
+      status: QuestionnaireStatus.DRAFT,
+      isActive: false,
+      schemaSnapshot: mockSchema,
+      publishedAt: undefined,
+      createdAt: mockVersion.createdAt,
+      updatedAt: mockVersion.updatedAt,
+    });
+    expect(result).not.toHaveProperty('deletedAt');
+    expect(result).not.toHaveProperty('questionnaire');
+  });
+
+  it('publishVersion should return QuestionnaireVersionDetailResponse', async () => {
+    const publishedVersion = {
+      ...mockVersion,
+      isActive: true,
+      status: QuestionnaireStatus.ACTIVE,
+      publishedAt: new Date(),
+    };
+    questionnaireService.PublishVersion.mockResolvedValue(
+      publishedVersion as any,
+    );
+
+    const result = await controller.publishVersion('v-1');
+
+    expect(result).toEqual({
+      id: 'v-1',
+      questionnaireId: 'q-1',
+      questionnaireTitle: 'Test Questionnaire',
+      questionnaireType: QuestionnaireType.FACULTY_IN_CLASSROOM,
+      versionNumber: 1,
+      status: QuestionnaireStatus.ACTIVE,
+      isActive: true,
+      schemaSnapshot: mockSchema,
+      publishedAt: publishedVersion.publishedAt,
+      createdAt: publishedVersion.createdAt,
+      updatedAt: publishedVersion.updatedAt,
+    });
+    expect(result).not.toHaveProperty('deletedAt');
+    expect(result).not.toHaveProperty('questionnaire');
+  });
+
+  it('deprecateVersion should return QuestionnaireVersionDetailResponse', async () => {
+    const deprecatedVersion = {
+      ...mockVersion,
+      isActive: false,
+      status: QuestionnaireStatus.DEPRECATED,
+    };
+    questionnaireService.DeprecateVersion.mockResolvedValue(
+      deprecatedVersion as any,
+    );
+
+    const result = await controller.deprecateVersion('v-1');
+
+    expect(result).toEqual({
+      id: 'v-1',
+      questionnaireId: 'q-1',
+      questionnaireTitle: 'Test Questionnaire',
+      questionnaireType: QuestionnaireType.FACULTY_IN_CLASSROOM,
+      versionNumber: 1,
+      status: QuestionnaireStatus.DEPRECATED,
+      isActive: false,
+      schemaSnapshot: mockSchema,
+      publishedAt: undefined,
+      createdAt: deprecatedVersion.createdAt,
+      updatedAt: deprecatedVersion.updatedAt,
+    });
+    expect(result).not.toHaveProperty('deletedAt');
+    expect(result).not.toHaveProperty('questionnaire');
   });
 });

--- a/src/modules/questionnaires/questionnaire.controller.ts
+++ b/src/modules/questionnaires/questionnaire.controller.ts
@@ -38,6 +38,7 @@ import { DraftResponse } from './dto/responses/draft-response.dto';
 import { CheckSubmissionQuery } from './dto/requests/check-submission-query.dto';
 import { CheckSubmissionResponse } from './dto/responses/check-submission-response.dto';
 import { SubmitQuestionnaireResponse } from './dto/responses/submit-questionnaire-response.dto';
+import { QuestionnaireResponseDto } from './dto/responses/questionnaire-response.dto';
 import { IngestionResultDto } from './ingestion/dto/ingestion-result.dto';
 import { UseJwtGuard } from 'src/security/decorators';
 import { UserRole } from '../auth/roles.enum';
@@ -91,20 +92,37 @@ export class QuestionnaireController {
 
   @Post()
   @ApiOperation({ summary: 'Create a new questionnaire' })
-  async createQuestionnaire(@Body() data: CreateQuestionnaireRequest) {
-    return this.questionnaireService.createQuestionnaire(data);
+  @ApiResponse({
+    status: 201,
+    description: 'Questionnaire created successfully',
+    type: QuestionnaireResponseDto,
+  })
+  async createQuestionnaire(
+    @Body() data: CreateQuestionnaireRequest,
+  ): Promise<QuestionnaireResponseDto> {
+    const questionnaire =
+      await this.questionnaireService.createQuestionnaire(data);
+    return QuestionnaireResponseDto.Map(questionnaire);
   }
 
   @Post(':id/versions')
   @ApiOperation({ summary: 'Create a new version for a questionnaire' })
-  @ApiResponse({ status: 201, description: 'Version created successfully' })
+  @ApiResponse({
+    status: 201,
+    description: 'Version created successfully',
+    type: QuestionnaireVersionDetailResponse,
+  })
   @ApiResponse({ status: 404, description: 'Questionnaire not found' })
   @ApiResponse({ status: 409, description: 'Draft version already exists' })
   async createVersion(
     @Param('id') id: string,
     @Body() data: CreateVersionRequest,
-  ) {
-    return this.questionnaireService.CreateVersion(id, data.schema);
+  ): Promise<QuestionnaireVersionDetailResponse> {
+    const version = await this.questionnaireService.CreateVersion(
+      id,
+      data.schema,
+    );
+    return QuestionnaireVersionDetailResponse.Map(version);
   }
 
   @Get(':id/latest-active-version')
@@ -125,23 +143,37 @@ export class QuestionnaireController {
 
   @Patch('versions/:versionId/publish')
   @ApiOperation({ summary: 'Publish a questionnaire version' })
-  @ApiResponse({ status: 200, description: 'Version published successfully' })
+  @ApiResponse({
+    status: 200,
+    description: 'Version published successfully',
+    type: QuestionnaireVersionDetailResponse,
+  })
   @ApiResponse({
     status: 400,
     description: 'Version already published or invalid schema',
   })
   @ApiResponse({ status: 404, description: 'Version not found' })
-  async publishVersion(@Param('versionId') versionId: string) {
-    return this.questionnaireService.PublishVersion(versionId);
+  async publishVersion(
+    @Param('versionId') versionId: string,
+  ): Promise<QuestionnaireVersionDetailResponse> {
+    const version = await this.questionnaireService.PublishVersion(versionId);
+    return QuestionnaireVersionDetailResponse.Map(version);
   }
 
   @Patch('versions/:versionId/deprecate')
   @ApiOperation({ summary: 'Deprecate a questionnaire version' })
-  @ApiResponse({ status: 200, description: 'Version deprecated successfully' })
+  @ApiResponse({
+    status: 200,
+    description: 'Version deprecated successfully',
+    type: QuestionnaireVersionDetailResponse,
+  })
   @ApiResponse({ status: 400, description: 'Version already deprecated' })
   @ApiResponse({ status: 404, description: 'Version not found' })
-  async deprecateVersion(@Param('versionId') versionId: string) {
-    return this.questionnaireService.DeprecateVersion(versionId);
+  async deprecateVersion(
+    @Param('versionId') versionId: string,
+  ): Promise<QuestionnaireVersionDetailResponse> {
+    const version = await this.questionnaireService.DeprecateVersion(versionId);
+    return QuestionnaireVersionDetailResponse.Map(version);
   }
 
   @Get('versions/:versionId')


### PR DESCRIPTION
## Summary

- Map raw MikroORM entities to response DTOs in 4 mutation endpoints that leaked internal schema details (soft-delete fields, relation metadata, `schemaSnapshot` bloat)
- Create `QuestionnaireResponseDto` for `POST /questionnaires`
- Reuse existing `QuestionnaireVersionDetailResponse.Map()` for version create/publish/deprecate endpoints
- Add `@ApiResponse({ type })` decorators for Swagger visibility

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] 4 new controller tests assert DTO shape (no raw entity fields leak)
- [x] All 21 controller tests pass

Closes #169