### PR TITLE
FAC-78 fix: enrollments endpoint uses raw query params without validation DTO

### DIFF
--- a/src/modules/common/dto/pagination-query.dto.ts
+++ b/src/modules/common/dto/pagination-query.dto.ts
@@ -1,0 +1,20 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class PaginationQueryDto {
+  @ApiPropertyOptional({ default: 1, minimum: 1 })
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  @Type(() => Number)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 10, minimum: 1, maximum: 100 })
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @IsOptional()
+  @Type(() => Number)
+  limit?: number = 10;
+}

--- a/src/modules/enrollments/dto/requests/my-enrollments-query.dto.ts
+++ b/src/modules/enrollments/dto/requests/my-enrollments-query.dto.ts
@@ -1,0 +1,3 @@
+import { PaginationQueryDto } from 'src/modules/common/dto/pagination-query.dto';
+
+export class MyEnrollmentsQueryDto extends PaginationQueryDto {}

--- a/src/modules/enrollments/enrollments.controller.ts
+++ b/src/modules/enrollments/enrollments.controller.ts
@@ -4,6 +4,7 @@ import { UseJwtGuard } from 'src/security/decorators';
 import { CurrentUserInterceptor } from '../common/interceptors/current-user.interceptor';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { MyEnrollmentsResponseDto } from './dto/responses/my-enrollments.response.dto';
+import { MyEnrollmentsQueryDto } from './dto/requests/my-enrollments-query.dto';
 
 @ApiTags('enrollments')
 @Controller('enrollments')
@@ -15,12 +16,8 @@ export class EnrollmentsController {
   @Get('me')
   @ApiOperation({ summary: "Get current user's enrolled courses" })
   async getMyEnrollments(
-    @Query('page') page: number = 1,
-    @Query('limit') limit: number = 10,
+    @Query() query: MyEnrollmentsQueryDto,
   ): Promise<MyEnrollmentsResponseDto> {
-    return await this.enrollmentsService.getMyEnrollments(
-      Number(page),
-      Number(limit),
-    );
+    return await this.enrollmentsService.getMyEnrollments(query);
   }
 }

--- a/src/modules/enrollments/enrollments.service.spec.ts
+++ b/src/modules/enrollments/enrollments.service.spec.ts
@@ -97,7 +97,7 @@ describe('EnrollmentsService', () => {
       .mockResolvedValueOnce(mockFacultyEnrollments)
       .mockResolvedValueOnce([]);
 
-    const result = await service.getMyEnrollments(1, 10);
+    const result = await service.getMyEnrollments({ page: 1, limit: 10 });
 
     expect(result.data).toHaveLength(1);
     expect(result.data[0].id).toBe('e1');
@@ -160,7 +160,7 @@ describe('EnrollmentsService', () => {
       .mockResolvedValueOnce([]) // faculty
       .mockResolvedValueOnce(mockSubmissions); // submissions
 
-    const result = await service.getMyEnrollments(1, 10);
+    const result = await service.getMyEnrollments({ page: 1, limit: 10 });
 
     expect(result.data[0].submission).toEqual({
       submitted: true,
@@ -196,7 +196,7 @@ describe('EnrollmentsService', () => {
     (em.findAndCount as jest.Mock).mockResolvedValue([mockEnrollments, 1]);
     (em.find as jest.Mock).mockResolvedValue([]);
 
-    const result = await service.getMyEnrollments(1, 10);
+    const result = await service.getMyEnrollments({ page: 1, limit: 10 });
 
     expect(result.data[0].faculty).toBeNull();
   });
@@ -220,7 +220,7 @@ describe('EnrollmentsService', () => {
     (em.findAndCount as jest.Mock).mockResolvedValue([mockEnrollments, 1]);
     (em.find as jest.Mock).mockResolvedValue([]);
 
-    const result = await service.getMyEnrollments(1, 10);
+    const result = await service.getMyEnrollments({ page: 1, limit: 10 });
 
     expect(result.data[0].semester).toBeNull();
   });
@@ -228,7 +228,7 @@ describe('EnrollmentsService', () => {
   it('should not query faculty or submissions when no enrollments exist', async () => {
     (em.findAndCount as jest.Mock).mockResolvedValue([[], 0]);
 
-    const result = await service.getMyEnrollments(1, 10);
+    const result = await service.getMyEnrollments({ page: 1, limit: 10 });
 
     expect(result.data).toHaveLength(0);
     // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/src/modules/enrollments/enrollments.service.ts
+++ b/src/modules/enrollments/enrollments.service.ts
@@ -5,6 +5,7 @@ import { QuestionnaireSubmission } from 'src/entities/questionnaire-submission.e
 import { CacheService } from '../common/cache/cache.service';
 import { CacheNamespace } from '../common/cache/cache-namespaces';
 import { CurrentUserService } from '../common/cls/current-user.service';
+import { MyEnrollmentsQueryDto } from './dto/requests/my-enrollments-query.dto';
 import { FacultyShortResponseDto } from './dto/responses/faculty-short.response.dto';
 import { MyEnrollmentsResponseDto } from './dto/responses/my-enrollments.response.dto';
 
@@ -17,9 +18,9 @@ export class EnrollmentsService {
   ) {}
 
   async getMyEnrollments(
-    page: number,
-    limit: number,
+    query: MyEnrollmentsQueryDto,
   ): Promise<MyEnrollmentsResponseDto> {
+    const { page = 1, limit = 10 } = query;
     const user = this.currentUserService.getOrFail();
     return this.cacheService.wrap(
       CacheNamespace.ENROLLMENTS_ME,


### PR DESCRIPTION
## Summary

- Extract shared `PaginationQueryDto` base class with `@IsInt()`, `@Min(1)`, `@Max(100)`, and `@Type(() => Number)` validation
- Create `MyEnrollmentsQueryDto` extending the base and wire it into the enrollments controller/service
- Remove manual `Number()` coercion — DTO handles transformation via class-transformer

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] All 6 enrollments unit tests pass with updated DTO signatures
- [x] `?page=abc` returns 400
- [x] `?limit=-5` returns 400
- [x] `?limit=999999` returns 400 (exceeds `@Max(100)`)
- [x] `?page=2&limit=20` works normally
- [x] No query params defaults to page=1, limit=10

Closes #171