### PR TITLE
FAC-93 perf: limit fields in getFacultyByCourseIds query

### DIFF
--- a/src/modules/enrollments/enrollments.service.ts
+++ b/src/modules/enrollments/enrollments.service.ts
@@ -130,7 +130,18 @@ export class EnrollmentsService {
         role: { $in: [EnrollmentRole.EDITING_TEACHER, EnrollmentRole.TEACHER] },
         isActive: true,
       },
-      { populate: ['user', 'course'] },
+      {
+        populate: ['user'],
+        fields: [
+          'course',
+          'user.id',
+          'user.fullName',
+          'user.firstName',
+          'user.lastName',
+          'user.userName',
+          'user.userProfilePicture',
+        ],
+      },
     );
 
     for (const enrollment of facultyEnrollments) {


### PR DESCRIPTION
## Summary

- Drop eager `Course` populate in `getFacultyByCourseIds()` — the FK `course.id` is already on the `Enrollment` entity
- Restrict `User` populate to only the 5 columns actually used in the mapping (`id`, `fullName`, `firstName`, `lastName`, `userName`, `userProfilePicture`)
- Follows the same `fields` pattern already used by `getSubmissionStatusByCourseIds()` in the same file

Closes #204

## Test plan

- [x] `enrollments.service.spec.ts` passes — all existing assertions hold
- [x] `npm run build` succeeds
- [x] Manual verification: enrollment card faculty data remains identical

https://claude.ai/code/session_01U2k8WWJ9EJ9b3Rzg4Vq81S