### PR TITLE
FAC-101 fix: resolve high severity path-to-regexp ReDoS in NestJS v11 packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11231,9 +11231,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.1.tgz",
+      "integrity": "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,8 @@
     },
     "@rushstack/node-core-library": {
       "ajv": "8.18.0"
-    }
+    },
+    "path-to-regexp": "8.4.1"
   },
   "jest": {
     "moduleFileExtensions": [


### PR DESCRIPTION
## Summary

- Pin `path-to-regexp` to `8.4.1` via npm `overrides` to fix two high-severity ReDoS vulnerabilities ([GHSA-j3q9-mxjg-w52f](https://github.com/advisories/GHSA-j3q9-mxjg-w52f), [GHSA-27v5-c462-wpq7](https://github.com/advisories/GHSA-27v5-c462-wpq7))
- Avoids a breaking `@nestjs/swagger` major version upgrade by using overrides instead of `npm audit fix --force`
- All transitive consumers (`@nestjs/core`, `@nestjs/platform-express`, `@nestjs/swagger`, `express`) now resolve to `8.4.1`

## Test plan

- [x] `npm audit` no longer reports `path-to-regexp` vulnerabilities
- [x] `npm run build` passes
- [x] `npm test` — all 330 tests pass (pre-existing env validation failures unrelated)

Closes #221

https://claude.ai/code/session_01BHq6RFwCFioLF9XzNAYvRm