### PR TITLE
FAC-91 FAC-92 fix: include teacher role in faculty lookup and use EnrollmentRole enum

### DIFF
--- a/src/modules/enrollments/enrollments.service.spec.ts
+++ b/src/modules/enrollments/enrollments.service.spec.ts
@@ -225,6 +225,58 @@ describe('EnrollmentsService', () => {
     expect(result.data[0].semester).toBeNull();
   });
 
+  it('should return faculty data for teacher role (not just editingteacher)', async () => {
+    const mockEnrollments = [
+      {
+        id: 'e1',
+        role: 'student',
+        course: {
+          id: 'c1',
+          moodleCourseId: 101,
+          shortname: 'CS101',
+          fullname: 'Intro to CS',
+          courseImage: null,
+          program: {
+            department: {
+              semester: {
+                id: 'sem-1',
+                code: 'S12526',
+                label: '1st Semester',
+                academicYear: '2025-2026',
+              },
+            },
+          },
+        },
+      },
+    ];
+
+    const mockFacultyEnrollments = [
+      {
+        course: { id: 'c1' },
+        user: {
+          id: 'faculty-2',
+          fullName: 'Prof. Jones',
+          userName: 'EMP002',
+          userProfilePicture: null,
+        },
+      },
+    ];
+
+    (em.findAndCount as jest.Mock).mockResolvedValue([mockEnrollments, 1]);
+    (em.find as jest.Mock)
+      .mockResolvedValueOnce(mockFacultyEnrollments)
+      .mockResolvedValueOnce([]);
+
+    const result = await service.getMyEnrollments({ page: 1, limit: 10 });
+
+    expect(result.data[0].faculty).toEqual({
+      id: 'faculty-2',
+      fullName: 'Prof. Jones',
+      employeeNumber: 'EMP002',
+      profilePicture: undefined,
+    });
+  });
+
   it('should not query faculty or submissions when no enrollments exist', async () => {
     (em.findAndCount as jest.Mock).mockResolvedValue([[], 0]);
 

--- a/src/modules/enrollments/enrollments.service.ts
+++ b/src/modules/enrollments/enrollments.service.ts
@@ -8,6 +8,7 @@ import { CurrentUserService } from '../common/cls/current-user.service';
 import { MyEnrollmentsQueryDto } from './dto/requests/my-enrollments-query.dto';
 import { FacultyShortResponseDto } from './dto/responses/faculty-short.response.dto';
 import { MyEnrollmentsResponseDto } from './dto/responses/my-enrollments.response.dto';
+import { EnrollmentRole } from '../questionnaires/lib/questionnaire.types';
 
 @Injectable()
 export class EnrollmentsService {
@@ -124,7 +125,11 @@ export class EnrollmentsService {
 
     const facultyEnrollments = await this.em.find(
       Enrollment,
-      { course: { $in: courseIds }, role: 'editingteacher', isActive: true },
+      {
+        course: { $in: courseIds },
+        role: { $in: [EnrollmentRole.EDITING_TEACHER, EnrollmentRole.TEACHER] },
+        isActive: true,
+      },
       { populate: ['user', 'course'] },
     );
 

--- a/src/modules/faculty/services/faculty.service.ts
+++ b/src/modules/faculty/services/faculty.service.ts
@@ -17,6 +17,7 @@ import { FacultyCardResponseDto } from '../dto/responses/faculty-card.response.d
 import { SubmissionCountResponseDto } from '../dto/responses/submission-count.response.dto';
 import { Course } from 'src/entities/course.entity';
 import { FilterQuery } from '@mikro-orm/core';
+import { EnrollmentRole } from 'src/modules/questionnaires/lib/questionnaire.types';
 
 @Injectable()
 export class FacultyService {
@@ -127,7 +128,9 @@ export class FacultyService {
         Enrollment,
         {
           user: { $in: userIds },
-          role: { $in: ['editingteacher', 'teacher'] },
+          role: {
+            $in: [EnrollmentRole.EDITING_TEACHER, EnrollmentRole.TEACHER],
+          },
           isActive: true,
           course: this.BuildCourseFilter(query, departmentIds),
         },

--- a/src/modules/questionnaires/lib/questionnaire.types.ts
+++ b/src/modules/questionnaires/lib/questionnaire.types.ts
@@ -21,6 +21,7 @@ export enum RespondentRole {
 export enum EnrollmentRole {
   STUDENT = 'student',
   EDITING_TEACHER = 'editingteacher',
+  TEACHER = 'teacher',
 }
 
 export interface QuestionNode {


### PR DESCRIPTION
## Summary

- **FAC-91** (#202): `getFacultyByCourseIds()` now queries both `editingteacher` and `teacher` roles, fixing students seeing `faculty: null` for courses with a `teacher`-role instructor
- **FAC-92** (#203): Replaced raw `'editingteacher'` / `'teacher'` strings with `EnrollmentRole` enum values in both `enrollments.service.ts` and `faculty.service.ts`
- Added `TEACHER = 'teacher'` to the `EnrollmentRole` enum to centralize all faculty role strings
- Added unit test covering the `teacher` role case in enrollment faculty resolution

## Test plan

- [x] New test: faculty with `teacher` role returns correctly in enrollment response
- [x] All 29 existing enrollment + faculty service tests pass
- [x] Lint-staged passes on commit

Closes #202
Closes #203

https://claude.ai/code/session_01LNfjqKQstgZ7skvJ2oXAkf