### PR TITLE
FAC-80 feat: questionnaire management — update title and archive

### DIFF
--- a/src/migrations/.snapshot-faculytics_db.json
+++ b/src/migrations/.snapshot-faculytics_db.json
@@ -454,7 +454,8 @@
           "enumItems": [
             "DRAFT",
             "ACTIVE",
-            "DEPRECATED"
+            "DEPRECATED",
+            "ARCHIVED"
           ],
           "mappedType": "enum"
         },
@@ -746,7 +747,8 @@
           "enumItems": [
             "DRAFT",
             "ACTIVE",
-            "DEPRECATED"
+            "DEPRECATED",
+            "ARCHIVED"
           ],
           "mappedType": "enum"
         }

--- a/src/migrations/Migration20260326161325.ts
+++ b/src/migrations/Migration20260326161325.ts
@@ -1,0 +1,24 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260326161325 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(
+      `alter table "questionnaire" drop constraint if exists "questionnaire_status_check";`,
+    );
+    this.addSql(
+      `alter table "questionnaire" add constraint "questionnaire_status_check" check("status" in ('DRAFT', 'ACTIVE', 'DEPRECATED', 'ARCHIVED'));`,
+    );
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(
+      `alter table "questionnaire" drop constraint if exists "questionnaire_status_check";`,
+    );
+    this.addSql(
+      `update "questionnaire" set "status" = 'DEPRECATED' where "status" = 'ARCHIVED';`,
+    );
+    this.addSql(
+      `alter table "questionnaire" add constraint "questionnaire_status_check" check("status" in ('DRAFT', 'ACTIVE', 'DEPRECATED'));`,
+    );
+  }
+}

--- a/src/modules/questionnaires/dto/requests/update-questionnaire-title-request.dto.ts
+++ b/src/modules/questionnaires/dto/requests/update-questionnaire-title-request.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class UpdateQuestionnaireTitleRequest {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  title!: string;
+}

--- a/src/modules/questionnaires/dto/responses/check-submission-response.dto.ts
+++ b/src/modules/questionnaires/dto/responses/check-submission-response.dto.ts
@@ -6,4 +6,7 @@ export class CheckSubmissionResponse {
 
   @ApiPropertyOptional()
   submittedAt?: Date;
+
+  @ApiPropertyOptional()
+  archived?: boolean;
 }

