### PR TITLE
FAC-84 feat: add super admin user directory endpoint

### DIFF
--- a/src/modules/admin/admin.controller.spec.ts
+++ b/src/modules/admin/admin.controller.spec.ts
@@ -1,0 +1,57 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthGuard } from '@nestjs/passport';
+import { RolesGuard } from 'src/security/guards/roles.guard';
+import { AdminController } from './admin.controller';
+import { AdminService } from './services/admin.service';
+import { ListUsersQueryDto } from './dto/requests/list-users-query.dto';
+
+describe('AdminController', () => {
+  let controller: AdminController;
+  let adminService: { ListUsers: jest.Mock };
+
+  beforeEach(async () => {
+    adminService = {
+      ListUsers: jest.fn().mockResolvedValue({
+        data: [],
+        meta: {
+          totalItems: 0,
+          itemCount: 0,
+          itemsPerPage: 20,
+          totalPages: 0,
+          currentPage: 1,
+        },
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminController],
+      providers: [
+        {
+          provide: AdminService,
+          useValue: adminService,
+        },
+      ],
+    })
+      .overrideGuard(AuthGuard('jwt'))
+      .useValue({ canActivate: () => true })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get(AdminController);
+  });
+
+  it('should delegate user listing to the admin service', async () => {
+    const query: ListUsersQueryDto = {
+      search: 'john',
+      role: undefined,
+      isActive: true,
+      page: 2,
+      limit: 10,
+    };
+
+    await controller.ListUsers(query);
+
+    expect(adminService.ListUsers).toHaveBeenCalledWith(query);
+  });
+});

--- a/src/modules/admin/admin.controller.ts
+++ b/src/modules/admin/admin.controller.ts
@@ -1,16 +1,90 @@
-import { Body, Controller, Delete, Post } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Delete, Get, Post, Query } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { UseJwtGuard } from 'src/security/decorators';
 import { UserRole } from '../auth/roles.enum';
 import { AdminService } from './services/admin.service';
 import { AssignInstitutionalRoleDto } from './dto/requests/assign-institutional-role.request.dto';
 import { RemoveInstitutionalRoleDto } from './dto/requests/remove-institutional-role.request.dto';
+import { ListUsersQueryDto } from './dto/requests/list-users-query.dto';
+import { AdminUserListResponseDto } from './dto/responses/admin-user-list.response.dto';
 
 @ApiTags('Admin')
 @Controller('admin')
 @UseJwtGuard(UserRole.SUPER_ADMIN)
