### PR TITLE
FAC-100 fix: resolve critical handlebars vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8027,9 +8027,9 @@
       "license": "ISC"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,8 @@
     },
     "@rushstack/node-core-library": {
       "ajv": "8.18.0"
-    }
+    },
+    "handlebars": "^4.7.9"
   },
   "jest": {
     "moduleFileExtensions": [


### PR DESCRIPTION
## Summary

- Adds `handlebars: "^4.7.9"` to `overrides` in `package.json` to resolve 8 critical/high vulnerabilities (JS injection, XSS, prototype pollution) in the transitive `handlebars` dependency pulled in by `ts-jest`
- Upgrades `handlebars` from `4.7.8` → `4.7.9`
- `npm audit` confirms all handlebars advisories are resolved

## Test plan

- [x] Verify `npm audit` no longer reports handlebars vulnerabilities
- [x] Verify `npm install` completes without errors
- [x] Verify existing tests pass (`npm run test`)

Closes #220

https://claude.ai/code/session_01R7yFfaeTSDWFSSmYU4AVtS