### PR TITLE
FAC-89 fix: username logged in plaintext in Moodle login error path

### DIFF
--- a/src/modules/auth/strategies/moodle-login.strategy.ts
+++ b/src/modules/auth/strategies/moodle-login.strategy.ts
@@ -57,7 +57,7 @@ export class MoodleLoginStrategy implements LoginStrategy {
     } catch (error) {
       if (error instanceof MoodleConnectivityError) {
         this.logger.error(
-          `Moodle connectivity failure during login for user "${body.username}": ${error.message}`,
+          `Moodle connectivity failure during login: ${error.message}`,
           error.cause?.stack,
         );
         throw new UnauthorizedException(


### PR DESCRIPTION
## Summary

- Removes plaintext username from the `MoodleLoginStrategy` error log when a `MoodleConnectivityError` occurs, eliminating PII exposure and user enumeration risk via log analysis
- Audited all other auth-path log messages — no other instances of raw username logging found

Closes #198

## Test plan

- [x] Lint passes (verified via pre-commit hook)
- [x] `npm run verify` passes (note: some test suites fail pre-existing due to missing env vars, unrelated to this change)
- [x] Manual review: confirm no username appears in log output during Moodle connectivity failure

https://claude.ai/code/session_01Nc5g565LNeaU51sPfPGKah