### PR TITLE
Release March 26, 2026

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,10 +72,15 @@ The app uses a split between **Infrastructure** and **Application** modules (`sr
 - Extend `BaseJob` class which provides startup execution and graceful shutdown
 - Jobs register results in `StartupJobRegistry` for boot summary
 - **Active jobs:**
-  - `CategorySyncJob`: Syncs Moodle categories to local hierarchy
-  - `CourseSyncJob`: Syncs Moodle courses
-  - `EnrollmentSyncJob`: Syncs user-course enrollments
   - `RefreshTokenCleanupJob`: Purges expired refresh tokens every 12 hours (7-day retention)
+
+**Moodle Sync Scheduling** (`src/modules/moodle/schedulers/`):
+
+- Dynamic cron via `SchedulerRegistry` (no static `@Cron()` decorator)
+- Interval resolves: DB (`SystemConfig`) > env var (`MOODLE_SYNC_INTERVAL_MINUTES`) > per-env default
+- Admin-configurable at runtime via `PUT /moodle/sync/schedule` (min 30 minutes)
+- `SyncLog` entity tracks every sync with per-phase metrics (fetched, inserted, updated, deactivated)
+- `SyncLog` does NOT extend `CustomBaseEntity` — queries must use `filters: { softDelete: false }`
 
 ### Analysis Job Queue
 
@@ -164,3 +169,4 @@ Optional:
 - `BULLMQ_HTTP_TIMEOUT_MS`: HTTP request timeout in ms (default: `90000`)
 - `BULLMQ_SENTIMENT_CONCURRENCY`: Sentiment processor concurrency (default: `3`)
 - `SENTIMENT_WORKER_URL`: RunPod/mock worker URL for sentiment analysis
+- `MOODLE_SYNC_INTERVAL_MINUTES`: Sync schedule interval in minutes (min `30`; defaults per env: dev=60, staging=360, prod=180)

--- a/docs/architecture/core-components.md
+++ b/docs/architecture/core-components.md
@@ -139,12 +139,12 @@ Priority ranges: `0-99` core auth, `100-199` external providers, `200+` fallback
 
 Institutional sync (categories, courses, enrollments) uses a BullMQ-based composite job instead of individual cron jobs. See [Institutional Sync Workflow](../workflows/institutional-sync.md) for the full flow.
 
-| Component              | Purpose                                                                             |
-| ---------------------- | ----------------------------------------------------------------------------------- |
-| `MoodleStartupService` | Blocking startup orchestrator — categories always, courses/enrollments gated by env |
-| `MoodleSyncProcessor`  | BullMQ processor — runs categories → courses → enrollments in sequence              |
-| `MoodleSyncScheduler`  | Hourly `@Cron` that enqueues a composite sync job (fixed `jobId` for deduplication) |
-| `MoodleSyncController` | `POST /moodle/sync` (manual trigger), `GET /moodle/sync/status` (queue state)       |
+| Component              | Purpose                                                                                                      |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `MoodleStartupService` | Blocking startup orchestrator — categories always, courses/enrollments gated by env                          |
+| `MoodleSyncProcessor`  | BullMQ processor — runs categories → courses → enrollments; creates/updates `SyncLog` with per-phase metrics |
+| `MoodleSyncScheduler`  | Dynamic `SchedulerRegistry`-based cron (env-aware, admin-configurable via `SystemConfig`)                    |
+| `MoodleSyncController` | Sync trigger, status, paginated history, schedule get/update — all SUPER_ADMIN only                          |
 
 Phase dependency: if categories fail, courses and enrollments are skipped. If courses fail, enrollments are skipped.
 

--- a/docs/decisions/decisions.md
+++ b/docs/decisions/decisions.md
@@ -227,6 +227,16 @@ The `UserInstitutionalRole` entity gains a `source` field (`auto` | `manual`) to
 - **Cleanup:** When a manual DEAN exists at a department, any CHAIRPERSON roles at child programs are automatically removed during hydration to prevent redundant roles.
 - **Trade-off:** Deans require a one-time manual promotion by an admin. This is accepted because Deans are fewer in number and the Moodle API provides no reliable way to auto-detect the distinction.
 
+## 33. Dynamic Sync Scheduling with SyncLog Observability
+
+The `MoodleSyncScheduler` was rewritten from a static `@Cron(CronExpression.EVERY_HOUR)` decorator to a dynamic `SchedulerRegistry`-based approach, paired with a `SyncLog` audit entity.
+
+- **Dynamic scheduling:** The scheduler implements `OnModuleInit` and registers a `CronJob` via `SchedulerRegistry` at startup. The interval resolves from DB (`SystemConfig`) > env var (`MOODLE_SYNC_INTERVAL_MINUTES`) > per-environment default (dev: 60 min, staging: 360 min, production: 180 min). Super admins can update the interval at runtime via `PUT /moodle/sync/schedule`, which persists to `SystemConfig` and replaces the running cron job.
+- **Minimum interval:** 30 minutes, enforced at the DTO validation layer (`@Min(30)`), the Zod env schema (`.min(30)`), and the DB resolution path (values below 30 are ignored).
+- **SyncLog entity:** Does not extend `CustomBaseEntity` (no `deletedAt` — audit records are never soft-deleted). Stores per-phase `SyncPhaseResult` as JSONB (fetched, inserted, updated, deactivated, errors, durationMs). Insert vs update counts use a count-before/after strategy — one extra `COUNT` query per phase, no per-record overhead.
+- **Soft-delete filter bypass:** Since `SyncLog` has no `deletedAt` column, MikroORM's global `softDelete` filter would fail at query time. Queries must use `filters: { softDelete: false }`. The `@Filter` decorator approach (`cond: {}, default: false`) was found to be insufficient at runtime.
+- **Trade-off:** Admin schedule changes don't survive process restarts unless persisted to the database (which they are, via `SystemConfig`). The scheduler reads from DB on init, so restarts pick up the latest admin-configured interval.
+
 ## 30. Semester Code Parsing for Display Labels
 
 The Moodle category sync now parses semester codes (e.g., `S22526`) into human-readable `label` ("Semester 2") and `academicYear` ("2025-2026") fields on the `Semester` entity.

--- a/docs/workflows/institutional-sync.md
+++ b/docs/workflows/institutional-sync.md
@@ -4,11 +4,21 @@ The system synchronizes institutional data (categories, courses, enrollments) fr
 
 ## Trigger Points
 
-| Trigger         | Mechanism                          | Behavior                                                                 |
-| --------------- | ---------------------------------- | ------------------------------------------------------------------------ |
-| **Startup**     | `MoodleStartupService` (blocking)  | Categories always sync; courses + enrollments gated by `SYNC_ON_STARTUP` |
-| **Hourly cron** | `MoodleSyncScheduler` → BullMQ job | Full sync (categories → courses → enrollments)                           |
-| **Manual**      | `POST /moodle/sync` (superadmin)   | Same as cron; returns `{ jobId }` or 409 if already running              |
+| Trigger            | Mechanism                          | Behavior                                                                 |
+| ------------------ | ---------------------------------- | ------------------------------------------------------------------------ |
+| **Startup**        | `MoodleStartupService` (blocking)  | Categories always sync; courses + enrollments gated by `SYNC_ON_STARTUP` |
+| **Scheduled cron** | `MoodleSyncScheduler` → BullMQ job | Full sync (categories → courses → enrollments)                           |
+| **Manual**         | `POST /moodle/sync` (superadmin)   | Same as cron; returns `{ jobId }` or 409 if already running              |
+
+### Schedule Resolution
+
+The scheduler uses dynamic cron via `SchedulerRegistry` (no static `@Cron()` decorator). The interval is resolved at startup in priority order:
+
+1. **Database** — `SystemConfig` key `MOODLE_SYNC_INTERVAL_MINUTES` (admin override via `PUT /moodle/sync/schedule`)
+2. **Environment variable** — `MOODLE_SYNC_INTERVAL_MINUTES`
+3. **Per-environment default** — dev/test: 60 min, staging: 360 min, production: 180 min
+
+Minimum interval is **30 minutes** (enforced at all three layers). The interval is converted to a cron expression internally via `minutesToCron()`.
 
 ## Pipeline Flow
 
@@ -48,12 +58,37 @@ Uses a 3-phase architecture to avoid deadlocks from overlapping user rows:
 
 No additional Moodle API calls are needed for sections — group data is already returned by the enrolled users endpoint.
 
+## Observability — SyncLog
+
+Every sync execution (scheduled, manual, startup) creates a `SyncLog` record in the database. The processor creates it at job start (`status: running`) and updates it after each phase and on completion.
+
+Each phase stores a `SyncPhaseResult` (JSONB) with:
+
+| Field         | Description                                       |
+| ------------- | ------------------------------------------------- |
+| `status`      | `success`, `failed`, or `skipped`                 |
+| `durationMs`  | Wall-clock time for the phase                     |
+| `fetched`     | Remote records received from Moodle               |
+| `inserted`    | New records created (count-before/after strategy) |
+| `updated`     | Existing records updated via upsert               |
+| `deactivated` | Records soft-deactivated (missing from remote)    |
+| `errors`      | Per-item error count within the phase             |
+
+Overall sync status: `completed` (all phases succeeded), `partial` (some failed/skipped), or `failed` (all failed).
+
+Manual syncs record `triggeredBy` (FK to User) via CLS (`CurrentUserService`).
+
+The `SyncLog` entity does **not** extend `CustomBaseEntity` — audit records are never soft-deleted. Queries must use `filters: { softDelete: false }` to bypass the global MikroORM filter.
+
 ## Endpoints
 
-| Method | Path                  | Auth        | Description                                |
-| ------ | --------------------- | ----------- | ------------------------------------------ |
-| POST   | `/moodle/sync`        | SUPER_ADMIN | Trigger sync (409 if already running)      |
-| GET    | `/moodle/sync/status` | SUPER_ADMIN | Queue state: `idle`, `active`, or `queued` |
+| Method | Path                    | Auth        | Description                                               |
+| ------ | ----------------------- | ----------- | --------------------------------------------------------- |
+| POST   | `/moodle/sync`          | SUPER_ADMIN | Trigger sync (409 if already running)                     |
+| GET    | `/moodle/sync/status`   | SUPER_ADMIN | Queue state: `idle`, `active`, or `queued`                |
+| GET    | `/moodle/sync/history`  | SUPER_ADMIN | Paginated sync log history with per-phase metrics         |
+| GET    | `/moodle/sync/schedule` | SUPER_ADMIN | Current interval (minutes), resolved cron, next execution |
+| PUT    | `/moodle/sync/schedule` | SUPER_ADMIN | Update interval in minutes (min 30), persists to DB       |
 
 ## Deduplication
 
@@ -63,8 +98,9 @@ No additional Moodle API calls are needed for sections — group data is already
 
 ## Environment Variables
 
-| Variable                           | Default | Purpose                                 |
-| ---------------------------------- | ------- | --------------------------------------- |
-| `SYNC_ON_STARTUP`                  | `false` | Enable course + enrollment sync at boot |
-| `DISABLE_SYNC_CATEGORY_ON_STARTUP` | `false` | Skip category sync at boot (dev only)   |
-| `MOODLE_SYNC_CONCURRENCY`          | `3`     | Max concurrent Moodle HTTP calls (1-20) |
+| Variable                           | Default | Purpose                                                        |
+| ---------------------------------- | ------- | -------------------------------------------------------------- |
+| `SYNC_ON_STARTUP`                  | `false` | Enable course + enrollment sync at boot                        |
+| `DISABLE_SYNC_CATEGORY_ON_STARTUP` | `false` | Skip category sync at boot (dev only)                          |
+| `MOODLE_SYNC_CONCURRENCY`          | `3`     | Max concurrent Moodle HTTP calls (1-20)                        |
+| `MOODLE_SYNC_INTERVAL_MINUTES`     | —       | Override sync interval (min 30); per-env default used if unset |

--- a/src/configurations/env/moodle.env.ts
+++ b/src/configurations/env/moodle.env.ts
@@ -4,6 +4,7 @@ export const moodleEnvSchema = z.object({
   MOODLE_BASE_URL: z.url(),
   MOODLE_MASTER_KEY: z.string(),
   MOODLE_SYNC_CONCURRENCY: z.coerce.number().min(1).max(20).default(3),
+  MOODLE_SYNC_INTERVAL_MINUTES: z.coerce.number().min(30).optional(),
 });
 
 export type MoodleEnv = z.infer<typeof moodleEnvSchema>;

--- a/src/entities/index.entity.ts
+++ b/src/entities/index.entity.ts
@@ -28,6 +28,7 @@ import { Topic } from './topic.entity';
 import { TopicAssignment } from './topic-assignment.entity';
 import { Section } from './section.entity';
 import { TopicModelRun } from './topic-model-run.entity';
+import { SyncLog } from './sync-log.entity';
 
 export {
   ChatKitThread,
@@ -60,6 +61,7 @@ export {
   Topic,
   TopicAssignment,
   TopicModelRun,
+  SyncLog,
 };
 
 export const entities = [
@@ -93,4 +95,5 @@ export const entities = [
   Topic,
   TopicAssignment,
   TopicModelRun,
+  SyncLog,
 ];

--- a/src/entities/sync-log.entity.ts
+++ b/src/entities/sync-log.entity.ts
@@ -1,0 +1,60 @@
+import {
+  Entity,
+  Index,
+  ManyToOne,
+  Opt,
+  PrimaryKey,
+  Property,
+} from '@mikro-orm/core';
+import { v4 } from 'uuid';
+import { User } from './user.entity';
+import type {
+  SyncPhaseResult,
+  SyncStatus,
+  SyncTrigger,
+} from '../modules/moodle/lib/sync-result.types';
+
+// No deletedAt — audit records are never soft-deleted.
+// Queries must use `filters: { softDelete: false }` to bypass the global filter.
+@Entity()
+export class SyncLog {
+  @PrimaryKey()
+  id: string & Opt = v4();
+
+  @Property()
+  trigger!: SyncTrigger;
+
+  @ManyToOne(() => User, { nullable: true })
+  triggeredBy?: User;
+
+  @Property()
+  status: SyncStatus & Opt = 'running';
+
+  @Index()
+  @Property()
+  startedAt: Date & Opt = new Date();
+
+  @Property({ nullable: true })
+  completedAt?: Date;
+
+  @Property({ nullable: true })
+  durationMs?: number;
+
+  @Property({ type: 'jsonb', nullable: true })
+  categories?: SyncPhaseResult;
+
+  @Property({ type: 'jsonb', nullable: true })
+  courses?: SyncPhaseResult;
+
+  @Property({ type: 'jsonb', nullable: true })
+  enrollments?: SyncPhaseResult;
+
+  @Property({ type: 'text', nullable: true })
+  errorMessage?: string;
+
+  @Property({ nullable: true })
+  jobId?: string;
+
+  @Property({ nullable: true })
+  cronExpression?: string;
+}

--- a/src/migrations/.snapshot-faculytics_db.json
+++ b/src/migrations/.snapshot-faculytics_db.json
@@ -1939,6 +1939,177 @@
           "length": 255,
           "mappedType": "string"
         },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 255,
+          "mappedType": "string"
+        },
+        "triggered_by_id": {
+          "name": "triggered_by_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "length": 255,
+          "mappedType": "string"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 255,
+          "default": "'running'",
+          "mappedType": "string"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 6,
+          "mappedType": "datetime"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "length": 6,
+          "mappedType": "datetime"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "int",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "integer"
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
+        },
+        "courses": {
+          "name": "courses",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
+        },
+        "enrollments": {
+          "name": "enrollments",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "text"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "length": 255,
+          "mappedType": "string"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "length": 255,
+          "mappedType": "string"
+        }
+      },
+      "name": "sync_log",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "started_at"
+          ],
+          "composite": false,
+          "keyName": "sync_log_started_at_index",
+          "constraint": false,
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "sync_log_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "sync_log_triggered_by_id_foreign": {
+          "constraintName": "sync_log_triggered_by_id_foreign",
+          "columnNames": [
+            "triggered_by_id"
+          ],
+          "localTableName": "public.sync_log",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.user",
+          "deleteRule": "set null",
+          "updateRule": "cascade"
+        }
+      },
+      "nativeEnums": {}
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 255,
+          "mappedType": "string"
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamptz",
@@ -2008,7 +2179,8 @@
           "nullable": false,
           "enumItems": [
             "STUDENT",
-            "DEAN"
+            "DEAN",
+            "CHAIRPERSON"
           ],
           "mappedType": "enum"
         },
@@ -5039,6 +5211,17 @@
           "primary": false,
           "nullable": false,
           "length": 255,
+          "mappedType": "string"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 255,
+          "default": "'auto'",
           "mappedType": "string"
         }
       },

--- a/src/migrations/Migration20260325121432.ts
+++ b/src/migrations/Migration20260325121432.ts
@@ -1,0 +1,16 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260325121432 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table "sync_log" ("id" varchar(255) not null, "trigger" varchar(255) not null, "triggered_by_id" varchar(255) null, "status" varchar(255) not null default 'running', "started_at" timestamptz not null, "completed_at" timestamptz null, "duration_ms" int null, "categories" jsonb null, "courses" jsonb null, "enrollments" jsonb null, "error_message" text null, "job_id" varchar(255) null, "cron_expression" varchar(255) null, constraint "sync_log_pkey" primary key ("id"));`);
+    this.addSql(`create index "sync_log_started_at_index" on "sync_log" ("started_at");`);
+
+    this.addSql(`alter table "sync_log" add constraint "sync_log_triggered_by_id_foreign" foreign key ("triggered_by_id") references "user" ("id") on update cascade on delete set null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "sync_log" cascade;`);
+  }
+
+}