+@ApiBearerAuth()
 export class AdminController {
   constructor(private readonly adminService: AdminService) {}
+
+  @Get('users')
+  @ApiOperation({ summary: 'List users for the admin console' })
+  @ApiQuery({
+    name: 'search',
+    required: false,
+    type: String,
+    example: 'john',
+    description: 'Search by username, full name, first name, last name, or id',
+  })
+  @ApiQuery({
+    name: 'role',
+    required: false,
+    enum: UserRole,
+    example: UserRole.FACULTY,
+    description: 'Filter by a role contained in the user roles array',
+  })
+  @ApiQuery({
+    name: 'isActive',
+    required: false,
+    type: Boolean,
+    example: true,
+    description: 'Filter by active or inactive users',
+  })
+  @ApiQuery({
+    name: 'campusId',
+    required: false,
+    type: String,
+    example: '3f6dd1dd-8f33-4b2e-bb0b-6ac2d8bbf5d7',
+    description: 'Filter by campus UUID',
+  })
+  @ApiQuery({
+    name: 'departmentId',
+    required: false,
+    type: String,
+    example: '9ad12fa1-6286-4461-93f8-33b48d2e5725',
+    description: 'Filter by department UUID',
+  })
+  @ApiQuery({
+    name: 'programId',
+    required: false,
+    type: String,
+    example: 'd8be53aa-59c0-4d1f-b7c8-1e739bf6e1e2',
+    description: 'Filter by program UUID',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    example: 1,
+    description: 'Page number starting at 1',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    example: 20,
+    description: 'Items per page, max 100',
+  })
+  @ApiResponse({ status: 200, type: AdminUserListResponseDto })
+  async ListUsers(
+    @Query() query: ListUsersQueryDto,
+  ): Promise<AdminUserListResponseDto> {
+    return this.adminService.ListUsers(query);
+  }
 
   @Post('institutional-roles')
   @ApiOperation({

--- a/src/modules/admin/dto/requests/list-users-query.dto.ts
+++ b/src/modules/admin/dto/requests/list-users-query.dto.ts
@@ -1,0 +1,64 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+import { UserRole } from 'src/modules/auth/roles.enum';
+import { BooleanQueryTransform } from 'src/modules/common/transforms/boolean-query.transform';
+
+export class ListUsersQueryDto {
+  @ApiPropertyOptional({
+    description: 'Search by username, full name, first name, last name, or id',
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  search?: string;
+
+  @ApiPropertyOptional({ enum: UserRole, description: 'Filter by user role' })
+  @IsEnum(UserRole)
+  @IsOptional()
+  role?: UserRole;
+
+  @ApiPropertyOptional({ description: 'Filter by active status' })
+  @IsOptional()
+  @BooleanQueryTransform()
+  isActive?: boolean;
+
+  @ApiPropertyOptional({ description: 'Filter by campus UUID' })
+  @IsUUID()
+  @IsOptional()
+  campusId?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by department UUID' })
+  @IsUUID()
+  @IsOptional()
+  departmentId?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by program UUID' })
+  @IsUUID()
+  @IsOptional()
+  programId?: string;
+
+  @ApiPropertyOptional({ default: 1, minimum: 1 })
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  @Type(() => Number)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 20, minimum: 1, maximum: 100 })
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @IsOptional()
+  @Type(() => Number)
+  limit?: number = 20;
+}

--- a/src/modules/admin/dto/responses/admin-user-item.response.dto.ts
+++ b/src/modules/admin/dto/responses/admin-user-item.response.dto.ts
@@ -1,0 +1,75 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { User } from 'src/entities/user.entity';
+import { UserRole } from 'src/modules/auth/roles.enum';
+
+class AdminUserScopedRelationDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  code: string;
+
+  @ApiPropertyOptional()
+  name?: string;
+}
+
+export class AdminUserItemResponseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  userName: string;
+
+  @ApiProperty()
+  fullName: string;
+
+  @ApiPropertyOptional()
+  moodleUserId?: number;
+
+  @ApiProperty({ enum: UserRole, isArray: true })
+  roles: UserRole[];
+
+  @ApiProperty()
+  isActive: boolean;
+
+  @ApiPropertyOptional({ type: AdminUserScopedRelationDto, nullable: true })
+  campus: AdminUserScopedRelationDto | null;
+
+  @ApiPropertyOptional({ type: AdminUserScopedRelationDto, nullable: true })
+  department: AdminUserScopedRelationDto | null;
+
+  @ApiPropertyOptional({ type: AdminUserScopedRelationDto, nullable: true })
+  program: AdminUserScopedRelationDto | null;
+
+  static Map(user: User): AdminUserItemResponseDto {
+    return {
+      id: user.id,
+      userName: user.userName,
+      fullName: user.fullName ?? `${user.firstName} ${user.lastName}`.trim(),
+      moodleUserId: user.moodleUserId,
+      roles: user.roles,
+      isActive: user.isActive,
+      campus: user.campus
+        ? {
+            id: user.campus.id,
+            code: user.campus.code,
+            name: user.campus.name,
+          }
+        : null,
+      department: user.department
+        ? {
+            id: user.department.id,
+            code: user.department.code,
+            name: user.department.name,
+          }
+        : null,
+      program: user.program
+        ? {
+            id: user.program.id,
+            code: user.program.code,
+            name: user.program.name,
+          }
+        : null,
+    };
+  }
+}

--- a/src/modules/admin/dto/responses/admin-user-list.response.dto.ts
+++ b/src/modules/admin/dto/responses/admin-user-list.response.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PaginationMeta } from 'src/modules/common/dto/pagination.dto';
+import { AdminUserItemResponseDto } from './admin-user-item.response.dto';
+
+export class AdminUserListResponseDto {
+  @ApiProperty({ type: [AdminUserItemResponseDto] })
+  data: AdminUserItemResponseDto[];
+
+  @ApiProperty({ type: PaginationMeta })
+  meta: PaginationMeta;
+}

