### PR TITLE
FAC-94 refactor: enrollment test relies on implicit Promise.all mock call order

### DIFF
--- a/src/modules/enrollments/enrollments.service.spec.ts
+++ b/src/modules/enrollments/enrollments.service.spec.ts
@@ -2,6 +2,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { EnrollmentsService } from './enrollments.service';
 import { EntityManager } from '@mikro-orm/core';
 import { User } from 'src/entities/user.entity';
+import { Enrollment } from 'src/entities/enrollment.entity';
+import { QuestionnaireSubmission } from 'src/entities/questionnaire-submission.entity';
 import { CacheService } from '../common/cache/cache.service';
 import { CurrentUserService } from '../common/cls/current-user.service';
 
@@ -92,10 +94,11 @@ describe('EnrollmentsService', () => {
     ];
 
     (em.findAndCount as jest.Mock).mockResolvedValue([mockEnrollments, 1]);
-    // Promise.all order: getFacultyByCourseIds first, getSubmissionStatusByCourseIds second
-    (em.find as jest.Mock)
-      .mockResolvedValueOnce(mockFacultyEnrollments)
-      .mockResolvedValueOnce([]);
+    (em.find as jest.Mock).mockImplementation((entity: unknown) => {
+      if (entity === Enrollment) return Promise.resolve(mockFacultyEnrollments);
+      if (entity === QuestionnaireSubmission) return Promise.resolve([]);
+      return Promise.resolve([]);
+    });
 
     const result = await service.getMyEnrollments({ page: 1, limit: 10 });
 
@@ -156,9 +159,12 @@ describe('EnrollmentsService', () => {
     const mockSubmissions = [{ course: { id: 'c1' }, submittedAt }];
 
     (em.findAndCount as jest.Mock).mockResolvedValue([mockEnrollments, 1]);
-    (em.find as jest.Mock)
-      .mockResolvedValueOnce([]) // faculty
-      .mockResolvedValueOnce(mockSubmissions); // submissions
+    (em.find as jest.Mock).mockImplementation((entity: unknown) => {
+      if (entity === Enrollment) return Promise.resolve([]);
+      if (entity === QuestionnaireSubmission)
+        return Promise.resolve(mockSubmissions);
+      return Promise.resolve([]);
+    });
 
     const result = await service.getMyEnrollments({ page: 1, limit: 10 });
 


### PR DESCRIPTION
## Summary

- Replace order-dependent `mockResolvedValueOnce` chains with argument-based `mockImplementation` in enrollment service tests
- Mock now matches on entity class (`Enrollment` vs `QuestionnaireSubmission`) instead of relying on `Promise.all` call order
- Tests are now resilient to internal reordering of concurrent queries in the service

Closes #205

## Changes

**`src/modules/enrollments/enrollments.service.spec.ts`**

- Added imports for `Enrollment` and `QuestionnaireSubmission` entity classes
- Replaced `mockResolvedValueOnce` chains in two test cases with `mockImplementation` that dispatches based on the entity argument passed to `em.find`

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] All 5 enrollment service tests pass (`enrollments.service.spec.ts`)
- [x] Mocks return correct data regardless of `Promise.all` array ordering

https://claude.ai/code/session_012UsMjq61dUvFhErpChg9cR