### PR TITLE
FAC-90 fix: LoginRequest DTO missing @IsNotEmpty and length constraints

### DIFF
--- a/src/modules/auth/auth.service.spec.ts
+++ b/src/modules/auth/auth.service.spec.ts
@@ -9,6 +9,9 @@ import { LOGIN_STRATEGIES, LoginStrategy } from './strategies';
 import { EntityManager } from '@mikro-orm/postgresql';
 import { CurrentUserService } from '../common/cls/current-user.service';
 import { RequestMetadataService } from '../common/cls/request-metadata.service';
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { LoginRequest } from './dto/requests/login.request.dto';
 
 const mockMetadata = {
   browserName: 'test',
@@ -292,5 +295,47 @@ describe('AuthService', () => {
         service.Login({ username: 'admin', password: 'wrong-password' }),
       ).rejects.toThrow(UnauthorizedException);
     });
+  });
+});
+
+describe('LoginRequest DTO validation', () => {
+  const toDto = (plain: Record<string, unknown>) =>
+    plainToInstance(LoginRequest, plain);
+
+  it('should pass with valid username and password', async () => {
+    const errors = await validate(
+      toDto({ username: 'admin', password: 'password123' }),
+    );
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should fail when username is empty', async () => {
+    const errors = await validate(
+      toDto({ username: '', password: 'password123' }),
+    );
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe('username');
+  });
+
+  it('should fail when password is empty', async () => {
+    const errors = await validate(toDto({ username: 'admin', password: '' }));
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe('password');
+  });
+
+  it('should fail when username exceeds max length', async () => {
+    const errors = await validate(
+      toDto({ username: 'a'.repeat(101), password: 'password123' }),
+    );
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe('username');
+  });
+
+  it('should fail when password exceeds max length', async () => {
+    const errors = await validate(
+      toDto({ username: 'admin', password: 'a'.repeat(256) }),
+    );
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe('password');
   });
 });

--- a/src/modules/auth/dto/requests/login.request.dto.ts
+++ b/src/modules/auth/dto/requests/login.request.dto.ts
@@ -1,9 +1,13 @@
-import { IsString } from 'class-validator';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
 
 export class LoginRequest {
   @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
   username: string;
 
   @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
   password: string;
 }


### PR DESCRIPTION
## Summary

- Add `@IsNotEmpty()` and `@MaxLength()` decorators to `LoginRequest` DTO fields (`username` max 100, `password` max 255)
- Aligns validation with `RefreshTokenRequestBody` which already uses `@IsNotEmpty()`
- Prevents empty strings from reaching the database and blocks oversized payloads before they hit bcrypt

## Test plan

- [x] Added 5 DTO validation tests: valid input passes, empty username/password rejected, oversized username/password rejected
- [x] All 586 existing tests pass
- [x] Lint and build pass (`npm run verify`)

Closes #196

https://claude.ai/code/session_01SCMpsmQ412qT6J7UrSuaPk