--- a/src/modules/admin/services/admin.service.spec.ts
+++ b/src/modules/admin/services/admin.service.spec.ts
@@ -1,0 +1,188 @@
+import { EntityManager } from '@mikro-orm/postgresql';
+import { Test, TestingModule } from '@nestjs/testing';
+import { User } from 'src/entities/user.entity';
+import { UserRole } from 'src/modules/auth/roles.enum';
+import { AdminService } from './admin.service';
+
+describe('AdminService', () => {
+  let service: AdminService;
+  let em: {
+    findAndCount: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    em = {
+      findAndCount: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminService,
+        {
+          provide: EntityManager,
+          useValue: em,
+        },
+      ],
+    }).compile();
+
+    service = module.get(AdminService);
+  });
+
+  it('should return paginated users mapped for admin console display', async () => {
+    const user = {
+      id: 'user-1',
+      userName: 'jdoe',
+      fullName: 'John Doe',
+      moodleUserId: 123,
+      roles: [UserRole.FACULTY],
+      isActive: true,
+      campus: { id: 'campus-1', code: 'UCMN', name: 'Main' },
+      department: { id: 'dept-1', code: 'CCS', name: 'Computer Studies' },
+      program: { id: 'prog-1', code: 'BSCS', name: 'Computer Science' },
+    } as User;
+
+    em.findAndCount.mockResolvedValue([[user], 1]);
+
+    const result = await service.ListUsers({ page: 1, limit: 20 });
+
+    expect(result.data).toEqual([
+      {
+        id: 'user-1',
+        userName: 'jdoe',
+        fullName: 'John Doe',
+        moodleUserId: 123,
+        roles: [UserRole.FACULTY],
+        isActive: true,
+        campus: { id: 'campus-1', code: 'UCMN', name: 'Main' },
+        department: {
+          id: 'dept-1',
+          code: 'CCS',
+          name: 'Computer Studies',
+        },
+        program: {
+          id: 'prog-1',
+          code: 'BSCS',
+          name: 'Computer Science',
+        },
+      },
+    ]);
+    expect(result.meta).toEqual({
+      totalItems: 1,
+      itemCount: 1,
+      itemsPerPage: 20,
+      totalPages: 1,
+      currentPage: 1,
+    });
+  });
+
+  it('should build a search filter across id and name fields', async () => {
+    em.findAndCount.mockResolvedValue([[], 0]);
+
+    await service.ListUsers({ search: 'john', page: 1, limit: 20 });
+
+    expect(em.findAndCount).toHaveBeenCalledWith(
+      User,
+      expect.objectContaining({
+        $or: [
+          { id: { $ilike: '%john%' } },
+          { userName: { $ilike: '%john%' } },
+          { fullName: { $ilike: '%john%' } },
+          { firstName: { $ilike: '%john%' } },
+          { lastName: { $ilike: '%john%' } },
+        ],
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('should apply role, active state, and relation filters', async () => {
+    em.findAndCount.mockResolvedValue([[], 0]);
+
+    await service.ListUsers({
+      role: UserRole.SUPER_ADMIN,
+      isActive: false,
+      campusId: 'campus-1',
+      departmentId: 'dept-1',
+      programId: 'prog-1',
+      page: 1,
+      limit: 20,
+    });
+
+    expect(em.findAndCount).toHaveBeenCalledWith(
+      User,
+      {
+        roles: { $contains: [UserRole.SUPER_ADMIN] },
+        isActive: false,
+        campus: 'campus-1',
+        department: 'dept-1',
+        program: 'prog-1',
+      },
+      expect.any(Object),
+    );
+  });
+
+  it('should return null relation payloads when relation data is absent', async () => {
+    const user = {
+      id: 'user-2',
+      userName: 'asmith',
+      firstName: 'Anna',
+      lastName: 'Smith',
+      fullName: null,
+      roles: [UserRole.STUDENT],
+      isActive: false,
+      campus: null,
+      department: null,
+      program: null,
+    } as unknown as User;
+
+    em.findAndCount.mockResolvedValue([[user], 1]);
+
+    const result = await service.ListUsers({ page: 1, limit: 20 });
+
+    expect(result.data[0]).toEqual({
+      id: 'user-2',
+      userName: 'asmith',
+      fullName: 'Anna Smith',
+      moodleUserId: undefined,
+      roles: [UserRole.STUDENT],
+      isActive: false,
+      campus: null,
+      department: null,
+      program: null,
+    });
+  });
+
+  it('should use stable ordering and pagination options', async () => {
+    em.findAndCount.mockResolvedValue([[], 0]);
+
+    await service.ListUsers({ page: 3, limit: 15 });
+
+    expect(em.findAndCount).toHaveBeenCalledWith(
+      User,
+      {},
+      expect.objectContaining({
+        limit: 15,
+        offset: 30,
+        orderBy: { userName: 'ASC', id: 'ASC' },
+        populate: ['campus', 'department', 'program'],
+      }),
+    );
+  });
+
+  it('should return empty pagination metadata when there are no matches', async () => {
+    em.findAndCount.mockResolvedValue([[], 0]);
+
+    const result = await service.ListUsers({ page: 1, limit: 20 });
+
+    expect(result).toEqual({
+      data: [],
+      meta: {
+        totalItems: 0,
+        itemCount: 0,
+        itemsPerPage: 20,
+        totalPages: 0,
+        currentPage: 1,
+      },
+    });
+  });
+});

--- a/src/modules/admin/services/admin.service.ts
+++ b/src/modules/admin/services/admin.service.ts
@@ -1,3 +1,4 @@
+import { FilterQuery } from '@mikro-orm/core';
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { EntityManager } from '@mikro-orm/postgresql';
 import {
@@ -9,10 +10,41 @@ import { MoodleCategory } from 'src/entities/moodle-category.entity';
 import { Enrollment } from 'src/entities/enrollment.entity';
 import { AssignInstitutionalRoleDto } from '../dto/requests/assign-institutional-role.request.dto';
 import { RemoveInstitutionalRoleDto } from '../dto/requests/remove-institutional-role.request.dto';
+import { ListUsersQueryDto } from '../dto/requests/list-users-query.dto';
+import { AdminUserItemResponseDto } from '../dto/responses/admin-user-item.response.dto';
+import { AdminUserListResponseDto } from '../dto/responses/admin-user-list.response.dto';
 
 @Injectable()
 export class AdminService {
   constructor(private readonly em: EntityManager) {}
+
+  async ListUsers(query: ListUsersQueryDto): Promise<AdminUserListResponseDto> {
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    const offset = (page - 1) * limit;
+
+    const [users, totalItems] = await this.em.findAndCount(
+      User,
+      this.BuildUserFilter(query),
+      {
+        populate: ['campus', 'department', 'program'],
+        limit,
+        offset,
+        orderBy: { userName: 'ASC', id: 'ASC' },
+      },
+    );
+
+    return {
+      data: users.map((user) => AdminUserItemResponseDto.Map(user)),
+      meta: {
+        totalItems,
+        itemCount: users.length,
+        itemsPerPage: limit,
+        totalPages: Math.ceil(totalItems / limit),
+        currentPage: page,
+      },
+    };
+  }
 
   async AssignInstitutionalRole(dto: AssignInstitutionalRoleDto) {
     const user = await this.em.findOneOrFail(
@@ -92,5 +124,46 @@ export class AdminService {
 
     user.updateRolesFromEnrollments(enrollments, institutionalRoles);
     await this.em.flush();
+  }
+
+  private BuildUserFilter(query: ListUsersQueryDto): FilterQuery<User> {
+    const filter: FilterQuery<User> = {};
+
+    if (query.search) {
+      const search = `%${this.EscapeLikePattern(query.search.trim())}%`;
+      filter.$or = [
+        { id: { $ilike: search } },
+        { userName: { $ilike: search } },
+        { fullName: { $ilike: search } },
+        { firstName: { $ilike: search } },
+        { lastName: { $ilike: search } },
+      ];
+    }
+
+    if (query.role) {
+      filter.roles = { $contains: [query.role] };
+    }
+
+    if (query.isActive !== undefined) {
+      filter.isActive = query.isActive;
+    }
+
+    if (query.campusId) {
+      filter.campus = query.campusId;
+    }
+
+    if (query.departmentId) {
+      filter.department = query.departmentId;
+    }
+
+    if (query.programId) {
+      filter.program = query.programId;
+    }
+
+    return filter;
+  }
+
+  private EscapeLikePattern(value: string): string {
+    return value.replace(/[%_\\]/g, '\\$&');
   }
 }


### PR DESCRIPTION
## Summary
- add a super-admin-only `GET /admin/users` endpoint for the future admin console
- support paginated filtering by search, role, active status, and campus/department/program scope
- add response DTOs, OpenAPI query examples, and focused controller/service tests

## Verification
- npm test -- --runInBand src/modules/admin/admin.controller.spec.ts src/modules/admin/services/admin.service.spec.ts
- npm run build

Closes #187