--- a/src/modules/common/dto/pagination-query.dto.ts
+++ b/src/modules/common/dto/pagination-query.dto.ts
@@ -1,0 +1,20 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class PaginationQueryDto {
+  @ApiPropertyOptional({ default: 1, minimum: 1 })
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  @Type(() => Number)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 10, minimum: 1, maximum: 100 })
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @IsOptional()
+  @Type(() => Number)
+  limit?: number = 10;
+}

--- a/src/modules/common/transforms/boolean-query.transform.spec.ts
+++ b/src/modules/common/transforms/boolean-query.transform.spec.ts
@@ -1,0 +1,45 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { IsOptional } from 'class-validator';
+import { BooleanQueryTransform } from './boolean-query.transform';
+
+class TestDto {
+  @IsOptional()
+  @BooleanQueryTransform()
+  flag?: boolean;
+}
+
+describe('BooleanQueryTransform', () => {
+  const transform = (plain: Record<string, unknown>) =>
+    plainToInstance(TestDto, plain, { enableImplicitConversion: true });
+
+  it('should transform string "true" to boolean true', () => {
+    expect(transform({ flag: 'true' }).flag).toBe(true);
+  });
+
+  it('should transform string "false" to boolean false', () => {
+    expect(transform({ flag: 'false' }).flag).toBe(false);
+  });
+
+  it('should preserve undefined when key is absent', () => {
+    expect(transform({}).flag).toBeUndefined();
+  });
+
+  it('should return undefined for explicit null', () => {
+    expect(transform({ flag: null }).flag).toBeUndefined();
+  });
+
+  it('should pass through boolean true unchanged', () => {
+    expect(transform({ flag: true }).flag).toBe(true);
+  });
+
+  it('should pass through boolean false unchanged', () => {
+    expect(transform({ flag: false }).flag).toBe(false);
+  });
+
+  it('should treat non-"true" strings as false', () => {
+    expect(transform({ flag: 'yes' }).flag).toBe(false);
+    expect(transform({ flag: '1' }).flag).toBe(false);
+    expect(transform({ flag: '' }).flag).toBe(false);
+  });
+});

--- a/src/modules/common/transforms/boolean-query.transform.ts
+++ b/src/modules/common/transforms/boolean-query.transform.ts
@@ -1,0 +1,23 @@
+import { Transform } from 'class-transformer';
+
+/**
+ * Transforms a string-typed boolean query/form parameter into a proper boolean.
+ *
+ * Three-state semantics:
+ *  - `"true"`  → `true`
+ *  - `"false"` → `false`
+ *  - absent / `undefined` / `null` → `undefined`  (preserves optionality)
+ *
+ * Works for both `@Query()` and `@Body()` (multipart form) parameters
+ * where values arrive as strings.
+ */
+export function BooleanQueryTransform() {
+  return Transform(
+    ({ obj, key }: { obj: Record<string, unknown>; key: string }) => {
+      const raw = obj[key];
+      if (raw === undefined || raw === null) return undefined;
+      if (typeof raw === 'string') return raw === 'true';
+      return raw === true;
+    },
+  );
+}

--- a/src/modules/dimensions/dto/requests/list-dimensions-query.dto.spec.ts
+++ b/src/modules/dimensions/dto/requests/list-dimensions-query.dto.spec.ts
@@ -1,0 +1,25 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { ListDimensionsQueryDto } from './list-dimensions-query.dto';
+
+describe('ListDimensionsQueryDto', () => {
+  const transform = (plain: Record<string, unknown>) =>
+    plainToInstance(ListDimensionsQueryDto, plain, {
+      enableImplicitConversion: true,
+    });
+
+  it('should parse active=true as boolean true', () => {
+    const dto = transform({ active: 'true' });
+    expect(dto.active).toBe(true);
+  });
+
+  it('should parse active=false as boolean false', () => {
+    const dto = transform({ active: 'false' });
+    expect(dto.active).toBe(false);
+  });
+
+  it('should leave active undefined when not provided', () => {
+    const dto = transform({});
+    expect(dto.active).toBeUndefined();
+  });
+});

