### PR TITLE
FAC-77 fix: harden boolean query parameter parsing across modules

### DIFF
--- a/src/modules/common/transforms/boolean-query.transform.spec.ts
+++ b/src/modules/common/transforms/boolean-query.transform.spec.ts
@@ -1,0 +1,45 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { IsOptional } from 'class-validator';
+import { BooleanQueryTransform } from './boolean-query.transform';
+
+class TestDto {
+  @IsOptional()
+  @BooleanQueryTransform()
+  flag?: boolean;
+}
+
+describe('BooleanQueryTransform', () => {
+  const transform = (plain: Record<string, unknown>) =>
+    plainToInstance(TestDto, plain, { enableImplicitConversion: true });
+
+  it('should transform string "true" to boolean true', () => {
+    expect(transform({ flag: 'true' }).flag).toBe(true);
+  });
+
+  it('should transform string "false" to boolean false', () => {
+    expect(transform({ flag: 'false' }).flag).toBe(false);
+  });
+
+  it('should preserve undefined when key is absent', () => {
+    expect(transform({}).flag).toBeUndefined();
+  });
+
+  it('should return undefined for explicit null', () => {
+    expect(transform({ flag: null }).flag).toBeUndefined();
+  });
+
+  it('should pass through boolean true unchanged', () => {
+    expect(transform({ flag: true }).flag).toBe(true);
+  });
+
+  it('should pass through boolean false unchanged', () => {
+    expect(transform({ flag: false }).flag).toBe(false);
+  });
+
+  it('should treat non-"true" strings as false', () => {
+    expect(transform({ flag: 'yes' }).flag).toBe(false);
+    expect(transform({ flag: '1' }).flag).toBe(false);
+    expect(transform({ flag: '' }).flag).toBe(false);
+  });
+});

--- a/src/modules/common/transforms/boolean-query.transform.ts
+++ b/src/modules/common/transforms/boolean-query.transform.ts
@@ -1,0 +1,23 @@
+import { Transform } from 'class-transformer';
+
+/**
+ * Transforms a string-typed boolean query/form parameter into a proper boolean.
+ *
+ * Three-state semantics:
+ *  - `"true"`  → `true`
+ *  - `"false"` → `false`
+ *  - absent / `undefined` / `null` → `undefined`  (preserves optionality)
+ *
+ * Works for both `@Query()` and `@Body()` (multipart form) parameters
+ * where values arrive as strings.
+ */
+export function BooleanQueryTransform() {
+  return Transform(
+    ({ obj, key }: { obj: Record<string, unknown>; key: string }) => {
+      const raw = obj[key];
+      if (raw === undefined || raw === null) return undefined;
+      if (typeof raw === 'string') return raw === 'true';
+      return raw === true;
+    },
+  );
+}

--- a/src/modules/dimensions/dto/requests/list-dimensions-query.dto.ts
+++ b/src/modules/dimensions/dto/requests/list-dimensions-query.dto.ts
@@ -1,7 +1,7 @@
 import { Type } from 'class-transformer';
 import { IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
 import { QuestionnaireType } from 'src/modules/questionnaires/lib/questionnaire.types';
-import { Transform } from 'class-transformer';
+import { BooleanQueryTransform } from 'src/modules/common/transforms/boolean-query.transform';
 
 export class ListDimensionsQueryDto {
   @IsEnum(QuestionnaireType)
@@ -9,9 +9,7 @@ export class ListDimensionsQueryDto {
   questionnaireType?: QuestionnaireType;
 
   @IsOptional()
-  @Transform(
-    ({ obj }: { obj: Record<string, unknown> }) => obj.active === 'true',
-  )
+  @BooleanQueryTransform()
   active?: boolean;
 
   @IsInt()

--- a/src/modules/questionnaires/dto/requests/ingest-csv-request.dto.ts
+++ b/src/modules/questionnaires/dto/requests/ingest-csv-request.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
+import { BooleanQueryTransform } from 'src/modules/common/transforms/boolean-query.transform';
 import {
   IsUUID,
   IsOptional,
@@ -21,11 +22,7 @@ export class IngestCsvRequestDto {
     description: 'Run in dry-run mode (validate only, no persistence)',
   })
   @IsOptional()
-  @Transform(({ obj, key }: { obj: Record<string, unknown>; key: string }) => {
-    const raw = obj[key];
-    if (typeof raw === 'string') return raw === 'true';
-    return raw === true;
-  })
+  @BooleanQueryTransform()
   @IsBoolean()
   dryRun?: boolean;
 


### PR DESCRIPTION
## Summary

- Extract shared `BooleanQueryTransform()` decorator that preserves three-state semantics (`true` | `false` | `undefined`) for optional boolean query/form parameters
- Replace ad-hoc inline `@Transform` logic in `ListDimensionsQueryDto.active` and `IngestCsvRequestDto.dryRun` with the shared utility
- Prevents the coercion bug (FAC-75 class) where absent params were silently treated as `false`

## Test plan

- [x] Unit tests for `BooleanQueryTransform` cover all 7 input states (string true/false, absent, null, boolean true/false, non-"true" strings)
- [x] Existing `ListDimensionsQueryDto` tests pass (active=true, active=false, active=undefined)
- [x] Existing `DimensionsService` tests pass
- [x] Existing `QuestionnaireController` tests pass

Closes #173