### PR TITLE
FAC-81 feat: set up OpenAI Codex CLI project scaffolding

### DIFF
--- a/.codex/commands/generate-moodle-index.md
+++ b/.codex/commands/generate-moodle-index.md
@@ -1,0 +1,60 @@
+# Generate Moodle Index
+
+Purpose: generate a searchable index from the Moodle API PDF documentation.
+
+## Source
+
+- PDF: `docs/moodle/moodle_api_documentation.pdf`
+
+## Output
+
+- File: `docs/moodle/moodle_api_index.md`
+
+## Workflow
+
+1. Read the PDF in batches and identify each Moodle web-service function entry.
+2. Extract only summary metadata:
+   - exact `wsfunction`
+   - one-line description
+   - start page
+   - compact parameter summary
+   - abbreviated return shape
+   - AJAX availability
+3. Write a pipe-delimited index with one function per line.
+4. Avoid duplicate entries when a function spans page boundaries.
+5. Finalize the header with the generation date and total function count.
+
+## Expected Index Format
+
+Header:
+
+```md
+# Moodle API Function Index
+
+Generated from: docs/moodle/moodle_api_documentation.pdf
+Generated on: {YYYY-MM-DD}
+Total functions: {count}
+
+## How to Use
+
+- By component: `grep "core_message" docs/moodle/moodle_api_index.md`
+- By keyword: `grep -i "send.*message" docs/moodle/moodle_api_index.md`
+- By action: `grep -i "completion" docs/moodle/moodle_api_index.md`
+
+## Functions
+
+<!-- FORMAT: wsfunction | description | page | params | return_shape | ajax -->
+```
+
+Entry:
+
+```text
+function_name | description | start_page | params_summary | return_shape | ajax
+```
+
+## Constraints
+
+- Keep descriptions concise.
+- Do not extract full XML-RPC or REST payload examples.
+- Use `...` to abbreviate large return shapes.
+- Maintain the PDF's alphabetical ordering.

--- a/.codex/commands/moodle-api-agent.md
+++ b/.codex/commands/moodle-api-agent.md
@@ -1,0 +1,46 @@
+# Moodle API Agent
+
+Purpose: provision new Moodle REST API integrations in the Faculytics NestJS backend.
+
+## Prerequisite
+
+The searchable index must exist at `docs/moodle/moodle_api_index.md`. If it does not, generate it first using `.codex/commands/generate-moodle-index.md`.
+
+## Workflow
+
+1. Clarify the requested Moodle capability.
+   - Determine the operation, expected consumer, and whether the user already knows the `wsfunction`.
+2. Search `docs/moodle/moodle_api_index.md` for candidate functions.
+   - Present the most relevant matches with function name, page, params, and return shape.
+   - Confirm which function to integrate before proceeding.
+3. Read the full PDF entry for the selected function from `docs/moodle/moodle_api_documentation.pdf`.
+   - Extract arguments, REST encoding, response shape, and access restrictions.
+4. Resolve credentials from `.env`.
+   - Use `MOODLE_BASE_URL` and `MOODLE_MASTER_KEY` unless the user provides overrides.
+5. Test the API against the real Moodle instance with `curl`.
+   - Always ask before executing write operations.
+   - Use `application/x-www-form-urlencoded` POSTs to `/webservice/rest/server.php`.
+6. Compare the real response to the documented response.
+   - Note missing, extra, or type-shifted fields.
+   - Prefer optional DTO fields when the Moodle behavior is version-dependent.
+7. Scaffold the NestJS integration using existing project patterns.
+
+## Scaffolding Targets
+
+- `src/modules/moodle/lib/moodle.constants.ts`
+  - Add the `MoodleWebServiceFunction` enum entry.
+- `src/modules/moodle/dto/responses/*.response.dto.ts`
+  - Follow existing validation and transformation patterns.
+- `src/modules/moodle/lib/moodle.types.ts`
+  - Re-export any new DTOs.
+- `src/modules/moodle/lib/moodle.client.ts`
+  - Add a typed client method that calls `this.call<T>()`.
+- Relevant service or controller layer files, only if the requested feature needs them.
+- Tests matching the touched patterns.
+
+## Rules
+
+- Follow existing DTO, client, and module patterns exactly.
+- Convert outgoing param values to strings when building Moodle REST payloads.
+- Do not write integration code until the function choice and API behavior are verified.
+- For write operations, require explicit user confirmation before live testing.