--- a/src/modules/questionnaires/lib/questionnaire.types.ts
+++ b/src/modules/questionnaires/lib/questionnaire.types.ts
@@ -9,6 +9,7 @@ export enum QuestionnaireStatus {
   DRAFT = 'DRAFT',
   ACTIVE = 'ACTIVE',
   DEPRECATED = 'DEPRECATED',
+  ARCHIVED = 'ARCHIVED',
 }
 
 export enum RespondentRole {

--- a/src/modules/questionnaires/questionnaire.controller.spec.ts
+++ b/src/modules/questionnaires/questionnaire.controller.spec.ts
@@ -42,6 +42,8 @@ describe('QuestionnaireController - checkSubmission', () => {
             UpdateDraftVersion: jest.fn(),
             submitQuestionnaire: jest.fn(),
             CheckSubmission: jest.fn(),
+            UpdateTitle: jest.fn(),
+            ArchiveQuestionnaire: jest.fn(),
             SaveOrUpdateDraft: jest.fn(),
             GetDraft: jest.fn(),
             ListMyDrafts: jest.fn(),
@@ -757,6 +759,8 @@ describe('QuestionnaireController - mutation DTO mapping', () => {
             UpdateDraftVersion: jest.fn(),
             submitQuestionnaire: jest.fn(),
             CheckSubmission: jest.fn(),
+            UpdateTitle: jest.fn(),
+            ArchiveQuestionnaire: jest.fn(),
             SaveOrUpdateDraft: jest.fn(),
             GetDraft: jest.fn(),
             ListMyDrafts: jest.fn(),
@@ -890,5 +894,64 @@ describe('QuestionnaireController - mutation DTO mapping', () => {
     });
     expect(result).not.toHaveProperty('deletedAt');
     expect(result).not.toHaveProperty('questionnaire');
+  });
+
+  it('updateTitle should return QuestionnaireResponseDto', async () => {
+    const mockQuestionnaire = {
+      id: 'q-1',
+      title: 'Updated Title',
+      status: QuestionnaireStatus.ACTIVE,
+      type: mockTypeEntity,
+    };
+    questionnaireService.UpdateTitle.mockResolvedValue(
+      mockQuestionnaire as any,
+    );
+
+    const result = await controller.updateTitle('q-1', {
+      title: 'Updated Title',
+    });
+
+    expect(result).toEqual({
+      id: 'q-1',
+      title: 'Updated Title',
+      type: {
+        id: mockTypeEntity.id,
+        name: mockTypeEntity.name,
+        code: mockTypeEntity.code,
+      },
+      status: QuestionnaireStatus.ACTIVE,
+    });
+    expect(questionnaireService.UpdateTitle).toHaveBeenCalledWith(
+      'q-1',
+      'Updated Title',
+    );
+  });
+
+  it('archiveQuestionnaire should return QuestionnaireResponseDto', async () => {
+    const mockQuestionnaire = {
+      id: 'q-1',
+      title: 'Test Questionnaire',
+      status: QuestionnaireStatus.ARCHIVED,
+      type: mockTypeEntity,
+    };
+    questionnaireService.ArchiveQuestionnaire.mockResolvedValue(
+      mockQuestionnaire as any,
+    );
+
+    const result = await controller.archiveQuestionnaire('q-1');
+
+    expect(result).toEqual({
+      id: 'q-1',
+      title: 'Test Questionnaire',
+      type: {
+        id: mockTypeEntity.id,
+        name: mockTypeEntity.name,
+        code: mockTypeEntity.code,
+      },
+      status: QuestionnaireStatus.ARCHIVED,
+    });
+    expect(questionnaireService.ArchiveQuestionnaire).toHaveBeenCalledWith(
+      'q-1',
+    );
   });
 });

--- a/src/modules/questionnaires/questionnaire.controller.ts
+++ b/src/modules/questionnaires/questionnaire.controller.ts
@@ -27,6 +27,7 @@ import type { Response } from 'express';
 import { CreateQuestionnaireRequest } from './dto/requests/create-questionnaire-request.dto';
 import { CreateVersionRequest } from './dto/requests/create-version-request.dto';
 import { UpdateVersionRequest } from './dto/requests/update-version-request.dto';
+import { UpdateQuestionnaireTitleRequest } from './dto/requests/update-questionnaire-title-request.dto';
 import { SubmitQuestionnaireRequest } from './dto/requests/submit-questionnaire-request.dto';
 import { SaveDraftRequest } from './dto/requests/save-draft-request.dto';
 import { GetDraftRequest } from './dto/requests/get-draft-request.dto';
@@ -104,6 +105,44 @@ export class QuestionnaireController {
       title: data.title,
       typeId: data.typeId,
     });