--- a/src/modules/dimensions/dto/requests/list-dimensions-query.dto.ts
+++ b/src/modules/dimensions/dto/requests/list-dimensions-query.dto.ts
@@ -1,7 +1,7 @@
 import { Type } from 'class-transformer';
 import { IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
 import { QuestionnaireType } from 'src/modules/questionnaires/lib/questionnaire.types';
-import { Transform } from 'class-transformer';
+import { BooleanQueryTransform } from 'src/modules/common/transforms/boolean-query.transform';
 
 export class ListDimensionsQueryDto {
   @IsEnum(QuestionnaireType)
@@ -9,7 +9,7 @@ export class ListDimensionsQueryDto {
   questionnaireType?: QuestionnaireType;
 
   @IsOptional()
-  @Transform(({ value }) => value === 'true' || value === true)
+  @BooleanQueryTransform()
   active?: boolean;
 
   @IsInt()

--- a/src/modules/dimensions/services/dimensions.service.spec.ts
+++ b/src/modules/dimensions/services/dimensions.service.spec.ts
@@ -141,13 +141,24 @@ describe('DimensionsService', () => {
       );
     });
 
-    it('should apply active filter', async () => {
+    it('should apply active=true filter', async () => {
       dimensionRepository.findAndCount.mockResolvedValue([[], 0]);
 
       await service.findAll({ active: true, page: 1, limit: 20 });
 
       expect(dimensionRepository.findAndCount).toHaveBeenCalledWith(
         { active: true },
+        expect.anything(),
+      );
+    });
+
+    it('should apply active=false filter', async () => {
+      dimensionRepository.findAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({ active: false, page: 1, limit: 20 });
+
+      expect(dimensionRepository.findAndCount).toHaveBeenCalledWith(
+        { active: false },
         expect.anything(),
       );
     });

--- a/src/modules/enrollments/dto/requests/my-enrollments-query.dto.ts
+++ b/src/modules/enrollments/dto/requests/my-enrollments-query.dto.ts
@@ -1,0 +1,3 @@
+import { PaginationQueryDto } from 'src/modules/common/dto/pagination-query.dto';
+
+export class MyEnrollmentsQueryDto extends PaginationQueryDto {}

--- a/src/modules/enrollments/dto/responses/enrollment.response.dto.ts
+++ b/src/modules/enrollments/dto/responses/enrollment.response.dto.ts
@@ -36,6 +36,14 @@ export class SectionShortResponseDto {
   name: string;
 }
 
+export class SubmissionStatusDto {
+  @ApiProperty()
+  submitted: boolean;
+
+  @ApiPropertyOptional()
+  submittedAt?: Date;
+}
+
 export class EnrollmentResponseDto {
   @ApiProperty()
   @IsString()
@@ -56,4 +64,7 @@ export class EnrollmentResponseDto {
 
   @ApiPropertyOptional({ type: SectionShortResponseDto, nullable: true })
   section: SectionShortResponseDto | null;
+
+  @ApiProperty({ type: SubmissionStatusDto })
+  submission: SubmissionStatusDto;
 }

--- a/src/modules/enrollments/enrollments.controller.ts
+++ b/src/modules/enrollments/enrollments.controller.ts
@@ -4,6 +4,7 @@ import { UseJwtGuard } from 'src/security/decorators';
 import { CurrentUserInterceptor } from '../common/interceptors/current-user.interceptor';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { MyEnrollmentsResponseDto } from './dto/responses/my-enrollments.response.dto';
+import { MyEnrollmentsQueryDto } from './dto/requests/my-enrollments-query.dto';
 
 @ApiTags('enrollments')
 @Controller('enrollments')
@@ -15,12 +16,8 @@ export class EnrollmentsController {
   @Get('me')
   @ApiOperation({ summary: "Get current user's enrolled courses" })
   async getMyEnrollments(
-    @Query('page') page: number = 1,
-    @Query('limit') limit: number = 10,
+    @Query() query: MyEnrollmentsQueryDto,
   ): Promise<MyEnrollmentsResponseDto> {
-    return await this.enrollmentsService.getMyEnrollments(
-      Number(page),
-      Number(limit),
-    );
+    return await this.enrollmentsService.getMyEnrollments(query);
   }
 }

--- a/src/modules/enrollments/enrollments.module.ts
+++ b/src/modules/enrollments/enrollments.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { Enrollment } from 'src/entities/enrollment.entity';
 import { Course } from 'src/entities/course.entity';
+import { QuestionnaireSubmission } from 'src/entities/questionnaire-submission.entity';
 import { EnrollmentsController } from './enrollments.controller';
 import { EnrollmentsService } from './enrollments.service';
 import { CommonModule } from '../common/common.module';
@@ -9,7 +10,7 @@ import DataLoaderModule from '../common/data-loaders/index.module';
 
 @Module({
   imports: [
-    MikroOrmModule.forFeature([Enrollment, Course]),
+    MikroOrmModule.forFeature([Enrollment, Course, QuestionnaireSubmission]),
     CommonModule,
     DataLoaderModule,
   ],

--- a/src/modules/enrollments/enrollments.service.spec.ts
+++ b/src/modules/enrollments/enrollments.service.spec.ts
@@ -92,9 +92,12 @@ describe('EnrollmentsService', () => {
     ];
 
     (em.findAndCount as jest.Mock).mockResolvedValue([mockEnrollments, 1]);
-    (em.find as jest.Mock).mockResolvedValue(mockFacultyEnrollments);
+    // Promise.all order: getFacultyByCourseIds first, getSubmissionStatusByCourseIds second
+    (em.find as jest.Mock)
+      .mockResolvedValueOnce(mockFacultyEnrollments)
+      .mockResolvedValueOnce([]);
 
-    const result = await service.getMyEnrollments(1, 10);
+    const result = await service.getMyEnrollments({ page: 1, limit: 10 });
 
     expect(result.data).toHaveLength(1);
     expect(result.data[0].id).toBe('e1');
@@ -110,6 +113,7 @@ describe('EnrollmentsService', () => {
       label: '1st Semester',
       academicYear: '2025-2026',
     });
+    expect(result.data[0].submission).toEqual({ submitted: false });
     expect(result.meta.totalItems).toBe(1);
     expect(result.meta.totalPages).toBe(1);
     // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -121,6 +125,47 @@ describe('EnrollmentsService', () => {
         offset: 0,
       }),
     );
+  });
+
+  it('should return submission status when submissions exist', async () => {
+    const submittedAt = new Date('2026-03-20T10:00:00Z');
+    const mockEnrollments = [
+      {
+        id: 'e1',
+        role: 'student',
+        course: {
+          id: 'c1',
+          moodleCourseId: 101,
+          shortname: 'CS101',
+          fullname: 'Intro to CS',
+          courseImage: null,
+          program: {
+            department: {
+              semester: {
+                id: 'sem-1',
+                code: 'S12526',
+                label: '1st Semester',
+                academicYear: '2025-2026',
+              },
+            },
+          },
+        },
+      },
+    ];
+
+    const mockSubmissions = [{ course: { id: 'c1' }, submittedAt }];
+
+    (em.findAndCount as jest.Mock).mockResolvedValue([mockEnrollments, 1]);
+    (em.find as jest.Mock)
+      .mockResolvedValueOnce([]) // faculty
+      .mockResolvedValueOnce(mockSubmissions); // submissions
+
+    const result = await service.getMyEnrollments({ page: 1, limit: 10 });
+
+    expect(result.data[0].submission).toEqual({
+      submitted: true,
+      submittedAt,
+    });
   });
 
   it('should return null faculty when no faculty enrolled in course', async () => {
@@ -151,7 +196,7 @@ describe('EnrollmentsService', () => {
     (em.findAndCount as jest.Mock).mockResolvedValue([mockEnrollments, 1]);
     (em.find as jest.Mock).mockResolvedValue([]);
 
-    const result = await service.getMyEnrollments(1, 10);
+    const result = await service.getMyEnrollments({ page: 1, limit: 10 });
 
     expect(result.data[0].faculty).toBeNull();
   });
@@ -175,15 +220,15 @@ describe('EnrollmentsService', () => {
     (em.findAndCount as jest.Mock).mockResolvedValue([mockEnrollments, 1]);
     (em.find as jest.Mock).mockResolvedValue([]);
 
-    const result = await service.getMyEnrollments(1, 10);
+    const result = await service.getMyEnrollments({ page: 1, limit: 10 });
 
     expect(result.data[0].semester).toBeNull();
   });
 
-  it('should not query faculty when no enrollments exist', async () => {
+  it('should not query faculty or submissions when no enrollments exist', async () => {
     (em.findAndCount as jest.Mock).mockResolvedValue([[], 0]);
 
-    const result = await service.getMyEnrollments(1, 10);
+    const result = await service.getMyEnrollments({ page: 1, limit: 10 });
 
     expect(result.data).toHaveLength(0);
     // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/src/modules/enrollments/enrollments.service.ts
+++ b/src/modules/enrollments/enrollments.service.ts
@@ -1,9 +1,11 @@
 import { EntityManager } from '@mikro-orm/core';
 import { Injectable } from '@nestjs/common';
 import { Enrollment } from 'src/entities/enrollment.entity';
+import { QuestionnaireSubmission } from 'src/entities/questionnaire-submission.entity';
 import { CacheService } from '../common/cache/cache.service';
 import { CacheNamespace } from '../common/cache/cache-namespaces';
 import { CurrentUserService } from '../common/cls/current-user.service';
+import { MyEnrollmentsQueryDto } from './dto/requests/my-enrollments-query.dto';
 import { FacultyShortResponseDto } from './dto/responses/faculty-short.response.dto';
 import { MyEnrollmentsResponseDto } from './dto/responses/my-enrollments.response.dto';
 
@@ -16,9 +18,9 @@ export class EnrollmentsService {
   ) {}
 
   async getMyEnrollments(
-    page: number,
-    limit: number,
+    query: MyEnrollmentsQueryDto,
   ): Promise<MyEnrollmentsResponseDto> {
+    const { page = 1, limit = 10 } = query;
     const user = this.currentUserService.getOrFail();
     return this.cacheService.wrap(
       CacheNamespace.ENROLLMENTS_ME,
@@ -45,7 +47,10 @@ export class EnrollmentsService {
     );
 
     const courseIds = [...new Set(enrollments.map((e) => e.course.id))];
-    const facultyMap = await this.getFacultyByCourseIds(courseIds);
+    const [facultyMap, submissionMap] = await Promise.all([
+      this.getFacultyByCourseIds(courseIds),
+      this.getSubmissionStatusByCourseIds(userId, courseIds),
+    ]);
 
     return {
       data: enrollments.map((e) => {
@@ -72,6 +77,10 @@ export class EnrollmentsService {
           section: e.section
             ? { id: e.section.id, name: e.section.name }
             : null,
+          submission: {
+            submitted: submissionMap.has(e.course.id),
+            submittedAt: submissionMap.get(e.course.id),
+          },
         };
       }),
       meta: {
@@ -82,6 +91,29 @@ export class EnrollmentsService {
         currentPage: page,
       },
     };
+  }
+
+  private async getSubmissionStatusByCourseIds(
+    userId: string,
+    courseIds: string[],
+  ): Promise<Map<string, Date>> {
+    const map = new Map<string, Date>();
+    if (courseIds.length === 0) return map;
+
+    const submissions = await this.em.find(
+      QuestionnaireSubmission,
+      { respondent: userId, course: { $in: courseIds } },
+      { fields: ['course', 'submittedAt'], orderBy: { submittedAt: 'DESC' } },
+    );
+
+    for (const submission of submissions) {
+      const courseId = submission.course?.id;
+      if (courseId && !map.has(courseId)) {
+        map.set(courseId, submission.submittedAt);
+      }
+    }
+
+    return map;
   }
 
   private async getFacultyByCourseIds(

--- a/src/modules/moodle/controllers/moodle-sync.controller.spec.ts
+++ b/src/modules/moodle/controllers/moodle-sync.controller.spec.ts
@@ -1,0 +1,267 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { getQueueToken } from '@nestjs/bullmq';
+import { EntityManager } from '@mikro-orm/core';
+import { QueueName } from 'src/configurations/common/queue-names';
+import { RolesGuard } from 'src/security/guards/roles.guard';
+import { CurrentUserService } from 'src/modules/common/cls/current-user.service';
+import { CurrentUserInterceptor } from 'src/modules/common/interceptors/current-user.interceptor';
+import { validate } from 'class-validator';
+import { MoodleSyncController } from './moodle-sync.controller';
+import { MoodleSyncScheduler } from '../schedulers/moodle-sync.scheduler';
+import { SyncState } from '../dto/responses/sync-status.response.dto';
+import { UpdateSyncScheduleDto } from '../dto/requests/update-sync-schedule.request.dto';
+import { MOODLE_SYNC_MIN_INTERVAL_MINUTES } from '../schedulers/moodle-sync.constants';
+
+describe('MoodleSyncController', () => {
+  let controller: MoodleSyncController;
+  let mockQueue: {
+    add: jest.Mock;
+    getActive: jest.Mock;
+    getActiveCount: jest.Mock;
+    getWaitingCount: jest.Mock;
+    getFailedCount: jest.Mock;
+  };
+  let mockScheduler: {
+    getSchedule: jest.Mock;
+    updateSchedule: jest.Mock;
+  };
+  let mockEm: {
+    fork: jest.Mock;
+    findAndCount: jest.Mock;
+  };
+  let mockCurrentUserService: {
+    getOrFail: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    mockQueue = {
+      add: jest.fn().mockResolvedValue({ id: 'job-1' }),
+      getActive: jest.fn().mockResolvedValue([]),
+      getActiveCount: jest.fn().mockResolvedValue(0),
+      getWaitingCount: jest.fn().mockResolvedValue(0),
+      getFailedCount: jest.fn().mockResolvedValue(0),
+    };
+    mockScheduler = {
+      getSchedule: jest.fn().mockReturnValue({
+        intervalMinutes: 60,
+        cronExpression: '0 * * * *',
+        nextExecution: '2026-03-25T21:00:00.000Z',
+      }),
+      updateSchedule: jest.fn().mockResolvedValue(undefined),
+    };
+    mockEm = {
+      findAndCount: jest.fn().mockResolvedValue([[], 0]),
+      fork: jest.fn(),
+    };
+    mockEm.fork.mockReturnValue(mockEm);
+    mockCurrentUserService = {
+      getOrFail: jest.fn().mockReturnValue({ id: 'user-1' }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MoodleSyncController],
+      providers: [
+        {
+          provide: getQueueToken(QueueName.MOODLE_SYNC),
+          useValue: mockQueue,
+        },
+        {
+          provide: MoodleSyncScheduler,
+          useValue: mockScheduler,
+        },
+        {
+          provide: EntityManager,
+          useValue: mockEm,
+        },
+        {
+          provide: CurrentUserService,
+          useValue: mockCurrentUserService,
+        },
+      ],
+    })
+      .overrideGuard(AuthGuard('jwt'))
+      .useValue({ canActivate: () => true })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .overrideInterceptor(CurrentUserInterceptor)
+      .useValue({
+        intercept: (_ctx: unknown, next: { handle: () => unknown }) =>
+          next.handle(),
+      })
+      .compile();
+
+    controller = module.get(MoodleSyncController);
+  });
+
+  describe('GetSyncStatus', () => {
+    it('should return IDLE when no jobs are active or queued', async () => {
+      const result = await controller.GetSyncStatus();
+
+      expect(result.state).toBe(SyncState.IDLE);
+      expect(result.waitingCount).toBe(0);
+    });
+
+    it('should return ACTIVE when a job is processing', async () => {
+      mockQueue.getActive.mockResolvedValue([
+        { id: 'job-1', data: { trigger: 'manual' }, processedOn: 1000 },
+      ]);
+
+      const result = await controller.GetSyncStatus();
+
+      expect(result.state).toBe(SyncState.ACTIVE);
+      expect(result.jobId).toBe('job-1');
+      expect(result.trigger).toBe('manual');
+    });
+
+    it('should return QUEUED when jobs are waiting but none active', async () => {
+      mockQueue.getWaitingCount.mockResolvedValue(2);
+
+      const result = await controller.GetSyncStatus();
+
+      expect(result.state).toBe(SyncState.QUEUED);
+      expect(result.waitingCount).toBe(2);
+    });
+  });
+
+  describe('TriggerSync', () => {
+    it('should enqueue a manual sync job with triggeredById from CLS', async () => {
+      const result = await controller.TriggerSync();
+
+      expect(result.jobId).toBe('job-1');
+      expect(mockCurrentUserService.getOrFail).toHaveBeenCalled();
+      expect(mockQueue.add).toHaveBeenCalledWith(
+        QueueName.MOODLE_SYNC,
+        expect.objectContaining({
+          trigger: 'manual',
+          triggeredById: 'user-1',
+        }),
+        expect.objectContaining({
+          removeOnComplete: true,
+          removeOnFail: 50,
+        }),
+      );
+    });
+
+    it('should throw 409 when a sync is already in progress', async () => {
+      mockQueue.getActiveCount.mockResolvedValue(1);
+
+      await expect(controller.TriggerSync()).rejects.toThrow(
+        new HttpException(
+          { error: 'Sync already in progress or queued' },
+          HttpStatus.CONFLICT,
+        ),
+      );
+    });
+
+    it('should throw 503 when the queue is unavailable', async () => {
+      mockQueue.add.mockRejectedValue(new Error('Redis down'));
+
+      await expect(controller.TriggerSync()).rejects.toThrow(HttpException);
+    });
+  });
+
+  describe('GetSyncHistory', () => {
+    it('should return paginated sync logs', async () => {
+      const mockLog = {
+        id: 'log-1',
+        trigger: 'manual',
+        triggeredBy: { id: 'user-1' },
+        status: 'completed',
+        startedAt: new Date(),
+        completedAt: new Date(),
+        durationMs: 5000,
+        categories: {
+          status: 'success',
+          fetched: 10,
+          inserted: 2,
+          updated: 8,
+          deactivated: 0,
+          errors: 0,
+          durationMs: 100,
+        },
+        courses: null,
+        enrollments: null,
+      };
+      mockEm.findAndCount.mockResolvedValue([[mockLog], 1]);
+
+      const result = await controller.GetSyncHistory(1, 20);
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].id).toBe('log-1');
+      expect(result.data[0].triggeredById).toBe('user-1');
+      expect(result.meta.totalItems).toBe(1);
+      expect(result.meta.currentPage).toBe(1);
+    });
+
+    it('should pass softDelete: false filter to bypass global filter', async () => {
+      await controller.GetSyncHistory(1, 20);
+
+      expect(mockEm.findAndCount).toHaveBeenCalledWith(
+        expect.anything(),
+        {},
+        expect.objectContaining({
+          filters: { softDelete: false },
+        }),
+      );
+    });
+
+    it('should clamp limit to max 100', async () => {
+      await controller.GetSyncHistory(1, 200);
+
+      expect(mockEm.findAndCount).toHaveBeenCalledWith(
+        expect.anything(),
+        {},
+        expect.objectContaining({ limit: 100 }),
+      );
+    });
+  });
+
+  describe('GetSyncSchedule', () => {
+    it('should return current schedule from scheduler', () => {
+      const result = controller.GetSyncSchedule();
+
+      expect(result.intervalMinutes).toBe(60);
+      expect(result.cronExpression).toBe('0 * * * *');
+      expect(result.nextExecution).toBe('2026-03-25T21:00:00.000Z');
+    });
+  });
+
+  describe('UpdateSyncSchedule', () => {
+    it('should update the schedule and return new values', async () => {
+      mockScheduler.getSchedule.mockReturnValue({
+        intervalMinutes: 180,
+        cronExpression: '0 */3 * * *',
+        nextExecution: '2026-03-26T00:00:00.000Z',
+      });
+
+      const result = await controller.UpdateSyncSchedule({
+        intervalMinutes: 180,
+      });
+
+      expect(mockScheduler.updateSchedule).toHaveBeenCalledWith(180);
+      expect(result.intervalMinutes).toBe(180);
+      expect(result.cronExpression).toBe('0 */3 * * *');
+    });
+
+    it('should reject interval below minimum via DTO validation', async () => {
+      const dto = new UpdateSyncScheduleDto();
+      dto.intervalMinutes = 10;
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+
+    it('should accept interval at minimum via DTO validation', async () => {
+      const dto = new UpdateSyncScheduleDto();
+      dto.intervalMinutes = MOODLE_SYNC_MIN_INTERVAL_MINUTES;
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+    });
+  });
+});

--- a/src/modules/moodle/controllers/moodle-sync.controller.ts
+++ b/src/modules/moodle/controllers/moodle-sync.controller.ts
@@ -1,4 +1,5 @@
 import {
+  Body,
   Controller,
   Get,
   HttpCode,
@@ -6,23 +7,36 @@ import {
   HttpStatus,
   Logger,
   Post,
+  Put,
+  Query,
+  UseInterceptors,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOperation,
+  ApiQuery,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
+import { EntityManager } from '@mikro-orm/core';
 import { QueueName } from 'src/configurations/common/queue-names';
 import { UseJwtGuard } from 'src/security/decorators';
 import { UserRole } from 'src/modules/auth/roles.enum';
+import { CurrentUserService } from 'src/modules/common/cls/current-user.service';
+import { CurrentUserInterceptor } from 'src/modules/common/interceptors/current-user.interceptor';
+import { SyncLog } from 'src/entities/sync-log.entity';
 import { TriggerSyncResponseDto } from '../dto/responses/trigger-sync.response.dto';
 import {
   SyncState,
   SyncStatusResponseDto,
 } from '../dto/responses/sync-status.response.dto';
+import { SyncLogResponseDto } from '../dto/responses/sync-log.response.dto';
+import { SyncHistoryResponseDto } from '../dto/responses/sync-history.response.dto';
+import { SyncScheduleResponseDto } from '../dto/responses/sync-schedule.response.dto';
+import { UpdateSyncScheduleDto } from '../dto/requests/update-sync-schedule.request.dto';
+import { MoodleSyncScheduler } from '../schedulers/moodle-sync.scheduler';
 
 @ApiTags('Moodle')
 @Controller('moodle')
@@ -31,6 +45,9 @@ export class MoodleSyncController {
 
   constructor(
     @InjectQueue(QueueName.MOODLE_SYNC) private readonly syncQueue: Queue,
+    private readonly syncScheduler: MoodleSyncScheduler,
+    private readonly em: EntityManager,
+    private readonly currentUserService: CurrentUserService,
   ) {}
 
   @Get('sync/status')
@@ -88,6 +105,7 @@ export class MoodleSyncController {
     description: 'Sync already in progress or queued',
   })
   @ApiResponse({ status: 503, description: 'Sync queue unavailable' })
+  @UseInterceptors(CurrentUserInterceptor)
   async TriggerSync(): Promise<TriggerSyncResponseDto> {
     try {
       const [activeCount, waitingCount] = await Promise.all([
@@ -102,9 +120,11 @@ export class MoodleSyncController {
         );
       }
 
+      const user = this.currentUserService.getOrFail();
+
       const job = await this.syncQueue.add(
         QueueName.MOODLE_SYNC,
-        { trigger: 'manual' },
+        { trigger: 'manual', triggeredById: user.id },
         {
           jobId: `moodle-sync-manual-${Date.now()}`,
           removeOnComplete: true,
@@ -125,5 +145,66 @@ export class MoodleSyncController {
         HttpStatus.SERVICE_UNAVAILABLE,
       );
     }
+  }
+
+  @Get('sync/history')
+  @UseJwtGuard(UserRole.SUPER_ADMIN)
+  @ApiOperation({ summary: 'Get paginated Moodle sync history' })
+  @ApiBearerAuth()
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiResponse({ status: 200, type: SyncHistoryResponseDto })
+  async GetSyncHistory(
+    @Query('page') page = 1,
+    @Query('limit') limit = 20,
+  ): Promise<SyncHistoryResponseDto> {
+    const fork = this.em.fork();
+    const currentPage = Math.max(1, Number(page));
+    const itemsPerPage = Math.min(100, Math.max(1, Number(limit)));
+    const offset = (currentPage - 1) * itemsPerPage;
+
+    const [logs, totalItems] = await fork.findAndCount(
+      SyncLog,
+      {},
+      {
+        orderBy: { startedAt: 'desc' },
+        limit: itemsPerPage,
+        offset,
+        populate: ['triggeredBy'],
+        filters: { softDelete: false },
+      },
+    );
+
+    return {
+      data: logs.map((log) => SyncLogResponseDto.Map(log)),
+      meta: {
+        totalItems,
+        itemCount: logs.length,
+        itemsPerPage,
+        totalPages: Math.ceil(totalItems / itemsPerPage),
+        currentPage,
+      },
+    };
+  }
+
+  @Get('sync/schedule')
+  @UseJwtGuard(UserRole.SUPER_ADMIN)
+  @ApiOperation({ summary: 'Get current sync schedule' })
+  @ApiBearerAuth()
+  @ApiResponse({ status: 200, type: SyncScheduleResponseDto })
+  GetSyncSchedule(): SyncScheduleResponseDto {
+    return this.syncScheduler.getSchedule();
+  }
+
+  @Put('sync/schedule')
+  @UseJwtGuard(UserRole.SUPER_ADMIN)
+  @ApiOperation({ summary: 'Update sync schedule interval' })
+  @ApiBearerAuth()
+  @ApiResponse({ status: 200, type: SyncScheduleResponseDto })
+  async UpdateSyncSchedule(
+    @Body() dto: UpdateSyncScheduleDto,
+  ): Promise<SyncScheduleResponseDto> {
+    await this.syncScheduler.updateSchedule(dto.intervalMinutes);
+    return this.syncScheduler.getSchedule();
   }
 }

--- a/src/modules/moodle/dto/requests/update-sync-schedule.request.dto.ts
+++ b/src/modules/moodle/dto/requests/update-sync-schedule.request.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, Min } from 'class-validator';
+import { MOODLE_SYNC_MIN_INTERVAL_MINUTES } from '../../schedulers/moodle-sync.constants';
+
+export class UpdateSyncScheduleDto {
+  @ApiProperty({
+    description: `Sync interval in minutes (minimum ${MOODLE_SYNC_MIN_INTERVAL_MINUTES})`,
+    example: 60,
+    minimum: MOODLE_SYNC_MIN_INTERVAL_MINUTES,
+  })
+  @IsInt()
+  @Min(MOODLE_SYNC_MIN_INTERVAL_MINUTES)
+  intervalMinutes: number;
+}

--- a/src/modules/moodle/dto/responses/sync-history.response.dto.ts
+++ b/src/modules/moodle/dto/responses/sync-history.response.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PaginationMeta } from 'src/modules/common/dto/pagination.dto';
+import { SyncLogResponseDto } from './sync-log.response.dto';
+
+export class SyncHistoryResponseDto {
+  @ApiProperty({ type: [SyncLogResponseDto] })
+  data: SyncLogResponseDto[];
+
+  @ApiProperty({ type: PaginationMeta })
+  meta: PaginationMeta;
+}

--- a/src/modules/moodle/dto/responses/sync-log.response.dto.ts
+++ b/src/modules/moodle/dto/responses/sync-log.response.dto.ts
@@ -1,0 +1,88 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import type { SyncPhaseResult } from '../../lib/sync-result.types';
+import { SyncLog } from 'src/entities/sync-log.entity';
+
+class SyncPhaseResultDto implements SyncPhaseResult {
+  @ApiProperty()
+  status: 'success' | 'failed' | 'skipped';
+
+  @ApiProperty()
+  durationMs: number;
+
+  @ApiProperty()
+  fetched: number;
+
+  @ApiProperty()
+  inserted: number;
+
+  @ApiProperty()
+  updated: number;
+
+  @ApiProperty()
+  deactivated: number;
+
+  @ApiProperty()
+  errors: number;
+
+  @ApiPropertyOptional()
+  errorMessage?: string;
+}
+
+export class SyncLogResponseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  trigger: string;
+
+  @ApiPropertyOptional()
+  triggeredById?: string;
+
+  @ApiProperty()
+  status: string;
+
+  @ApiProperty()
+  startedAt: Date;
+
+  @ApiPropertyOptional()
+  completedAt?: Date;
+
+  @ApiPropertyOptional()
+  durationMs?: number;
+
+  @ApiPropertyOptional({ type: SyncPhaseResultDto })
+  categories?: SyncPhaseResult;
+
+  @ApiPropertyOptional({ type: SyncPhaseResultDto })
+  courses?: SyncPhaseResult;
+
+  @ApiPropertyOptional({ type: SyncPhaseResultDto })
+  enrollments?: SyncPhaseResult;
+
+  @ApiPropertyOptional()
+  errorMessage?: string;
+
+  @ApiPropertyOptional()
+  jobId?: string;
+
+  @ApiPropertyOptional()
+  cronExpression?: string;
+
+  static Map(entity: SyncLog): SyncLogResponseDto {
+    return {
+      id: entity.id,
+      trigger: entity.trigger,
+      triggeredById: entity.triggeredBy?.id,
+      status: entity.status,
+      startedAt: entity.startedAt,
+      completedAt: entity.completedAt,
+      durationMs: entity.durationMs,
+      categories: entity.categories,
+      courses: entity.courses,
+      enrollments: entity.enrollments,
+      errorMessage: entity.errorMessage,
+      jobId: entity.jobId,
+      cronExpression: entity.cronExpression,
+    };
+  }
+}

--- a/src/modules/moodle/dto/responses/sync-schedule.response.dto.ts
+++ b/src/modules/moodle/dto/responses/sync-schedule.response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class SyncScheduleResponseDto {
+  @ApiProperty()
+  intervalMinutes: number;
+
+  @ApiProperty()
+  cronExpression: string;
+
+  @ApiPropertyOptional()
+  nextExecution: string | null;
+}

--- a/src/modules/moodle/lib/sync-result.types.ts
+++ b/src/modules/moodle/lib/sync-result.types.ts
@@ -1,0 +1,19 @@
+export interface SyncPhaseResult {
+  status: 'success' | 'failed' | 'skipped';
+  durationMs: number;
+  fetched: number;
+  inserted: number;
+  updated: number;
+  deactivated: number;
+  errors: number;
+  errorMessage?: string;
+}
+
+export type SyncTrigger = 'scheduled' | 'manual' | 'startup';
+
+export type SyncStatus = 'running' | 'completed' | 'partial' | 'failed';
+
+export interface MoodleSyncJobData {
+  trigger: SyncTrigger;
+  triggeredById?: string;
+}

--- a/src/modules/moodle/moodle.module.ts
+++ b/src/modules/moodle/moodle.module.ts
@@ -15,12 +15,15 @@ import { EnrollmentSyncService } from './services/moodle-enrollment-sync.service
 import { Enrollment } from 'src/entities/enrollment.entity';
 import { Course } from 'src/entities/course.entity';
 import { Section } from 'src/entities/section.entity';
+import { SyncLog } from 'src/entities/sync-log.entity';
+import { SystemConfig } from 'src/entities/system-config.entity';
 import { MoodleCourseSyncService } from './services/moodle-course-sync.service';
 import { MoodleUserHydrationService } from './services/moodle-user-hydration.service';
 import { MoodleSyncProcessor } from './processors/moodle-sync.processor';
 import { MoodleSyncScheduler } from './schedulers/moodle-sync.scheduler';
 import { MoodleStartupService } from './services/moodle-startup.service';
 import { MoodleSyncController } from './controllers/moodle-sync.controller';
+import DataLoaderModule from '../common/data-loaders/index.module';
 
 @Module({
   imports: [
@@ -34,8 +37,11 @@ import { MoodleSyncController } from './controllers/moodle-sync.controller';
       Enrollment,
       Course,
       Section,
+      SyncLog,
+      SystemConfig,
     ]),
     CommonModule,
+    DataLoaderModule,
   ],
   controllers: [MoodleSyncController],
   providers: [

--- a/src/modules/moodle/processors/moodle-sync.processor.spec.ts
+++ b/src/modules/moodle/processors/moodle-sync.processor.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Test, TestingModule } from '@nestjs/testing';
 import { Job } from 'bullmq';
+import { EntityManager } from '@mikro-orm/core';
 import { MoodleSyncProcessor } from './moodle-sync.processor';
 import { MoodleCategorySyncService } from '../services/moodle-category-sync.service';
 import { MoodleCourseSyncService } from '../services/moodle-course-sync.service';
@@ -8,6 +9,34 @@ import { EnrollmentSyncService } from '../services/moodle-enrollment-sync.servic
 import { CacheService } from 'src/modules/common/cache/cache.service';
 import { CacheNamespace } from 'src/modules/common/cache/cache-namespaces';
 import { QueueName } from 'src/configurations/common/queue-names';
+import type {
+  MoodleSyncJobData,
+  SyncPhaseResult,
+} from '../lib/sync-result.types';
+
+const successPhase = (
+  overrides?: Partial<SyncPhaseResult>,
+): SyncPhaseResult => ({
+  status: 'success',
+  durationMs: 100,
+  fetched: 10,
+  inserted: 2,
+  updated: 8,
+  deactivated: 0,
+  errors: 0,
+  ...overrides,
+});
+
+const failedPhase = (errorMessage: string): SyncPhaseResult => ({
+  status: 'failed',
+  durationMs: 50,
+  fetched: 0,
+  inserted: 0,
+  updated: 0,
+  deactivated: 0,
+  errors: 1,
+  errorMessage,
+});
 
 describe('MoodleSyncProcessor', () => {
   let processor: MoodleSyncProcessor;
@@ -15,37 +44,63 @@ describe('MoodleSyncProcessor', () => {
   let courseSyncService: jest.Mocked<MoodleCourseSyncService>;
   let enrollmentSyncService: jest.Mocked<EnrollmentSyncService>;
   let cacheService: jest.Mocked<CacheService>;
+  let mockEm: {
+    fork: jest.Mock;
+    create: jest.Mock;
+    persistAndFlush: jest.Mock;
+    flush: jest.Mock;
+    getReference: jest.Mock;
+  };
 
   const mockJob = {
     id: 'test-job-1',
-    data: { trigger: 'manual' },
+    data: { trigger: 'manual' } as MoodleSyncJobData,
     queueName: QueueName.MOODLE_SYNC,
     attemptsMade: 1,
-  } as Job<{ trigger?: string }>;
+  } as Job<MoodleSyncJobData>;
 
   beforeEach(async () => {
+    mockEm = {
+      create: jest.fn().mockReturnValue({ id: 'sync-log-1' }),
+      persistAndFlush: jest.fn().mockResolvedValue(undefined),
+      flush: jest.fn().mockResolvedValue(undefined),
+      getReference: jest.fn().mockReturnValue({ id: 'user-1' }),
+      fork: jest.fn(),
+    };
+    mockEm.fork.mockReturnValue(mockEm);
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         MoodleSyncProcessor,
         {
           provide: MoodleCategorySyncService,
           useValue: {
-            SyncAndRebuildHierarchy: jest.fn().mockResolvedValue(undefined),
+            SyncAndRebuildHierarchy: jest
+              .fn()
+              .mockResolvedValue(successPhase()),
           },
         },
         {
           provide: MoodleCourseSyncService,
-          useValue: { SyncAllPrograms: jest.fn().mockResolvedValue(undefined) },
+          useValue: {
+            SyncAllPrograms: jest.fn().mockResolvedValue(successPhase()),
+          },
         },
         {
           provide: EnrollmentSyncService,
-          useValue: { SyncAllCourses: jest.fn().mockResolvedValue(undefined) },
+          useValue: {
+            SyncAllCourses: jest.fn().mockResolvedValue(successPhase()),
+          },
         },
         {
           provide: CacheService,
           useValue: {
             invalidateNamespace: jest.fn().mockResolvedValue(undefined),
           },
+        },
+        {
+          provide: EntityManager,
+          useValue: mockEm,
         },
       ],
     }).compile();
@@ -63,11 +118,7 @@ describe('MoodleSyncProcessor', () => {
     expect(categorySyncService.SyncAndRebuildHierarchy).toHaveBeenCalled();
     expect(courseSyncService.SyncAllPrograms).toHaveBeenCalled();
     expect(enrollmentSyncService.SyncAllCourses).toHaveBeenCalled();
-    expect(result).toEqual({
-      categories: true,
-      courses: true,
-      enrollments: true,
-    });
+    expect(result.status).toBe('completed');
   });
 
   it('should invalidate enrollment cache after successful enrollment sync', async () => {
@@ -79,47 +130,49 @@ describe('MoodleSyncProcessor', () => {
   });
 
   it('should abort courses and enrollments when category sync fails', async () => {
-    categorySyncService.SyncAndRebuildHierarchy.mockRejectedValue(
-      new Error('Moodle down'),
+    categorySyncService.SyncAndRebuildHierarchy.mockResolvedValue(
+      failedPhase('Moodle down'),
     );
 
     const result = await processor.process(mockJob);
 
     expect(courseSyncService.SyncAllPrograms).not.toHaveBeenCalled();
     expect(enrollmentSyncService.SyncAllCourses).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      categories: false,
-      courses: false,
-      enrollments: false,
-    });
+    expect(result.status).toBe('failed');
   });
 
   it('should abort enrollments when course sync fails', async () => {
-    courseSyncService.SyncAllPrograms.mockRejectedValue(new Error('timeout'));
+    courseSyncService.SyncAllPrograms.mockResolvedValue(failedPhase('timeout'));
 
     const result = await processor.process(mockJob);
 
     expect(categorySyncService.SyncAndRebuildHierarchy).toHaveBeenCalled();
     expect(enrollmentSyncService.SyncAllCourses).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      categories: true,
-      courses: false,
-      enrollments: false,
-    });
+    expect(result.status).toBe('partial');
   });
 
   it('should handle enrollment sync failure without crashing', async () => {
-    enrollmentSyncService.SyncAllCourses.mockRejectedValue(
-      new Error('deadlock'),
+    enrollmentSyncService.SyncAllCourses.mockResolvedValue(
+      failedPhase('deadlock'),
     );
 
     const result = await processor.process(mockJob);
 
-    expect(result).toEqual({
-      categories: true,
-      courses: true,
-      enrollments: false,
-    });
+    expect(result.status).toBe('partial');
     expect(cacheService.invalidateNamespace).not.toHaveBeenCalled();
+  });
+
+  it('should create a SyncLog entry on job start', async () => {
+    await processor.process(mockJob);
+
+    expect(mockEm.create).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        trigger: 'manual',
+        status: 'running',
+        jobId: 'test-job-1',
+      }),
+    );
+    expect(mockEm.persistAndFlush).toHaveBeenCalled();
   });
 });

--- a/src/modules/moodle/processors/moodle-sync.processor.ts
+++ b/src/modules/moodle/processors/moodle-sync.processor.ts
@@ -1,19 +1,21 @@
 import { Logger } from '@nestjs/common';
 import { Processor, WorkerHost, OnWorkerEvent } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
+import { EntityManager } from '@mikro-orm/core';
 import { env } from 'src/configurations/env';
 import { QueueName } from 'src/configurations/common/queue-names';
+import { SyncLog } from 'src/entities/sync-log.entity';
+import { User } from 'src/entities/user.entity';
 import { MoodleCategorySyncService } from '../services/moodle-category-sync.service';
 import { MoodleCourseSyncService } from '../services/moodle-course-sync.service';
 import { EnrollmentSyncService } from '../services/moodle-enrollment-sync.service';
 import { CacheService } from 'src/modules/common/cache/cache.service';
 import { CacheNamespace } from 'src/modules/common/cache/cache-namespaces';
-
-interface MoodleSyncResult {
-  categories: boolean;
-  courses: boolean;
-  enrollments: boolean;
-}
+import {
+  MoodleSyncJobData,
+  SyncPhaseResult,
+  SyncStatus,
+} from '../lib/sync-result.types';
 
 @Processor(QueueName.MOODLE_SYNC, {
   concurrency: 1,
@@ -28,62 +30,132 @@ export class MoodleSyncProcessor extends WorkerHost {
     private readonly courseSyncService: MoodleCourseSyncService,
     private readonly enrollmentSyncService: EnrollmentSyncService,
     private readonly cacheService: CacheService,
+    private readonly em: EntityManager,
   ) {
     super();
   }
 
-  async process(job: Job<{ trigger?: string }>): Promise<MoodleSyncResult> {
+  async process(job: Job<MoodleSyncJobData>): Promise<SyncLog> {
+    const fork = this.em.fork();
+    const startedAt = new Date();
+
     this.logger.log(
       `Processing moodle-sync job ${job.id} (trigger: ${job.data?.trigger ?? 'unknown'})`,
     );
 
-    const result: MoodleSyncResult = {
-      categories: false,
-      courses: false,
-      enrollments: false,
-    };
+    const syncLog = fork.create(SyncLog, {
+      trigger: job.data?.trigger ?? 'scheduled',
+      triggeredBy: job.data?.triggeredById
+        ? fork.getReference(User, job.data.triggeredById)
+        : undefined,
+      status: 'running',
+      startedAt,
+      jobId: job.id,
+    });
+    await fork.persistAndFlush(syncLog);
+
+    let coursesResult: SyncPhaseResult | undefined;
+    let enrollmentsResult: SyncPhaseResult | undefined;
 
     // Phase 1: Categories (required — courses/enrollments depend on hierarchy)
-    try {
+    const categoriesResult =
       await this.categorySyncService.SyncAndRebuildHierarchy();
-      result.categories = true;
+    syncLog.categories = categoriesResult;
+    await fork.flush();
+
+    if (categoriesResult.status === 'failed') {
+      this.logger.error(
+        `Category sync failed — aborting remaining phases: ${categoriesResult.errorMessage}`,
+      );
+      coursesResult = {
+        status: 'skipped',
+        durationMs: 0,
+        fetched: 0,
+        inserted: 0,
+        updated: 0,
+        deactivated: 0,
+        errors: 0,
+      };
+      enrollmentsResult = {
+        status: 'skipped',
+        durationMs: 0,
+        fetched: 0,
+        inserted: 0,
+        updated: 0,
+        deactivated: 0,
+        errors: 0,
+      };
+    } else {
       this.logger.log('Category sync completed');
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      this.logger.error(
-        `Category sync failed — aborting remaining phases: ${message}`,
-      );
-      return result;
+
+      // Phase 2: Courses (required — enrollments depend on courses)
+      coursesResult = await this.courseSyncService.SyncAllPrograms();
+      syncLog.courses = coursesResult;
+      await fork.flush();
+
+      if (coursesResult.status === 'failed') {
+        this.logger.error(
+          `Course sync failed — skipping enrollment sync: ${coursesResult.errorMessage}`,
+        );
+        enrollmentsResult = {
+          status: 'skipped',
+          durationMs: 0,
+          fetched: 0,
+          inserted: 0,
+          updated: 0,
+          deactivated: 0,
+          errors: 0,
+        };
+      } else {
+        this.logger.log('Course sync completed');
+
+        // Phase 3: Enrollments
+        enrollmentsResult = await this.enrollmentSyncService.SyncAllCourses();
+        syncLog.enrollments = enrollmentsResult;
+
+        if (enrollmentsResult.status !== 'failed') {
+          this.logger.log('Enrollment sync completed');
+          await this.cacheService.invalidateNamespace(
+            CacheNamespace.ENROLLMENTS_ME,
+          );
+        } else {
+          this.logger.error(
+            `Enrollment sync failed: ${enrollmentsResult.errorMessage}`,
+          );
+        }
+      }
     }
 
-    // Phase 2: Courses (required — enrollments depend on courses)
-    try {
-      await this.courseSyncService.SyncAllPrograms();
-      result.courses = true;
-      this.logger.log('Course sync completed');
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      this.logger.error(
-        `Course sync failed — skipping enrollment sync: ${message}`,
-      );
-      return result;
-    }
+    // Finalize sync log
+    const completedAt = new Date();
+    syncLog.courses = coursesResult;
+    syncLog.enrollments = enrollmentsResult;
+    syncLog.completedAt = completedAt;
+    syncLog.durationMs = completedAt.getTime() - startedAt.getTime();
+    syncLog.status = this.resolveOverallStatus(
+      categoriesResult,
+      coursesResult,
+      enrollmentsResult,
+    );
+    await fork.flush();
 
-    // Phase 3: Enrollments
-    try {
-      await this.enrollmentSyncService.SyncAllCourses();
-      result.enrollments = true;
-      this.logger.log('Enrollment sync completed');
+    return syncLog;
+  }
 
-      await this.cacheService.invalidateNamespace(
-        CacheNamespace.ENROLLMENTS_ME,
-      );
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      this.logger.error(`Enrollment sync failed: ${message}`);
-    }
+  private resolveOverallStatus(
+    categories: SyncPhaseResult,
+    courses: SyncPhaseResult,
+    enrollments: SyncPhaseResult,
+  ): SyncStatus {
+    const phases = [categories, courses, enrollments];
+    const allFailed = phases.every(
+      (p) => p.status === 'failed' || p.status === 'skipped',
+    );
+    const allSuccess = phases.every((p) => p.status === 'success');
 
-    return result;
+    if (allFailed) return 'failed';
+    if (allSuccess) return 'completed';
+    return 'partial';
   }
 
   @OnWorkerEvent('failed')

--- a/src/modules/moodle/schedulers/moodle-sync.constants.spec.ts
+++ b/src/modules/moodle/schedulers/moodle-sync.constants.spec.ts
@@ -1,0 +1,26 @@
+import { minutesToCron } from './moodle-sync.constants';
+
+describe('minutesToCron', () => {
+  it('should convert 1 minute to every-minute cron', () => {
+    expect(minutesToCron(1)).toBe('* * * * *');
+  });
+
+  it('should convert sub-hour minutes to minute-based cron', () => {
+    expect(minutesToCron(15)).toBe('*/15 * * * *');
+    expect(minutesToCron(30)).toBe('*/30 * * * *');
+  });
+
+  it('should convert 60 minutes to hourly cron', () => {
+    expect(minutesToCron(60)).toBe('0 * * * *');
+  });
+
+  it('should convert multiples of 60 to hour-based cron', () => {
+    expect(minutesToCron(120)).toBe('0 */2 * * *');
+    expect(minutesToCron(180)).toBe('0 */3 * * *');
+    expect(minutesToCron(360)).toBe('0 */6 * * *');
+  });
+
+  it('should treat non-multiple-of-60 values above 60 as minute-based', () => {
+    expect(minutesToCron(90)).toBe('*/90 * * * *');
+  });
+});

--- a/src/modules/moodle/schedulers/moodle-sync.constants.ts
+++ b/src/modules/moodle/schedulers/moodle-sync.constants.ts
@@ -1,0 +1,20 @@
+export const MOODLE_SYNC_JOB_NAME = 'moodle-sync-cron';
+
+export const MOODLE_SYNC_CONFIG_KEY = 'MOODLE_SYNC_INTERVAL_MINUTES';
+
+export const MOODLE_SYNC_MIN_INTERVAL_MINUTES = 30;
+
+export const MOODLE_SYNC_INTERVAL_DEFAULTS: Record<string, number> = {
+  development: 60,
+  test: 60,
+  staging: 360,
+  production: 180,
+};
+
+export function minutesToCron(minutes: number): string {
+  if (minutes >= 60 && minutes % 60 === 0) {
+    const hours = minutes / 60;
+    return hours === 1 ? '0 * * * *' : `0 */${hours} * * *`;
+  }
+  return minutes === 1 ? '* * * * *' : `*/${minutes} * * * *`;
+}

--- a/src/modules/moodle/schedulers/moodle-sync.scheduler.spec.ts
+++ b/src/modules/moodle/schedulers/moodle-sync.scheduler.spec.ts
@@ -1,14 +1,42 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getQueueToken } from '@nestjs/bullmq';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { EntityManager } from '@mikro-orm/core';
+import { CronJob } from 'cron';
 import { QueueName } from 'src/configurations/common/queue-names';
 import { MoodleSyncScheduler } from './moodle-sync.scheduler';
 
 describe('MoodleSyncScheduler', () => {
   let scheduler: MoodleSyncScheduler;
   let mockQueue: { add: jest.Mock };
+  let capturedCronJobs: CronJob[];
+  let mockSchedulerRegistry: {
+    addCronJob: jest.Mock;
+    deleteCronJob: jest.Mock;
+    getCronJob: jest.Mock;
+  };
+  let mockEm: { fork: jest.Mock; findOne: jest.Mock; flush: jest.Mock };
 
   beforeEach(async () => {
+    capturedCronJobs = [];
     mockQueue = { add: jest.fn().mockResolvedValue({ id: 'test-job-id' }) };
+    mockSchedulerRegistry = {
+      addCronJob: jest
+        .fn()
+        .mockImplementation((_name: string, job: CronJob) => {
+          capturedCronJobs.push(job);
+        }),
+      deleteCronJob: jest.fn(),
+      getCronJob: jest.fn().mockReturnValue({
+        nextDate: () => ({ toISO: () => '2026-03-25T21:00:00.000Z' }),
+      }),
+    };
+    mockEm = {
+      findOne: jest.fn().mockResolvedValue(null),
+      flush: jest.fn().mockResolvedValue(undefined),
+      fork: jest.fn(),
+    };
+    mockEm.fork.mockReturnValue(mockEm);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -17,34 +45,65 @@ describe('MoodleSyncScheduler', () => {
           provide: getQueueToken(QueueName.MOODLE_SYNC),
           useValue: mockQueue,
         },
+        {
+          provide: SchedulerRegistry,
+          useValue: mockSchedulerRegistry,
+        },
+        {
+          provide: EntityManager,
+          useValue: mockEm,
+        },
       ],
     }).compile();
 
     scheduler = module.get(MoodleSyncScheduler);
   });
 
-  it('should enqueue a moodle-sync job with correct options', async () => {
-    await scheduler.HandleScheduledSync();
+  afterEach(() => {
+    for (const job of capturedCronJobs) {
+      void job.stop();
+    }
+  });
 
-    expect(mockQueue.add).toHaveBeenCalledWith(
-      QueueName.MOODLE_SYNC,
-      { trigger: 'scheduled' },
-      {
-        jobId: 'moodle-sync-scheduled',
-        removeOnComplete: true,
-        removeOnFail: 50,
-      },
+  it('should register a cron job on module init', async () => {
+    await scheduler.onModuleInit();
+
+    expect(mockSchedulerRegistry.addCronJob).toHaveBeenCalledWith(
+      'moodle-sync-cron',
+      expect.anything(),
     );
   });
 
-  it('should catch and log error when Redis is unavailable', async () => {
-    mockQueue.add.mockRejectedValue(new Error('Redis connection refused'));
-    const errorSpy = jest.spyOn(scheduler['logger'], 'error');
+  it('should return schedule info after init', async () => {
+    await scheduler.onModuleInit();
 
-    await scheduler.HandleScheduledSync();
+    const schedule = scheduler.getSchedule();
+    expect(schedule.intervalMinutes).toBeDefined();
+    expect(schedule.cronExpression).toBeDefined();
+  });
 
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to enqueue scheduled sync'),
-    );
+  it('should use database config when available', async () => {
+    mockEm.findOne.mockResolvedValue({
+      key: 'MOODLE_SYNC_INTERVAL_MINUTES',
+      value: '120',
+    });
+
+    await scheduler.onModuleInit();
+
+    const schedule = scheduler.getSchedule();
+    expect(schedule.intervalMinutes).toBe(120);
+    expect(schedule.cronExpression).toBe('0 */2 * * *');
+  });
+
+  it('should ignore database config below minimum (30 minutes) and fall back to default', async () => {
+    mockEm.findOne.mockResolvedValue({
+      key: 'MOODLE_SYNC_INTERVAL_MINUTES',
+      value: '10',
+    });
+
+    await scheduler.onModuleInit();
+
+    const schedule = scheduler.getSchedule();
+    expect(schedule.intervalMinutes).toBeGreaterThanOrEqual(30);
   });
 });

--- a/src/modules/moodle/schedulers/moodle-sync.scheduler.ts
+++ b/src/modules/moodle/schedulers/moodle-sync.scheduler.ts
@@ -1,19 +1,106 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { SchedulerRegistry } from '@nestjs/schedule';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
+import { CronJob } from 'cron';
+import { EntityManager } from '@mikro-orm/core';
 import { QueueName } from 'src/configurations/common/queue-names';
+import { SystemConfig } from 'src/entities/system-config.entity';
+import { env } from 'src/configurations/env';
+import {
+  MOODLE_SYNC_JOB_NAME,
+  MOODLE_SYNC_CONFIG_KEY,
+  MOODLE_SYNC_INTERVAL_DEFAULTS,
+  MOODLE_SYNC_MIN_INTERVAL_MINUTES,
+  minutesToCron,
+} from './moodle-sync.constants';
 
 @Injectable()
-export class MoodleSyncScheduler {
+export class MoodleSyncScheduler implements OnModuleInit {
   private readonly logger = new Logger(MoodleSyncScheduler.name);
+  private currentIntervalMinutes: number;
+  private currentCronExpression: string;
 
   constructor(
     @InjectQueue(QueueName.MOODLE_SYNC) private readonly syncQueue: Queue,
+    private readonly schedulerRegistry: SchedulerRegistry,
+    private readonly em: EntityManager,
   ) {}
 
-  @Cron(CronExpression.EVERY_HOUR)
-  async HandleScheduledSync() {
+  async onModuleInit() {
+    const interval = await this.resolveInterval();
+    this.currentIntervalMinutes = interval;
+    this.currentCronExpression = minutesToCron(interval);
+
+    const job = CronJob.from({
+      cronTime: this.currentCronExpression,
+      onTick: () => this.handleScheduledSync(),
+      start: true,
+    });
+
+    this.schedulerRegistry.addCronJob(MOODLE_SYNC_JOB_NAME, job);
+    this.logger.log(
+      `Sync scheduler initialized: every ${interval}min (${this.currentCronExpression})`,
+    );
+  }
+
+  async updateSchedule(intervalMinutes: number): Promise<void> {
+    const cronExpression = minutesToCron(intervalMinutes);
+
+    // Validate by constructing — throws if invalid
+    CronJob.from({ cronTime: cronExpression, onTick: () => {} });
+
+    // Replace the running job
+    this.schedulerRegistry.deleteCronJob(MOODLE_SYNC_JOB_NAME);
+
+    const job = CronJob.from({
+      cronTime: cronExpression,
+      onTick: () => this.handleScheduledSync(),
+      start: true,
+    });
+
+    this.schedulerRegistry.addCronJob(MOODLE_SYNC_JOB_NAME, job);
+
+    // Persist to SystemConfig
+    const fork = this.em.fork();
+    const config = await fork.findOne(SystemConfig, {
+      key: MOODLE_SYNC_CONFIG_KEY,
+    });
+
+    if (config) {
+      config.value = String(intervalMinutes);
+    } else {
+      fork.create(SystemConfig, {
+        key: MOODLE_SYNC_CONFIG_KEY,
+        value: String(intervalMinutes),
+        description: 'Moodle sync interval in minutes',
+      });
+    }
+    await fork.flush();
+
+    this.currentIntervalMinutes = intervalMinutes;
+    this.currentCronExpression = cronExpression;
+    this.logger.log(
+      `Sync schedule updated: every ${intervalMinutes}min (${cronExpression})`,
+    );
+  }
+
+  getSchedule(): {
+    intervalMinutes: number;
+    cronExpression: string;
+    nextExecution: string | null;
+  } {
+    const job = this.schedulerRegistry.getCronJob(MOODLE_SYNC_JOB_NAME);
+    const nextDate = job.nextDate();
+
+    return {
+      intervalMinutes: this.currentIntervalMinutes,
+      cronExpression: this.currentCronExpression,
+      nextExecution: nextDate?.toISO() ?? null,
+    };
+  }
+
+  private async handleScheduledSync() {
     try {
       await this.syncQueue.add(
         QueueName.MOODLE_SYNC,
@@ -36,5 +123,45 @@ export class MoodleSyncScheduler {
         this.logger.error(`Failed to enqueue scheduled sync: ${message}`);
       }
     }
+  }
+
+  private async resolveInterval(): Promise<number> {
+    // Priority 1: Database config (admin override)
+    try {
+      const fork = this.em.fork();
+      const config = await fork.findOne(SystemConfig, {
+        key: MOODLE_SYNC_CONFIG_KEY,
+      });
+      if (config?.value) {
+        const parsed = parseInt(config.value, 10);
+        if (!isNaN(parsed) && parsed >= MOODLE_SYNC_MIN_INTERVAL_MINUTES) {
+          this.logger.log(
+            `Using sync interval from database: ${parsed} minutes`,
+          );
+          return parsed;
+        }
+      }
+    } catch {
+      this.logger.warn(
+        'Could not read sync interval from database, falling back to env/default',
+      );
+    }
+
+    // Priority 2: Environment variable
+    if (env.MOODLE_SYNC_INTERVAL_MINUTES) {
+      this.logger.log(
+        `Using sync interval from env: ${env.MOODLE_SYNC_INTERVAL_MINUTES} minutes`,
+      );
+      return env.MOODLE_SYNC_INTERVAL_MINUTES;
+    }
+
+    // Priority 3: Per-environment default
+    const defaultInterval =
+      MOODLE_SYNC_INTERVAL_DEFAULTS[env.NODE_ENV] ??
+      MOODLE_SYNC_INTERVAL_DEFAULTS.development;
+    this.logger.log(
+      `Using default sync interval for ${env.NODE_ENV}: ${defaultInterval} minutes`,
+    );
+    return defaultInterval;
   }
 }

--- a/src/modules/moodle/services/moodle-category-sync.service.ts
+++ b/src/modules/moodle/services/moodle-category-sync.service.ts
@@ -9,6 +9,7 @@ import { Program } from 'src/entities/program.entity';
 import { MoodleCategoryResponse } from '../lib/moodle.types';
 import { MoodleService } from '../moodle.service';
 import UnitOfWork from 'src/modules/common/unit-of-work';
+import { SyncPhaseResult } from '../lib/sync-result.types';
 
 @Injectable()
 export class MoodleCategorySyncService {
@@ -17,18 +18,53 @@ export class MoodleCategorySyncService {
     private readonly unitOfWork: UnitOfWork,
   ) {}
 
-  async SyncAndRebuildHierarchy(): Promise<void> {
-    return await this.unitOfWork.runInTransaction(async (tx) => {
-      const remoteCategories = await this.moodleService.GetCategories({
-        token: env.MOODLE_MASTER_KEY,
+  async SyncAndRebuildHierarchy(): Promise<SyncPhaseResult> {
+    const startTime = Date.now();
+    try {
+      const result = await this.unitOfWork.runInTransaction(async (tx) => {
+        const countBefore = await tx.count(MoodleCategory);
+
+        const remoteCategories = await this.moodleService.GetCategories({
+          token: env.MOODLE_MASTER_KEY,
+        });
+
+        // Phase 1: Raw mirror sync
+        await this.syncRawCategories(tx, remoteCategories);
+
+        // Phase 2: Rebuild normalized hierarchy
+        await this.rebuildHierarchy(tx);
+
+        const upserted = remoteCategories.length;
+        const inserted = Math.max(0, upserted - countBefore);
+
+        return {
+          fetched: remoteCategories.length,
+          inserted,
+          updated: upserted - inserted,
+        };
       });
 
-      // Phase 1: Raw mirror sync
-      await this.syncRawCategories(tx, remoteCategories);
-
-      // Phase 2: Rebuild normalized hierarchy
-      await this.rebuildHierarchy(tx);
-    });
+      return {
+        status: 'success',
+        durationMs: Date.now() - startTime,
+        fetched: result.fetched,
+        inserted: result.inserted,
+        updated: result.updated,
+        deactivated: 0,
+        errors: 0,
+      };
+    } catch (error: unknown) {
+      return {
+        status: 'failed',
+        durationMs: Date.now() - startTime,
+        fetched: 0,
+        inserted: 0,
+        updated: 0,
+        deactivated: 0,
+        errors: 1,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      };
+    }
   }
 
   private async syncRawCategories(

--- a/src/modules/moodle/services/moodle-course-sync.service.ts
+++ b/src/modules/moodle/services/moodle-course-sync.service.ts
@@ -6,6 +6,7 @@ import { Program } from 'src/entities/program.entity';
 import { Course } from 'src/entities/course.entity';
 import { MoodleService } from '../moodle.service';
 import UnitOfWork from 'src/modules/common/unit-of-work';
+import { SyncPhaseResult } from '../lib/sync-result.types';
 
 @Injectable()
 export class MoodleCourseSyncService {
@@ -17,17 +18,28 @@ export class MoodleCourseSyncService {
     private readonly unitOfWork: UnitOfWork,
   ) {}
 
-  async SyncAllPrograms(): Promise<void> {
+  async SyncAllPrograms(): Promise<SyncPhaseResult> {
+    const startTime = Date.now();
     const em = this.em.fork();
+    const countBefore = await em.count(Course);
     const programs = await em.find(Program, {});
     const limit = pLimit(env.MOODLE_SYNC_CONCURRENCY);
+
+    let fetched = 0;
+    let upserted = 0;
+    let deactivated = 0;
+    let errors = 0;
 
     await Promise.all(
       programs.map((program) =>
         limit(async () => {
           try {
-            await this.syncProgramCourses(program);
+            const metrics = await this.syncProgramCourses(program);
+            fetched += metrics.fetched;
+            upserted += metrics.upserted;
+            deactivated += metrics.deactivated;
           } catch (error: unknown) {
+            errors++;
             const message =
               error instanceof Error ? error.message : String(error);
             this.logger.error(
@@ -37,15 +49,30 @@ export class MoodleCourseSyncService {
         }),
       ),
     );
+
+    const inserted = Math.max(0, upserted - countBefore);
+
+    return {
+      status: errors > 0 && upserted === 0 ? 'failed' : 'success',
+      durationMs: Date.now() - startTime,
+      fetched,
+      inserted,
+      updated: upserted - inserted,
+      deactivated,
+      errors,
+    };
   }
 
-  private async syncProgramCourses(program: Program) {
+  private async syncProgramCourses(
+    program: Program,
+  ): Promise<{ fetched: number; upserted: number; deactivated: number }> {
     const remoteData = await this.moodleService.GetCoursesByCategory(
       env.MOODLE_MASTER_KEY,
       program.moodleCategoryId,
     );
 
     const remoteCourses = remoteData.courses;
+    let deactivated = 0;
 
     await this.unitOfWork.runInTransaction(async (tx) => {
       const existing = await tx.find(Course, {
@@ -98,8 +125,15 @@ export class MoodleCourseSyncService {
           course.isActive = false;
           course.isVisible = false;
           tx.persist(course);
+          deactivated++;
         }
       }
     });
+
+    return {
+      fetched: remoteCourses.length,
+      upserted: remoteCourses.length,
+      deactivated,
+    };
   }
 }

--- a/src/modules/moodle/services/moodle-enrollment-sync.service.ts
+++ b/src/modules/moodle/services/moodle-enrollment-sync.service.ts
@@ -9,6 +9,7 @@ import { User } from 'src/entities/user.entity';
 import { MoodleEnrolledUser } from '../lib/moodle.types';
 import { MoodleService } from '../moodle.service';
 import UnitOfWork from 'src/modules/common/unit-of-work';
+import { SyncPhaseResult } from '../lib/sync-result.types';
 
 @Injectable()
 export class EnrollmentSyncService {
@@ -20,10 +21,15 @@ export class EnrollmentSyncService {
     private readonly unitOfWork: UnitOfWork,
   ) {}
 
-  async SyncAllCourses() {
+  async SyncAllCourses(): Promise<SyncPhaseResult> {
+    const startTime = Date.now();
     const em = this.em.fork();
+    const enrollmentCountBefore = await em.count(Enrollment);
     const courses = await em.find(Course, { isVisible: true });
     const limit = pLimit(env.MOODLE_SYNC_CONCURRENCY);
+
+    let totalFetched = 0;
+    let fetchErrors = 0;
 
     // Phase 1: Concurrent HTTP fetch
     const results = await Promise.all(
@@ -35,8 +41,10 @@ export class EnrollmentSyncService {
                 token: env.MOODLE_MASTER_KEY,
                 courseId: course.moodleCourseId,
               });
+            totalFetched += remoteUsers.length;
             return { course, remoteUsers };
           } catch (error: unknown) {
+            fetchErrors++;
             const message =
               error instanceof Error ? error.message : String(error);
             this.logger.error(
@@ -56,16 +64,38 @@ export class EnrollmentSyncService {
     await this.syncAllUsers(fetched);
 
     // Phase 3: Sequential per-course enrollment upsert
+    let enrollmentUpserts = 0;
+    let deactivated = 0;
+    let enrollmentErrors = 0;
+
     for (const { course, remoteUsers } of fetched) {
       try {
-        await this.syncCourseEnrollments(course, remoteUsers);
+        const metrics = await this.syncCourseEnrollments(course, remoteUsers);
+        enrollmentUpserts += metrics.upserted;
+        deactivated += metrics.deactivated;
       } catch (error: unknown) {
+        enrollmentErrors++;
         const message = error instanceof Error ? error.message : String(error);
         this.logger.error(
           `Failed to sync enrollments for course ${course.moodleCourseId}: ${message}`,
         );
       }
     }
+
+    const inserted = Math.max(0, enrollmentUpserts - enrollmentCountBefore);
+
+    return {
+      status:
+        fetchErrors + enrollmentErrors > 0 && enrollmentUpserts === 0
+          ? 'failed'
+          : 'success',
+      durationMs: Date.now() - startTime,
+      fetched: totalFetched,
+      inserted,
+      updated: enrollmentUpserts - inserted,
+      deactivated,
+      errors: fetchErrors + enrollmentErrors,
+    };
   }
 
   private async syncAllUsers(
@@ -153,7 +183,10 @@ export class EnrollmentSyncService {
   private async syncCourseEnrollments(
     course: Course,
     remoteUsers: MoodleEnrolledUser[],
-  ) {
+  ): Promise<{ upserted: number; deactivated: number }> {
+    let upserted = 0;
+    let deactivated = 0;
+
     await this.unitOfWork.runInTransaction(async (tx) => {
       const existing = await tx.find(
         Enrollment,
@@ -221,6 +254,7 @@ export class EnrollmentSyncService {
             'updatedAt',
           ],
         });
+        upserted++;
       }
 
       // Soft deactivate users missing from remote
@@ -231,9 +265,12 @@ export class EnrollmentSyncService {
         ) {
           enrollment.isActive = false;
           tx.persist(enrollment);
+          deactivated++;
         }
       }
     });
+
+    return { upserted, deactivated };
   }
 
   private async upsertSectionsFromGroups(

--- a/src/modules/moodle/services/moodle-startup.service.ts
+++ b/src/modules/moodle/services/moodle-startup.service.ts
@@ -99,7 +99,7 @@ export class MoodleStartupService {
 
   private async RunPhase(
     name: string,
-    fn: () => Promise<void>,
+    fn: () => Promise<unknown>,
   ): Promise<JobRecordType> {
     const start = Date.now();
     try {

--- a/src/modules/questionnaires/dto/requests/ingest-csv-request.dto.ts
+++ b/src/modules/questionnaires/dto/requests/ingest-csv-request.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
+import { BooleanQueryTransform } from 'src/modules/common/transforms/boolean-query.transform';
 import {
   IsUUID,
   IsOptional,
@@ -21,11 +22,7 @@ export class IngestCsvRequestDto {
     description: 'Run in dry-run mode (validate only, no persistence)',
   })
   @IsOptional()
-  @Transform(({ obj, key }: { obj: Record<string, unknown>; key: string }) => {
-    const raw = obj[key];
-    if (typeof raw === 'string') return raw === 'true';
-    return raw === true;
-  })
+  @BooleanQueryTransform()
   @IsBoolean()
   dryRun?: boolean;
 

--- a/src/modules/questionnaires/dto/responses/questionnaire-response.dto.ts
+++ b/src/modules/questionnaires/dto/responses/questionnaire-response.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  QuestionnaireStatus,
+  QuestionnaireType,
+} from '../../lib/questionnaire.types';
+import type { Questionnaire } from 'src/entities/questionnaire.entity';
+
+export class QuestionnaireResponseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  title: string;
+
+  @ApiProperty({ enum: QuestionnaireType })
+  type: QuestionnaireType;
+
+  @ApiProperty({ enum: QuestionnaireStatus })
+  status: QuestionnaireStatus;
+
+  static Map(entity: Questionnaire): QuestionnaireResponseDto {
+    return {
+      id: entity.id,
+      title: entity.title,
+      type: entity.type,
+      status: entity.status,
+    };
+  }
+}

--- a/src/modules/questionnaires/dto/responses/submit-questionnaire-response.dto.ts
+++ b/src/modules/questionnaires/dto/responses/submit-questionnaire-response.dto.ts
@@ -1,0 +1,46 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { RespondentRole } from '../../lib/questionnaire.types';
+import type { QuestionnaireSubmission } from 'src/entities/questionnaire-submission.entity';
+
+export class SubmitQuestionnaireResponse {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  submittedAt: Date;
+
+  @ApiProperty({ enum: RespondentRole })
+  respondentRole: RespondentRole;
+
+  @ApiProperty({ type: 'number' })
+  totalScore: number;
+
+  @ApiProperty({ type: 'number' })
+  normalizedScore: number;
+
+  @ApiProperty()
+  faculty: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  course?: string;
+
+  @ApiProperty()
+  semester: string;
+
+  @ApiProperty()
+  academicYear: string;
+
+  static Map(submission: QuestionnaireSubmission): SubmitQuestionnaireResponse {
+    return {
+      id: submission.id,
+      submittedAt: submission.submittedAt,
+      respondentRole: submission.respondentRole,
+      totalScore: submission.totalScore,
+      normalizedScore: submission.normalizedScore,
+      faculty: submission.facultyNameSnapshot,
+      course: submission.courseTitleSnapshot,
+      semester: submission.semesterLabelSnapshot,
+      academicYear: submission.academicYearSnapshot,
+    };
+  }
+}

--- a/src/modules/questionnaires/ingestion/services/ingestion-engine.service.ts
+++ b/src/modules/questionnaires/ingestion/services/ingestion-engine.service.ts
@@ -14,7 +14,7 @@ import {
   IngestionResultDto,
   IngestionRecordResult,
 } from '../dto/ingestion-result.dto';
-import { QuestionnaireSubmission } from 'src/entities/questionnaire-submission.entity';
+import { SubmitQuestionnaireResponse } from '../../dto/responses/submit-questionnaire-response.dto';
 
 export class DryRunRollbackError extends Error {
   constructor() {
@@ -171,9 +171,9 @@ export class IngestionEngine {
     em: EntityManager,
     mapped: MappedSubmission,
     dryRun: boolean,
-  ): Promise<QuestionnaireSubmission> {
+  ): Promise<SubmitQuestionnaireResponse> {
     if (dryRun) {
-      let submission: QuestionnaireSubmission | undefined;
+      let submission: SubmitQuestionnaireResponse | undefined;
       try {
         await em.transactional(async () => {
           submission = await this.questionnaireService.submitQuestionnaire(

--- a/src/modules/questionnaires/questionnaire.controller.spec.ts
+++ b/src/modules/questionnaires/questionnaire.controller.spec.ts
@@ -11,7 +11,11 @@ import { QuestionnaireService } from './services/questionnaire.service';
 import { IngestionEngine } from './ingestion/services/ingestion-engine.service';
 import { CSVAdapter } from './ingestion/adapters/csv.adapter';
 import { IngestionResultDto } from './ingestion/dto/ingestion-result.dto';
-import { QuestionnaireSchemaSnapshot } from './lib/questionnaire.types';
+import {
+  QuestionnaireSchemaSnapshot,
+  QuestionnaireStatus,
+  QuestionnaireType,
+} from './lib/questionnaire.types';
 import { RolesGuard } from 'src/security/guards/roles.guard';
 import { CurrentUserInterceptor } from '../common/interceptors/current-user.interceptor';
 import { AuthGuard } from '@nestjs/passport';
@@ -688,5 +692,198 @@ describe('QuestionnaireController - GetCsvTemplate', () => {
     const [headerRow, dataRow] = csv.split('\n');
 
     expect(headerRow.split(',').length).toBe(dataRow.split(',').length);
+  });
+});
+
+describe('QuestionnaireController - mutation DTO mapping', () => {
+  let controller: QuestionnaireController;
+  let questionnaireService: jest.Mocked<QuestionnaireService>;
+
+  const mockSchema: QuestionnaireSchemaSnapshot = {
+    meta: {
+      questionnaireType: 'FACULTY_IN_CLASSROOM',
+      scoringModel: 'SECTION_WEIGHTED',
+      version: 1,
+      maxScore: 5,
+    },
+    sections: [],
+  };
+
+  const mockQuestionnaire = {
+    id: 'q-1',
+    title: 'Test Questionnaire',
+    type: QuestionnaireType.FACULTY_IN_CLASSROOM,
+    status: QuestionnaireStatus.DRAFT,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+    versions: { isInitialized: () => false },
+  };
+
+  const mockVersion = {
+    id: 'v-1',
+    questionnaire: mockQuestionnaire,
+    versionNumber: 1,
+    schemaSnapshot: mockSchema,
+    isActive: false,
+    status: QuestionnaireStatus.DRAFT,
+    publishedAt: undefined,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [QuestionnaireController],
+      providers: [
+        {
+          provide: QuestionnaireService,
+          useValue: {
+            GetVersionById: jest.fn(),
+            GetAllQuestions: jest.fn(),
+            getQuestionnaireTypes: jest.fn(),
+            getVersionsByType: jest.fn(),
+            createQuestionnaire: jest.fn(),
+            CreateVersion: jest.fn(),
+            GetLatestActiveVersion: jest.fn(),
+            PublishVersion: jest.fn(),
+            DeprecateVersion: jest.fn(),
+            UpdateDraftVersion: jest.fn(),
+            submitQuestionnaire: jest.fn(),
+            CheckSubmission: jest.fn(),
+            SaveOrUpdateDraft: jest.fn(),
+            GetDraft: jest.fn(),
+            ListMyDrafts: jest.fn(),
+            DeleteDraft: jest.fn(),
+            WipeSubmissions: jest.fn(),
+          },
+        },
+        {
+          provide: IngestionEngine,
+          useValue: { processStream: jest.fn() },
+        },
+        {
+          provide: CSVAdapter,
+          useValue: new CSVAdapter(),
+        },
+      ],
+    })
+      .overrideGuard(AuthGuard('jwt'))
+      .useValue({ canActivate: () => true })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .overrideInterceptor(CurrentUserInterceptor)
+      .useValue({
+        intercept: (_ctx: ExecutionContext, next: CallHandler) => next.handle(),
+      })
+      .compile();
+
+    controller = module.get(QuestionnaireController);
+    questionnaireService = module.get(QuestionnaireService);
+  });
+
+  it('createQuestionnaire should return QuestionnaireResponseDto', async () => {
+    questionnaireService.createQuestionnaire.mockResolvedValue(
+      mockQuestionnaire as any,
+    );
+
+    const result = await controller.createQuestionnaire({
+      title: 'Test Questionnaire',
+      type: QuestionnaireType.FACULTY_IN_CLASSROOM,
+    });
+
+    expect(result).toEqual({
+      id: 'q-1',
+      title: 'Test Questionnaire',
+      type: QuestionnaireType.FACULTY_IN_CLASSROOM,
+      status: QuestionnaireStatus.DRAFT,
+    });
+    expect(result).not.toHaveProperty('createdAt');
+    expect(result).not.toHaveProperty('updatedAt');
+    expect(result).not.toHaveProperty('deletedAt');
+  });
+
+  it('createVersion should return QuestionnaireVersionDetailResponse', async () => {
+    questionnaireService.CreateVersion.mockResolvedValue(mockVersion as any);
+
+    const result = await controller.createVersion('q-1', {
+      schema: mockSchema,
+    });
+
+    expect(result).toEqual({
+      id: 'v-1',
+      questionnaireId: 'q-1',
+      questionnaireTitle: 'Test Questionnaire',
+      questionnaireType: QuestionnaireType.FACULTY_IN_CLASSROOM,
+      versionNumber: 1,
+      status: QuestionnaireStatus.DRAFT,
+      isActive: false,
+      schemaSnapshot: mockSchema,
+      publishedAt: undefined,
+      createdAt: mockVersion.createdAt,
+      updatedAt: mockVersion.updatedAt,
+    });
+    expect(result).not.toHaveProperty('deletedAt');
+    expect(result).not.toHaveProperty('questionnaire');
+  });
+
+  it('publishVersion should return QuestionnaireVersionDetailResponse', async () => {
+    const publishedVersion = {
+      ...mockVersion,
+      isActive: true,
+      status: QuestionnaireStatus.ACTIVE,
+      publishedAt: new Date(),
+    };
+    questionnaireService.PublishVersion.mockResolvedValue(
+      publishedVersion as any,
+    );
+
+    const result = await controller.publishVersion('v-1');
+
+    expect(result).toEqual({
+      id: 'v-1',
+      questionnaireId: 'q-1',
+      questionnaireTitle: 'Test Questionnaire',
+      questionnaireType: QuestionnaireType.FACULTY_IN_CLASSROOM,
+      versionNumber: 1,
+      status: QuestionnaireStatus.ACTIVE,
+      isActive: true,
+      schemaSnapshot: mockSchema,
+      publishedAt: publishedVersion.publishedAt,
+      createdAt: publishedVersion.createdAt,
+      updatedAt: publishedVersion.updatedAt,
+    });
+    expect(result).not.toHaveProperty('deletedAt');
+    expect(result).not.toHaveProperty('questionnaire');
+  });
+
+  it('deprecateVersion should return QuestionnaireVersionDetailResponse', async () => {
+    const deprecatedVersion = {
+      ...mockVersion,
+      isActive: false,
+      status: QuestionnaireStatus.DEPRECATED,
+    };
+    questionnaireService.DeprecateVersion.mockResolvedValue(
+      deprecatedVersion as any,
+    );
+
+    const result = await controller.deprecateVersion('v-1');
+
+    expect(result).toEqual({
+      id: 'v-1',
+      questionnaireId: 'q-1',
+      questionnaireTitle: 'Test Questionnaire',
+      questionnaireType: QuestionnaireType.FACULTY_IN_CLASSROOM,
+      versionNumber: 1,
+      status: QuestionnaireStatus.DEPRECATED,
+      isActive: false,
+      schemaSnapshot: mockSchema,
+      publishedAt: undefined,
+      createdAt: deprecatedVersion.createdAt,
+      updatedAt: deprecatedVersion.updatedAt,
+    });
+    expect(result).not.toHaveProperty('deletedAt');
+    expect(result).not.toHaveProperty('questionnaire');
   });
 });

--- a/src/modules/questionnaires/questionnaire.controller.ts
+++ b/src/modules/questionnaires/questionnaire.controller.ts
@@ -37,6 +37,8 @@ import { QuestionnaireVersionDetailResponse } from './dto/responses/questionnair
 import { DraftResponse } from './dto/responses/draft-response.dto';
 import { CheckSubmissionQuery } from './dto/requests/check-submission-query.dto';
 import { CheckSubmissionResponse } from './dto/responses/check-submission-response.dto';
+import { SubmitQuestionnaireResponse } from './dto/responses/submit-questionnaire-response.dto';
+import { QuestionnaireResponseDto } from './dto/responses/questionnaire-response.dto';
 import { IngestionResultDto } from './ingestion/dto/ingestion-result.dto';
 import { UseJwtGuard } from 'src/security/decorators';
 import { UserRole } from '../auth/roles.enum';
@@ -90,20 +92,37 @@ export class QuestionnaireController {
 
   @Post()
   @ApiOperation({ summary: 'Create a new questionnaire' })
-  async createQuestionnaire(@Body() data: CreateQuestionnaireRequest) {
-    return this.questionnaireService.createQuestionnaire(data);
+  @ApiResponse({
+    status: 201,
+    description: 'Questionnaire created successfully',
+    type: QuestionnaireResponseDto,
+  })
+  async createQuestionnaire(
+    @Body() data: CreateQuestionnaireRequest,
+  ): Promise<QuestionnaireResponseDto> {
+    const questionnaire =
+      await this.questionnaireService.createQuestionnaire(data);
+    return QuestionnaireResponseDto.Map(questionnaire);
   }
 
   @Post(':id/versions')
   @ApiOperation({ summary: 'Create a new version for a questionnaire' })
-  @ApiResponse({ status: 201, description: 'Version created successfully' })
+  @ApiResponse({
+    status: 201,
+    description: 'Version created successfully',
+    type: QuestionnaireVersionDetailResponse,
+  })
   @ApiResponse({ status: 404, description: 'Questionnaire not found' })
   @ApiResponse({ status: 409, description: 'Draft version already exists' })
   async createVersion(
     @Param('id') id: string,
     @Body() data: CreateVersionRequest,
-  ) {
-    return this.questionnaireService.CreateVersion(id, data.schema);
+  ): Promise<QuestionnaireVersionDetailResponse> {
+    const version = await this.questionnaireService.CreateVersion(
+      id,
+      data.schema,
+    );
+    return QuestionnaireVersionDetailResponse.Map(version);
   }
 
   @Get(':id/latest-active-version')
@@ -124,23 +143,37 @@ export class QuestionnaireController {
 
   @Patch('versions/:versionId/publish')
   @ApiOperation({ summary: 'Publish a questionnaire version' })
-  @ApiResponse({ status: 200, description: 'Version published successfully' })
+  @ApiResponse({
+    status: 200,
+    description: 'Version published successfully',
+    type: QuestionnaireVersionDetailResponse,
+  })
   @ApiResponse({
     status: 400,
     description: 'Version already published or invalid schema',
   })
   @ApiResponse({ status: 404, description: 'Version not found' })
-  async publishVersion(@Param('versionId') versionId: string) {
-    return this.questionnaireService.PublishVersion(versionId);
+  async publishVersion(
+    @Param('versionId') versionId: string,
+  ): Promise<QuestionnaireVersionDetailResponse> {
+    const version = await this.questionnaireService.PublishVersion(versionId);
+    return QuestionnaireVersionDetailResponse.Map(version);
   }
 
   @Patch('versions/:versionId/deprecate')
   @ApiOperation({ summary: 'Deprecate a questionnaire version' })
-  @ApiResponse({ status: 200, description: 'Version deprecated successfully' })
+  @ApiResponse({
+    status: 200,
+    description: 'Version deprecated successfully',
+    type: QuestionnaireVersionDetailResponse,
+  })
   @ApiResponse({ status: 400, description: 'Version already deprecated' })
   @ApiResponse({ status: 404, description: 'Version not found' })
-  async deprecateVersion(@Param('versionId') versionId: string) {
-    return this.questionnaireService.DeprecateVersion(versionId);
+  async deprecateVersion(
+    @Param('versionId') versionId: string,
+  ): Promise<QuestionnaireVersionDetailResponse> {
+    const version = await this.questionnaireService.DeprecateVersion(versionId);
+    return QuestionnaireVersionDetailResponse.Map(version);
   }
 
   @Get('versions/:versionId')
@@ -200,7 +233,9 @@ export class QuestionnaireController {
   @Post('submissions')
   @UseJwtGuard()
   @ApiOperation({ summary: 'Submit a completed questionnaire' })
-  async submitQuestionnaire(@Body() data: SubmitQuestionnaireRequest) {
+  async submitQuestionnaire(
+    @Body() data: SubmitQuestionnaireRequest,
+  ): Promise<SubmitQuestionnaireResponse> {
     return this.questionnaireService.submitQuestionnaire(data);
   }
 

--- a/src/modules/questionnaires/services/questionnaire.service.spec.ts
+++ b/src/modules/questionnaires/services/questionnaire.service.spec.ts
@@ -20,6 +20,7 @@ import { QuestionnaireSchemaValidator } from './questionnaire-schema.validator';
 import { ScoringService } from './scoring.service';
 import { EntityManager } from '@mikro-orm/postgresql';
 import { CacheService } from '../../common/cache/cache.service';
+import { CacheNamespace } from '../../common/cache/cache-namespaces';
 import { AnalysisService } from '../../analysis/analysis.service';
 import { CurrentUserService } from '../../common/cls/current-user.service';
 import {
@@ -43,6 +44,10 @@ describe('QuestionnaireService', () => {
   let versionRepo: jest.Mocked<EntityRepository<QuestionnaireVersion>>;
   let questionnaireRepo: jest.Mocked<EntityRepository<Questionnaire>>;
   let analysisService: { EnqueueJob: jest.Mock };
+  let cacheService: {
+    invalidateNamespace: jest.Mock;
+    invalidateNamespaces: jest.Mock;
+  };
 
   const RESPONDENT_ID = 'r1';
   const FACULTY_ID = 'f1';
@@ -157,6 +162,7 @@ describe('QuestionnaireService', () => {
     versionRepo = module.get(getRepositoryToken(QuestionnaireVersion));
     questionnaireRepo = module.get(getRepositoryToken(Questionnaire));
     analysisService = module.get(AnalysisService);
+    cacheService = module.get(CacheService);
   });
 
   it('should be defined', () => {
@@ -367,7 +373,10 @@ describe('QuestionnaireService', () => {
       expect(result).toBeDefined();
       expect(em.persist).toHaveBeenCalled();
       expect(em.flush).toHaveBeenCalled();
-      expect(result.facultyEmployeeNumberSnapshot).toBe('fac123');
+      expect(result.faculty).toBe('Faculty Name');
+      expect(cacheService.invalidateNamespace).toHaveBeenCalledWith(
+        CacheNamespace.ENROLLMENTS_ME,
+      );
     });
 
     it('should enqueue embedding job when submission has qualitative comment and worker URL is configured', async () => {

--- a/src/modules/questionnaires/services/questionnaire.service.ts
+++ b/src/modules/questionnaires/services/questionnaire.service.ts
@@ -38,6 +38,7 @@ import {
   EnrollmentRole,
 } from '../lib/questionnaire.types';
 import { QuestionnaireTypeResponse } from '../dto/responses/questionnaire-type-response.dto';
+import { SubmitQuestionnaireResponse } from '../dto/responses/submit-questionnaire-response.dto';
 import { QuestionnaireVersionsResponse } from '../dto/responses/questionnaire-version-response.dto';
 import { QuestionnaireSchemaValidator } from './questionnaire-schema.validator';
 import { ScoringService } from './scoring.service';
@@ -615,6 +616,8 @@ export class QuestionnaireService {
       throw e;
     }
 
+    await this.cacheService.invalidateNamespace(CacheNamespace.ENROLLMENTS_ME);
+
     // Fire-and-forget embedding dispatch (uses cleaned text for alignment with topic modeling)
     if (
       !options?.skipAnalysis &&
@@ -638,7 +641,7 @@ export class QuestionnaireService {
       }
     }
 
-    return submission;
+    return SubmitQuestionnaireResponse.Map(submission);
   }
 
   // F6: Iterative traversal to avoid stack overflow


### PR DESCRIPTION
## Summary
- Cherry-picks FAC-72 through FAC-78 from develop into production
- Includes sync log tracking, sync schedule management endpoints, pagination/filtering improvements, and response DTO additions across Moodle, Enrollments, and Questionnaire modules
- Adds new migration, unit tests, and documentation updates

## Test plan
- [x] Verify all existing tests pass (`npm run test`)
- [x] Run E2E tests (`npm run test:e2e`)
- [x] Validate migration applies cleanly (`npx mikro-orm migration:up`)
- [x] Smoke-test sync schedule and sync history endpoints
- [x] Confirm enrollment filtering and questionnaire response DTOs work as expected