--- a/.codex/commands/promote-backlog.md
+++ b/.codex/commands/promote-backlog.md
@@ -1,0 +1,41 @@
+# Promote Backlog
+
+Purpose: promote a GitHub issue from Backlog to Ready on the Faculytics project board and assign the next `FAC-XX` ticket number.
+
+## Project Context
+
+- Org: `CtrlAltElite-Devs`
+- Repo: `api.faculytics`
+- Project number: `1`
+- Project ID: `PVT_kwDODSVvHc4BRISI`
+- Status field ID: `PVTSSF_lADODSVvHc4BRISIzg_DCfA`
+- Ready option ID: `32dbe553`
+- Ticket prefix: `FAC-`
+
+## Workflow
+
+1. List project items with:
+   - `gh project item-list 1 --owner CtrlAltElite-Devs --format json --limit 100`
+2. Filter for issues whose status is `Backlog`.
+3. Let the user choose which backlog issue to promote, unless they already provided an issue number.
+4. Inspect existing issue titles to determine the next unused `FAC-XX` number.
+5. Propose a final title in the format:
+   - `FAC-XX type: description`
+6. Confirm before making changes.
+7. Update the issue title if needed:
+   - `gh issue edit <number> --repo CtrlAltElite-Devs/api.faculytics --title "FAC-XX type: description"`
+8. Move the project item to `Ready`:
+   - `gh project item-edit --project-id PVT_kwDODSVvHc4BRISI --id <item-id> --field-id PVTSSF_lADODSVvHc4BRISIzg_DCfA --single-select-option-id 32dbe553`
+
+## Rules
+
+- Verify the `FAC-XX` number is unused before assigning it.
+- If the issue already has a `FAC-XX` prefix, skip renaming and only move it.
+- Use one of these title types when suggesting the new title:
+  - `feat`
+  - `fix`
+  - `chore`
+  - `refactor`
+  - `docs`
+  - `test`
+  - `perf`

--- a/.codex/skills/neon-postgres/SKILL.md
+++ b/.codex/skills/neon-postgres/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: neon-postgres
+description: Guides and best practices for working with Neon Serverless Postgres. Covers setup, local development, connection methods, Neon features, and platform tooling.
+---
+
+# Neon Serverless Postgres
+
+Use this skill for Neon-related architecture, operational guidance, and implementation decisions.
+
+## Source Of Truth
+
+Prefer current Neon documentation over memory. Relevant docs can be fetched as markdown, and the docs index is available at:
+
+- `https://neon.com/docs/llms.txt`
+
+## Recommended Topic Areas
+
+- What Neon is and how its branching and compute model works
+- Getting started and choosing a connection approach
+- `@neondatabase/serverless` usage
+- `@neondatabase/neon-js` usage
+- Local development and Neon tooling
+- Neon CLI workflows
+- Neon REST API and SDKs
+- Neon Auth
+- Branching, autoscaling, and scale-to-zero
+- Read replicas, connection pooling, IP allow lists, and logical replication
+
+## Working Rules
+
+- Verify claims against the official Neon docs when specifics matter.
+- Do not guess feature behavior or API details.
+- Prefer the right Neon topic page for the specific task instead of broad summaries.
+- When implementation advice depends on runtime constraints, choose the connection method accordingly.