+    return QuestionnaireResponseDto.Map(questionnaire);
+  }
+
+  @Patch(':id/archive')
+  @UseJwtGuard(UserRole.SUPER_ADMIN, UserRole.ADMIN)
+  @ApiOperation({ summary: 'Archive a questionnaire' })
+  @ApiResponse({
+    status: 200,
+    description: 'Questionnaire archived successfully',
+    type: QuestionnaireResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Questionnaire already archived' })
+  @ApiResponse({ status: 404, description: 'Questionnaire not found' })
+  async archiveQuestionnaire(
+    @Param('id') id: string,
+  ): Promise<QuestionnaireResponseDto> {
+    const questionnaire =
+      await this.questionnaireService.ArchiveQuestionnaire(id);
+    return QuestionnaireResponseDto.Map(questionnaire);
+  }
+
+  @Patch(':id')
+  @UseJwtGuard(UserRole.SUPER_ADMIN, UserRole.ADMIN)
+  @ApiOperation({ summary: 'Update questionnaire title' })
+  @ApiResponse({
+    status: 200,
+    description: 'Questionnaire updated successfully',
+    type: QuestionnaireResponseDto,
+  })
+  @ApiResponse({ status: 404, description: 'Questionnaire not found' })
+  async updateTitle(
+    @Param('id') id: string,
+    @Body() data: UpdateQuestionnaireTitleRequest,
+  ): Promise<QuestionnaireResponseDto> {
+    const questionnaire = await this.questionnaireService.UpdateTitle(
+      id,
+      data.title,
+    );
     return QuestionnaireResponseDto.Map(questionnaire);
   }
 

--- a/src/modules/questionnaires/services/questionnaire.service.spec.ts
+++ b/src/modules/questionnaires/services/questionnaire.service.spec.ts
@@ -187,6 +187,10 @@ describe('QuestionnaireService', () => {
     const mockVersion = {
       id: 'v1',
       isActive: true,
+      questionnaire: {
+        status: QuestionnaireStatus.ACTIVE,
+        type: { code: 'T1' },
+      },
       schemaSnapshot: {
         meta: { maxScore: 5 },
         sections: [
@@ -1127,6 +1131,167 @@ describe('QuestionnaireService', () => {
         { submission: { $in: ids } },
       ]);
       expect(calls[4]).toEqual([expect.anything(), { id: { $in: ids } }]);
+    });
+  });
+
+  describe('UpdateTitle', () => {
+    const mockQuestionnaire = {
+      id: 'q1',
+      title: 'Old Title',
+      status: QuestionnaireStatus.ACTIVE,
+      type: { id: 't1', name: 'Type 1', code: 'T1' },
+    };
+
+    it('should throw NotFoundException if questionnaire not found', async () => {
+      questionnaireRepo.findOne.mockResolvedValue(null);
+      await expect(service.UpdateTitle('q1', 'New Title')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should update title and invalidate caches', async () => {
+      questionnaireRepo.findOne.mockResolvedValue({
+        ...mockQuestionnaire,
+      } as any);
+
+      const result = await service.UpdateTitle('q1', 'New Title');
+
+      expect(result.title).toBe('New Title');
+      expect(em.flush).toHaveBeenCalled();
+      expect(cacheService.invalidateNamespaces).toHaveBeenCalledWith(
+        CacheNamespace.QUESTIONNAIRE_TYPES,
+        CacheNamespace.QUESTIONNAIRE_VERSIONS,
+      );
+    });
+  });
+
+  describe('ArchiveQuestionnaire', () => {
+    const mockQuestionnaire = {
+      id: 'q1',
+      title: 'Test',
+      status: QuestionnaireStatus.ACTIVE,
+      type: { id: 't1', name: 'Type 1', code: 'T1' },
+    };
+
+    it('should throw NotFoundException if questionnaire not found', async () => {
+      questionnaireRepo.findOne.mockResolvedValue(null);
+      await expect(service.ArchiveQuestionnaire('q1')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw BadRequestException if already archived', async () => {
+      questionnaireRepo.findOne.mockResolvedValue({
+        ...mockQuestionnaire,
+        status: QuestionnaireStatus.ARCHIVED,
+      } as any);
+      await expect(service.ArchiveQuestionnaire('q1')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should set status to ARCHIVED and invalidate caches', async () => {
+      const questionnaire = { ...mockQuestionnaire };
+      questionnaireRepo.findOne.mockResolvedValue(questionnaire as any);
+
+      const result = await service.ArchiveQuestionnaire('q1');
+
+      expect(result.status).toBe(QuestionnaireStatus.ARCHIVED);
+      expect(em.flush).toHaveBeenCalled();
+      expect(cacheService.invalidateNamespaces).toHaveBeenCalledWith(
+        CacheNamespace.QUESTIONNAIRE_TYPES,
+        CacheNamespace.QUESTIONNAIRE_VERSIONS,
+      );
+    });
+  });
+
+  describe('archive guards', () => {
+    it('submitQuestionnaire should reject archived questionnaire', async () => {
+      versionRepo.findOne.mockResolvedValue({
+        id: 'v1',
+        isActive: true,
+        questionnaire: {
+          status: QuestionnaireStatus.ARCHIVED,
+          type: { code: 'T1' },
+        },
+        schemaSnapshot: { meta: { maxScore: 5 }, sections: [] },
+      } as any);
+
+      await expect(
+        service.submitQuestionnaire({
+          versionId: 'v1',
+          respondentId: RESPONDENT_ID,
+          facultyId: FACULTY_ID,
+          semesterId: SEMESTER_ID,
+          answers: {},
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('CheckSubmission should return archived true for archived questionnaire', async () => {
+      versionRepo.findOne.mockResolvedValue({
+        id: 'v1',
+        questionnaire: { status: QuestionnaireStatus.ARCHIVED },
+      } as any);
+
+      const result = await service.CheckSubmission({
+        versionId: 'v1',
+        facultyId: FACULTY_ID,
+        semesterId: SEMESTER_ID,
+      });
+
+      expect(result).toEqual({ submitted: false, archived: true });
+    });
+
+    it('CreateVersion should reject archived questionnaire', async () => {
+      questionnaireRepo.findOne.mockResolvedValue({
+        id: 'q1',
+        status: QuestionnaireStatus.ARCHIVED,
+        type: { id: 't1' },
+      } as any);
+
+      await expect(
+        service.CreateVersion('q1', {
+          meta: {
+            questionnaireType: 'T1',
+            scoringModel: 'SECTION_WEIGHTED',
+            version: 1,
+            maxScore: 5,
+          },
+          sections: [],
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('PublishVersion should reject archived questionnaire', async () => {
+      versionRepo.findOne.mockResolvedValue({
+        id: 'v1',
+        publishedAt: null,
+        questionnaire: {
+          status: QuestionnaireStatus.ARCHIVED,
+          type: { code: 'T1' },
+        },
+        schemaSnapshot: { meta: { maxScore: 5 }, sections: [] },
+      } as any);
+
+      await expect(service.PublishVersion('v1')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('DeprecateVersion should reject archived questionnaire', async () => {
+      versionRepo.findOne.mockResolvedValue({
+        id: 'v1',
+        status: QuestionnaireStatus.ACTIVE,
+        questionnaire: {
+          status: QuestionnaireStatus.ARCHIVED,
+          type: { code: 'T1' },
+        },
+      } as any);
+
+      await expect(service.DeprecateVersion('v1')).rejects.toThrow(
+        BadRequestException,
+      );
     });
   });
 });

--- a/src/modules/questionnaires/services/questionnaire.service.ts
+++ b/src/modules/questionnaires/services/questionnaire.service.ts
@@ -211,6 +211,28 @@ export class QuestionnaireService {
     return questionnaire;
   }
 
+  async UpdateTitle(questionnaireId: string, title: string) {
+    const questionnaire = await this.questionnaireRepo.findOne(
+      questionnaireId,
+      { populate: ['type'] },
+    );
+
+    if (!questionnaire) {
+      throw new NotFoundException(
+        `Questionnaire with ID ${questionnaireId} not found.`,
+      );
+    }
+
+    questionnaire.title = title;
+    await this.em.flush();
+    await this.cacheService.invalidateNamespaces(
+      CacheNamespace.QUESTIONNAIRE_TYPES,
+      CacheNamespace.QUESTIONNAIRE_VERSIONS,
+    );
+
+    return questionnaire;
+  }
+
   async CreateVersion(
     questionnaireId: string,
     schema: QuestionnaireSchemaSnapshot,
@@ -223,6 +245,12 @@ export class QuestionnaireService {
     if (!questionnaire) {
       throw new NotFoundException(
         `Questionnaire with ID ${questionnaireId} not found.`,
+      );
+    }
+
+    if (questionnaire.status === QuestionnaireStatus.ARCHIVED) {
+      throw new BadRequestException(
+        'Cannot create a version for an archived questionnaire.',
       );
     }
 
@@ -277,6 +305,12 @@ export class QuestionnaireService {
       throw new BadRequestException('Version is already published.');
     }
 
+    if (version.questionnaire.status === QuestionnaireStatus.ARCHIVED) {
+      throw new BadRequestException(
+        'Cannot publish a version for an archived questionnaire.',
+      );
+    }
+
     // Validate schema before publishing
     await this.validator.validate(version.schemaSnapshot);
 
@@ -318,6 +352,12 @@ export class QuestionnaireService {
       throw new BadRequestException('Version is already deprecated.');
     }
 
+    if (version.questionnaire.status === QuestionnaireStatus.ARCHIVED) {
+      throw new BadRequestException(
+        'Cannot deprecate a version for an archived questionnaire.',
+      );
+    }
+
     version.isActive = false;
     version.status = QuestionnaireStatus.DEPRECATED;
 
@@ -340,6 +380,32 @@ export class QuestionnaireService {
       CacheNamespace.QUESTIONNAIRE_VERSIONS,
     );
     return version;
+  }
+
+  async ArchiveQuestionnaire(questionnaireId: string) {
+    const questionnaire = await this.questionnaireRepo.findOne(
+      questionnaireId,
+      { populate: ['type'] },
+    );
+
+    if (!questionnaire) {
+      throw new NotFoundException(
+        `Questionnaire with ID ${questionnaireId} not found.`,
+      );
+    }
+
+    if (questionnaire.status === QuestionnaireStatus.ARCHIVED) {
+      throw new BadRequestException('Questionnaire is already archived.');
+    }
+
+    questionnaire.status = QuestionnaireStatus.ARCHIVED;
+    await this.em.flush();
+    await this.cacheService.invalidateNamespaces(
+      CacheNamespace.QUESTIONNAIRE_TYPES,
+      CacheNamespace.QUESTIONNAIRE_VERSIONS,
+    );
+
+    return questionnaire;
   }
 
   async GetVersionById(versionId: string): Promise<QuestionnaireVersion> {
@@ -431,6 +497,12 @@ export class QuestionnaireService {
     if (!version.isActive) {
       throw new BadRequestException(
         'Cannot submit to an inactive questionnaire version.',
+      );
+    }
+
+    if (version.questionnaire.status === QuestionnaireStatus.ARCHIVED) {
+      throw new BadRequestException(
+        'Cannot submit to an archived questionnaire.',
       );
     }
 
@@ -839,8 +911,17 @@ export class QuestionnaireService {
     facultyId: string;
     semesterId: string;
     courseId?: string;
-  }): Promise<{ submitted: boolean; submittedAt?: Date }> {
+  }): Promise<{ submitted: boolean; submittedAt?: Date; archived?: boolean }> {
     const respondentId = this.currentUserService.getOrFail().id;
+
+    const version = await this.versionRepo.findOne(query.versionId, {
+      populate: ['questionnaire'],
+    });
+
+    if (version?.questionnaire.status === QuestionnaireStatus.ARCHIVED) {
+      return { submitted: false, archived: true };
+    }
+
     const submission = await this.submissionRepo.findOne(
       {
         respondent: respondentId,


### PR DESCRIPTION
## Summary

- Add `ARCHIVED` status to `QuestionnaireStatus` enum (questionnaire-level only — versions keep `DRAFT`/`ACTIVE`/`DEPRECATED`)
- Add `PATCH /questionnaires/:id` endpoint to update questionnaire title (any status, SUPER_ADMIN/ADMIN)
- Add `PATCH /questionnaires/:id/archive` endpoint to archive a questionnaire (SUPER_ADMIN/ADMIN)
- Add archive guards in `submitQuestionnaire`, `CheckSubmission`, `CreateVersion`, `PublishVersion`, and `DeprecateVersion`
- Add migration to update the `questionnaire` table check constraint to include `ARCHIVED`

## Test plan

- [x] 91 unit tests passing (68 service + 23 controller)
- [x] Lint clean
- [x] Run `npx mikro-orm migration:up` against dev database
- [x] Create questionnaire, archive it, verify submit and check-submission reject it
- [x] Verify title update works across all statuses

Closes #163