--- a/.codex/skills/update-docs/SKILL.md
+++ b/.codex/skills/update-docs/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: update-docs
+description: Update project documentation in docs/ to reflect recent code changes, new features, or architectural decisions.
+---
+
+# Update Documentation
+
+Review the recent code changes on the current branch and update the project documentation accordingly.
+
+## Documentation Structure
+
+The docs live in `docs/` with this layout:
+
+- `docs/architecture/` - System design, module architecture, component descriptions
+- `docs/decisions/` - Architectural decision records
+- `docs/workflows/` - Step-by-step flows
+- `docs/ROADMAP.md` - High-level project roadmap
+
+## Process
+
+1. Identify what changed.
+   - Run `git diff master...HEAD --name-only` and read the relevant source files.
+2. Determine which docs need updating.
+   - New module or major component: add or update `docs/architecture/`
+   - New architectural pattern or trade-off: update `docs/decisions/decisions.md`
+   - New user-facing flow or integration: add or update `docs/workflows/`
+   - Changed behavior: update the relevant existing doc
+3. Read the target docs before editing.
+   - Match their existing tone and structure.
+4. Update systematically.
+   - Prefer editing existing docs over creating redundant ones.
+   - Cross-reference related docs with relative links.
+5. Keep the docs concise.
+   - Focus on why and how, not code restatement.
+
+## Optional Focus
+
+If a task provides a specific topic, narrow the documentation update to that topic.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,206 @@
+# AGENTS.md
+
+This file provides guidance to OpenAI Codex CLI when working with code in this repository.
+
+## Project Overview
+
+Faculytics API is a NestJS backend for an analytics platform that integrates with Moodle LMS. It uses MikroORM with PostgreSQL, JWT authentication via Passport, and Zod for configuration validation.
+
+## Common Commands
+
+```bash
+# Development
+npm run start:dev          # Start with watch mode
+npm run build              # Build the project
+npm run lint               # Lint and auto-fix
+docker compose up          # Start Redis + mock worker for local dev
+
+# Testing
+npm run test               # Run unit tests
+npm run test -- --testPathPattern=<pattern>  # Run specific test file
+npm run test:e2e           # Run E2E tests
+npm run test:cov           # Run tests with coverage
+
+# Database (MikroORM)
+npx mikro-orm migration:create   # Create a new migration
+npx mikro-orm migration:up       # Apply pending migrations
+npx mikro-orm migration:list     # Check migration status
+```
+
+## Architecture
+
+### Module Organization
+
+The app uses a split between **Infrastructure** and **Application** modules (`src/modules/index.module.ts`):
+
+- **InfrastructureModules**: ConfigModule, PassportModule, MikroOrmModule, JwtModule, ScheduleModule, BullModule, TerminusModule
+- **ApplicationModules**: HealthModule, MoodleModule, AuthModule, ChatKitModule, EnrollmentsModule, QuestionnaireModule, AnalysisModule
+
+### Key Patterns
+
+**Entity Base Class** (`src/entities/base.entity.ts`):
+
+- All entities extend `CustomBaseEntity` with UUID primary key, timestamps, and soft delete
+- Soft delete is enforced globally via MikroORM filter in `mikro-orm.config.ts`
+
+**Custom Repository Pattern**:
+
+- Entities specify their repository: `@Entity({ repository: () => UserRepository })`
+- Repositories are in `src/repositories/`
+
+**Environment Configuration**:
+
+- Zod schemas in `src/configurations/env/` validate all env vars at startup
+- Access validated env via `import { env } from 'src/configurations/index.config'`
+
+**JWT Authentication**:
+
+- Use `@UseJwtGuard()` decorator from `src/security/decorators/` to protect endpoints
+- Two Passport strategies: `jwt` (access token) and `refresh-jwt` (refresh token)
+
+**Login Strategy Pattern** (`src/modules/auth/strategies/`):
+
+- Authentication uses the Strategy pattern via the `LoginStrategy` interface
+- Each strategy defines a `priority` (lower = higher precedence), `CanHandle()`, and `Execute()`
+- Priority ranges: `0-99` core auth (local passwords), `100-199` external providers (Moodle), `200+` fallbacks
+- **LocalLoginStrategy** (priority 10): bcrypt password comparison for users with local credentials
+- **MoodleLoginStrategy** (priority 100): Moodle token-based auth with user hydration
+- New strategies are registered via the `LOGIN_STRATEGIES` injection token
+
+**Cron Jobs** (`src/crons/`):
+
+- Extend `BaseJob` class which provides startup execution and graceful shutdown
+- Jobs register results in `StartupJobRegistry` for boot summary
+- **Active jobs:**
+  - `RefreshTokenCleanupJob`: Purges expired refresh tokens every 12 hours (7-day retention)
+
+**Moodle Sync Scheduling** (`src/modules/moodle/schedulers/`):
+
+- Dynamic cron via `SchedulerRegistry` (no static `@Cron()` decorator)
+- Interval resolves: DB (`SystemConfig`) > env var (`MOODLE_SYNC_INTERVAL_MINUTES`) > per-env default
+- Admin-configurable at runtime via `PUT /moodle/sync/schedule` (min 30 minutes)
+- `SyncLog` entity tracks every sync with per-phase metrics (fetched, inserted, updated, deactivated)
+- `SyncLog` does not extend `CustomBaseEntity` so queries must use `filters: { softDelete: false }`
+
+**Analysis Job Queue**:
+
+- BullMQ on Redis provides async job processing for AI analysis tasks
+- Each analysis type (sentiment, topic model, embeddings) has its own BullMQ queue and processor
+- Entry points are `AnalysisService.EnqueueJob()` and `EnqueueBatch()`
+- `BaseAnalysisProcessor` handles HTTP dispatch to external workers, Zod validation of responses, retry or error handling, and observability events
+- `mock-worker/` contains a Hono HTTP server that mimics worker responses for local development
+
+**Ingestion Engine** (`src/modules/questionnaires/ingestion/`):
+
+- `SourceAdapter` defines `extract()` as an async generator for streaming records
+- CSV and Excel adapters live in `adapters/`
+- `IngestionEngine` handles concurrency control, dry-run support, and timeout handling
+- `IngestionMapperService` maps raw data into domain entities
+
+**Moodle Integration**:
+
+- `MoodleModule` handles communication with Moodle LMS
+- Users are synced from Moodle site info
+- Enrollments, categories, and courses are synced via scheduled jobs
+- `MoodleClient` enforces a 10-second request timeout on Moodle API calls
+- Network and timeout errors are wrapped in `MoodleConnectivityError` and surfaced as 401 responses
+
+## Testing
+
+Tests use NestJS `TestingModule` with Jest mocks:
+
+```typescript
+const module: TestingModule = await Test.createTestingModule({
+  providers: [
+    ServiceUnderTest,
+    { provide: Dependency, useValue: { method: jest.fn() } },
+  ],
+}).compile();
+```
+
+## Code Style Rules
+
+- Implement only the change requested by the issue or task; do not add speculative features
+- Prefer the existing module and repository patterns over new abstractions
+- Do not add backwards-compatibility shims unless the requirement explicitly calls for them
+- Keep changes consistent with the current NestJS, MikroORM, and DTO structure already used in the codebase
+- Update tests when behavior changes or when adding logic that can regress
+
+## Custom Workflows
+
+Repository-specific Codex workflow docs live in `.codex/commands/`.
+
+- `.codex/commands/generate-moodle-index.md` - Build or refresh the searchable Moodle API index from the PDF in `docs/moodle/`
+- `.codex/commands/moodle-api-agent.md` - Research and scaffold new Moodle API integrations using the indexed PDF docs and the existing NestJS patterns
+- `.codex/commands/promote-backlog.md` - Promote a GitHub issue from Backlog to Ready with the next `FAC-XX` ticket number
+
+These mirror the non-BMAD custom Claude commands in `.claude/commands/`. Prefer the Codex copies when following project-specific workflows.
+
+## Custom Skills
+
+Repository-specific Codex skills live in `.codex/skills/`.
+
+- `.codex/skills/update-docs/SKILL.md` - Review branch changes and update `docs/` to match the current implementation
+- `.codex/skills/neon-postgres/SKILL.md` - Neon Serverless Postgres guidance and reference links for Neon-related work
+
+These mirror the repo-local Claude skills in `.claude/skills/`.
+
+## Custom Skills
+
+Repository-specific Codex skills live in `.codex/skills/`.
+
+- `.codex/skills/update-docs/SKILL.md` - Review branch changes and update `docs/` to match the current implementation
+- `.codex/skills/neon-postgres/SKILL.md` - Neon Serverless Postgres guidance and reference links for Neon-related work
+
+These mirror the repo-local Claude skills in `.claude/skills/`.
+
+## Project Board And Workflow
+
+The project is tracked on a GitHub Projects board.
+
+### Issue Lifecycle
+
+1. **Backlog** - Issues are created freely (rough ideas, bugs, feature requests). No ticket number required yet.
+2. **Ready** - During refinement, the issue is cleaned up with details and scope, then assigned a `FAC-XX` ticket number in the title. The ticket number signals the issue is well-defined and ready to be picked up.
+3. **In Progress** - A developer picks up the issue and begins work.
+4. **In Review** - A PR is opened and linked to the issue.
+5. **In Develop** - PR is merged into the `develop` branch.
+6. **In Staging** - The merge commit is cherry-picked onto the `staging` branch for pre-production validation.
+7. **Done** - Deployed to production.
+
+### Conventions
+
+- Issue titles follow the format: `FAC-XX type: description` (example: `FAC-33 feat: add Moodle connectivity error handling`)
+- PR titles should match their issue title
+- Issue bodies should include the PR link and merge commit hash for cherry-pick reference when moving to staging
+- The `FAC-XX` ticket number prefix is the quality gate; only assigned issues are ready for development
+
+## Configuration
+
+Required environment variables (see `.env.sample`):
+
+- `PORT`: Server port (default: `5200`)
+- `NODE_ENV`: `development` | `production` | `test` (default: `development`)
+- `DATABASE_URL`: PostgreSQL connection string (supports Neon.tech SSL)
+- `MOODLE_BASE_URL`: Moodle instance URL
+- `MOODLE_MASTER_KEY`: Moodle web services master key
+- `JWT_SECRET`, `REFRESH_SECRET`: Token signing secrets
+- `CORS_ORIGINS`: JSON array of allowed origins
+- `OPENAI_API_KEY`: OpenAI API key (for ChatKit module)
+- `REDIS_URL`: Redis connection URL (used for caching and job queues)
+
+Optional:
+
+- `OPENAPI_MODE`: Set to `"true"` to enable Swagger docs (default: disabled)
+- `SYNC_ON_STARTUP`: Set to `"true"` to run Course and Enrollment sync on startup (default: disabled)
+- `SUPER_ADMIN_USERNAME`: Default super admin username (default: `superadmin`)
+- `SUPER_ADMIN_PASSWORD`: Default super admin password (default: `password123`)
+- `BULLMQ_DEFAULT_ATTEMPTS`: Job retry attempts (default: `3`)
+- `BULLMQ_DEFAULT_BACKOFF_MS`: Initial backoff delay in ms (default: `5000`)
+- `BULLMQ_DEFAULT_TIMEOUT_MS`: Job-level timeout in ms (default: `120000`)
+- `BULLMQ_HTTP_TIMEOUT_MS`: HTTP request timeout in ms (default: `90000`)
+- `BULLMQ_SENTIMENT_CONCURRENCY`: Sentiment processor concurrency (default: `3`)
+- `SENTIMENT_WORKER_URL`: RunPod or mock worker URL for sentiment analysis
+- `MOODLE_SYNC_INTERVAL_MINUTES`: Sync schedule interval in minutes (min `30`; defaults per env: dev=60, staging=360, prod=180)
+
+Keep `CLAUDE.md` and `AGENTS.md` in sync when project architecture or workflow guidance changes.

--- a/_bmad/_config/ides/codex.yaml
+++ b/_bmad/_config/ides/codex.yaml
@@ -1,0 +1,5 @@
+ide: codex
+configured_date: 2026-03-27T00:00:00.000Z
+last_updated: 2026-03-27T00:00:00.000Z
+configuration:
+  _noConfigNeeded: true

--- a/_bmad/_config/ides/gemini.yaml
+++ b/_bmad/_config/ides/gemini.yaml
@@ -1,5 +1,0 @@
-ide: gemini
-configured_date: 2026-02-17T01:08:38.022Z
-last_updated: 2026-02-17T12:15:13.073Z
-configuration:
-  _noConfigNeeded: true


### PR DESCRIPTION
## Summary
- add AGENTS.md as the Codex project instruction file
- mirror the repo-local non-BMAD Claude commands into .codex/commands
- mirror the repo-local Claude skills into .codex/skills and register the Codex IDE marker while removing Gemini

## Testing
- not run (documentation and repo scaffolding only)

Closes #181