### PR TITLE
FAC-102 feat: reshape pipeline status endpoint for frontend polling

### DIFF
--- a/_bmad-output/implementation-artifacts/tech-spec-frontend-pipeline-polling.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-frontend-pipeline-polling.md
@@ -10,6 +10,7 @@ files_to_modify:
   - 'src/modules/analysis/dto/pipeline-status.dto.ts'
   - 'src/modules/analysis/services/pipeline-orchestrator.service.ts'
   - 'src/modules/analysis/services/pipeline-orchestrator.service.spec.ts'
+  - 'src/modules/analysis/analysis.controller.spec.ts'
 code_patterns:
   - 'PascalCase public service methods'
   - 'Zod schemas for response DTOs'
@@ -74,7 +75,7 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 | ---- | ------- |
 | `src/modules/analysis/dto/pipeline-status.dto.ts` | Zod schema for status response — `pipelineStatusSchema`, `stageStatusSchema`, `PipelineStatusResponse` type |
 | `src/entities/base.entity.ts` | `CustomBaseEntity` — defines shared `updatedAt` without `onUpdate` hook (Task 0 overrides on pipeline entity instead) |
-| `src/modules/analysis/services/pipeline-orchestrator.service.ts` | `GetPipelineStatus()` at ~line 438 — constructs response from pipeline + run entities (up to 8 DB queries after adding sentiment COUNT) |
+| `src/modules/analysis/services/pipeline-orchestrator.service.ts` | `GetPipelineStatus()` at ~line 438 — constructs response from pipeline + run entities (up to 7 DB queries after adding sentiment COUNT; some conditional) |
 | `src/modules/analysis/analysis.controller.ts` | Status endpoint at line 69 — `GET pipelines/:id/status`, delegates to orchestrator |
 | `src/entities/analysis-pipeline.entity.ts` | Pipeline entity — has `updatedAt` (inherited from CustomBaseEntity), `status`, `commentCount`, `sentimentGateIncluded/Excluded` |
 | `src/entities/sentiment-run.entity.ts` | SentimentRun — `status: RunStatus`, `submissionCount`, has `results` collection |
@@ -122,7 +123,7 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
       completedAt: z.string().datetime().nullable(),
     });
     ```
-  - Notes: This removes the old `total`, `completed`, `processed`, `included`, `excluded` optional fields. The `progress` object is either fully present or `null`. `startedAt` and `completedAt` give the frontend elapsed-time signal.
+  - Notes: This removes the old `total`, `completed`, `processed`, `included`, `excluded` optional fields. The `progress` object is either fully present or `null`. `startedAt` and `completedAt` give the frontend elapsed-time signal. **Preserve all existing top-level fields** (`confirmedAt`, `completedAt`, `createdAt`, `scope`, `coverage`, `warnings`). Only the `stages` shape, `errorMessage` optionality, and new fields (`retryable`, `updatedAt`) change.
 
 - [ ] Task 2: Add `retryable` and `updatedAt` to `pipelineStatusSchema`
   - File: `src/modules/analysis/dto/pipeline-status.dto.ts`
@@ -141,7 +142,16 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
       excluded: z.number().int().nullable(),
     });
     ```
-  - Update `stages` in `pipelineStatusSchema` to use `sentimentGateSchema` for the `sentimentGate` field.
+  - Update `stages` in `pipelineStatusSchema` — change the `sentimentGate` field from `stageStatusSchema` to `sentimentGateSchema`:
+    ```typescript
+    stages: z.object({
+      embeddings: stageStatusSchema,
+      sentiment: stageStatusSchema,
+      sentimentGate: sentimentGateSchema,  // ← changed from stageStatusSchema
+      topicModeling: stageStatusSchema,
+      recommendations: stageStatusSchema,
+    }),
+    ```
 
 - [ ] Task 4: Update `GetPipelineStatus()` — add sentiment progress count query
   - File: `src/modules/analysis/services/pipeline-orchestrator.service.ts`
@@ -156,9 +166,10 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 
 - [ ] Task 5: Update `GetPipelineStatus()` — reshape return object to match new DTO
   - File: `src/modules/analysis/services/pipeline-orchestrator.service.ts`
-  - **Ordering dependency**: Tasks 1-3 (DTO changes) must be completed before Tasks 4-6 (service changes). Do not implement in isolation — the intermediate state where the schema is updated but the service is not (or vice versa) will produce a compile error.
-  - Action: Replace the `stageStatus` helper and reshape the return object. Key changes:
-    1. Remove the `stageStatus()` and `getRunStageStatus()` helpers. Replace with a new helper:
+  - **Ordering dependency**: Tasks 1-3 (DTO changes) must be completed before Tasks 4-5 (service changes). Do not implement in isolation — the intermediate state where the schema is updated but the service is not (or vice versa) will produce a compile error.
+  - Action: Replace the `stageStatus` helper, update `getEmbeddingStageStatus()`, and reshape the return object. Key changes:
+    1. **First**, update `getEmbeddingStageStatus()` (currently at line 937): change return type from `{ status }` object to bare status string. Verify it has only one call site (line 518) by grepping for `getEmbeddingStageStatus`. This must be done before step 4 below, which consumes it as a string.
+    2. Remove the `stageStatus()` and `getRunStageStatus()` helpers. Replace with a new helper:
        ```typescript
        const buildStage = (
          status: 'pending' | 'processing' | 'completed' | 'failed' | 'skipped',
@@ -171,38 +182,37 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
          completedAt: run?.completedAt?.toISOString() ?? null,
        });
        ```
-    2. Add a `getRunStatus` helper with a comment about enum coupling:
+    3. Add a `getRunStatus` helper with a comment about enum coupling:
        ```typescript
        // If RunStatus gains new values, update this mapping to match the stage status union
        const getRunStatus = (run: SentimentRun | TopicModelRun | RecommendationRun | null) =>
          run ? (run.status.toLowerCase() as 'pending' | 'processing' | 'completed' | 'failed') : 'pending';
        ```
-    3. Derive `gateStatus` before building the return block (handles terminal pipeline states):
+    4. Derive `gateStatus` before building the return block (handles terminal pipeline states):
        ```typescript
+       // Gate either completed (has data) or didn't. Top-level pipeline.status
+       // handles failure attribution — no per-stage failure tracking for MVP.
+       // FAILED pipelines: gate shows 'pending' (never completed) which is correct.
+       // CANCELLED pipelines: gate shows 'skipped' (explicitly not attempted).
        const gateStatus = pipeline.sentimentGateIncluded != null ? 'completed'
          : pipeline.status === PipelineStatus.SENTIMENT_GATE ? 'processing'
          : pipeline.status === PipelineStatus.CANCELLED ? 'skipped'
          : 'pending';
        ```
-    4. Update each stage in the return block:
+    5. Update each stage in the return block:
        - `embeddings`: `buildStage(this.getEmbeddingStageStatus(pipeline), null)` — no run entity, no progress. Note: `startedAt` and `completedAt` will always be `null` for this stage since there is no run entity. Frontend should use `pipeline.confirmedAt` as a proxy if timing is needed.
-       - `sentiment`: `buildStage(getRunStatus(sentimentRun), sentimentRun, { current: sentimentCompleted, total: sentimentRun?.submissionCount ?? pipeline.commentCount })` — real progress, uses run's own `submissionCount` as total for tighter coupling
+       - `sentiment`: when `sentimentRun` exists → `buildStage(getRunStatus(sentimentRun), sentimentRun, { current: sentimentCompleted, total: sentimentRun.submissionCount })` — real progress using run's own `submissionCount` as total. When `sentimentRun` is `null` → `buildStage('pending', null)` — no progress (consistent with binary "not started" pattern)
        - `sentimentGate`: `{ ...buildStage(gateStatus, null), included: pipeline.sentimentGateIncluded ?? null, excluded: pipeline.sentimentGateExcluded ?? null }` — note: `startedAt`/`completedAt` always `null` (no run entity, same as embeddings)
        - `topicModeling`: `buildStage(getRunStatus(topicModelRun), topicModelRun)`
        - `recommendations`: `buildStage(getRunStatus(recommendationRun), recommendationRun)`
-    5. Add to the top-level return: `updatedAt: pipeline.updatedAt.toISOString()` and `retryable: pipeline.status === PipelineStatus.FAILED`
-    6. Optional runtime safety net — add `return pipelineStatusSchema.parse(response)` at the end to catch schema/implementation drift at runtime (the Zod schema is currently only used for type inference via `z.infer`, not runtime validation)
+    6. Add to the top-level return: `updatedAt: pipeline.updatedAt.toISOString()` and `retryable: pipeline.status === PipelineStatus.FAILED`
+    7. Optional runtime safety net — add `return pipelineStatusSchema.parse(response)` at the end to catch schema/implementation drift at runtime (the Zod schema is currently only used for type inference via `z.infer`, not runtime validation)
   - Notes:
     - For `retryable`, all current failure modes are transient (worker timeouts, network errors), so `status === FAILED` is sufficient. The flag provides intent signaling — when error categories are added later, `retryable` becomes meaningful without a frontend change. Add a code comment: `// Intent signal for future error categorization — currently equivalent to status === FAILED`
     - `startedAt` uses `run.createdAt` as a proxy — this is the best available approximation since run entities don't have a dedicated `startedAt` field. Runs are created at enqueue time, which is close to processing start for the polling UI's purposes.
   - **Commit strategy**: Split this task into two commits for reviewability: (a) replace helpers + reshape return block, (b) add `updatedAt` + `retryable` top-level fields.
 
-- [ ] Task 6: Update `getEmbeddingStageStatus()` return type
-  - File: `src/modules/analysis/services/pipeline-orchestrator.service.ts`
-  - Action: The private method at line 937 currently returns `{ status }`. Since the `buildStage` helper in Task 5 only needs the status string, change the return type to just return the status string. Call site becomes `buildStage(this.getEmbeddingStageStatus(pipeline), null)`.
-  - Notes: **Before changing**, verify this method has only one call site (currently line 518). Grep for `getEmbeddingStageStatus` to confirm no other callers depend on the object shape.
-
-- [ ] Task 7: Update service tests for reshaped response
+- [ ] Task 6: Update service tests for reshaped response
   - File: `src/modules/analysis/services/pipeline-orchestrator.service.spec.ts`
   - Action: Update the `GetPipelineStatus` test cases:
     1. Add mock for `fork.count(SentimentResult, ...)` returning a number (e.g., `47`)
@@ -212,14 +222,14 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
     5. Add a test case verifying sentiment `progress.current` equals the mocked count
     6. Add a test case for sentiment start: `sentimentRun` exists with status `PROCESSING` and zero results → `progress: { current: 0, total: N }`
 
-- [ ] Task 8 (optional): Update controller tests for reshaped response
+- [ ] Task 7: Update controller tests for reshaped response
   - File: `src/modules/analysis/analysis.controller.spec.ts`
-  - Action: Update the `GetPipelineStatus` test's `mockStatus` object to match the new response shape (add `retryable`, `updatedAt`, update stage shapes). The controller test is a pass-through, so this is mainly updating the mock data shape.
-  - Notes: **Optional** — the controller is a pure pass-through. This test only verifies delegation, not response correctness. Not listed in `files_to_modify` — skip unless the test fails due to type changes.
+  - Action: Update the `GetPipelineStatus` test's `mockStatus` object to match the new response shape (add `retryable`, `updatedAt`, update stage shapes). The controller test is a pass-through, but the `PipelineStatusResponse` type change will cause TypeScript compile errors in mock data.
+  - Notes: Required because `PipelineStatusResponse` (inferred from the reshaped Zod schema) is used to type mock data in the controller spec.
 
 ### Acceptance Criteria
 
-- [ ] AC 1: Given a pipeline in `SENTIMENT_ANALYSIS` status with 120 comments and 47 sentiment results, when `GET /analysis/pipelines/:id/status` is called, then the response `stages.sentiment.progress` is `{ current: 47, total: 120 }` and `stages.sentiment.status` is `"processing"`.
+- [ ] AC 1: Given a pipeline in `SENTIMENT_ANALYSIS` status with a `SentimentRun` where `submissionCount` is 120 and 47 `SentimentResult` rows exist for that run, when `GET /analysis/pipelines/:id/status` is called, then `stages.sentiment.progress` is `{ current: 47, total: 120 }` and `stages.sentiment.status` is `"processing"`.
 
 - [ ] AC 2: Given a pipeline in `TOPIC_MODELING` status, when `GET /analysis/pipelines/:id/status` is called, then `stages.topicModeling.progress` is `null` and `stages.topicModeling.status` is `"processing"`.
 
@@ -237,14 +247,14 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 
 - [ ] AC 9: Given a pipeline that does not exist, when `GET /analysis/pipelines/:id/status` is called, then a `404 Not Found` is returned (existing behavior preserved).
 
-- [ ] AC 10: Given a pipeline in `CANCELLED` status, when `GET /analysis/pipelines/:id/status` is called, then `retryable` is `false`, `stages.embeddings.status` is `"skipped"`, and `stages.sentimentGate.status` is `"skipped"`.
+- [ ] AC 10: Given a pipeline in `CANCELLED` status with `sentimentGateIncluded` as `null` (gate never completed), when `GET /analysis/pipelines/:id/status` is called, then `retryable` is `false`, `stages.embeddings.status` is `"skipped"`, and `stages.sentimentGate.status` is `"skipped"`. (Note: if a pipeline is cancelled *after* the gate completed, `sentimentGate.status` would correctly be `"completed"` since the gate data is real.)
 
 ## Additional Context
 
 ### Dependencies
 
 - No new packages required. All changes use existing NestJS, MikroORM, and Zod infrastructure.
-- Sentiment progress count requires a `COUNT` query on `SentimentResult` for the active run — this is a new query addition to `GetPipelineStatus()` (up to 8 DB queries per poll; fewer when conditional queries are skipped, e.g., no courseIds → enrollment query skipped). The COUNT scopes to the latest run via `{ run: sentimentRun }`, so progress cannot regress across retries (new runs get new result rows).
+- Sentiment progress count requires a `COUNT` query on `SentimentResult` for the active run — this is a new query addition to `GetPipelineStatus()` (up to 7 DB queries per poll; fewer when conditional queries are skipped, e.g., no courseIds → enrollment query skipped, no sentimentRun → COUNT skipped). The COUNT scopes to the latest run via `{ run: sentimentRun }`, so progress cannot regress across retries (new runs get new result rows).
 - **Task 0 is a prerequisite**: `CustomBaseEntity.updatedAt` currently has no `onUpdate` hook — it is set once at creation and never updated. Task 0 fixes this by overriding `updatedAt` on `AnalysisPipeline` with `onUpdate: () => new Date()`. Scoped to pipeline only to avoid cross-cutting impact on entities like `Enrollment` whose `updatedAt` is used for sync tracking. No migration needed.
 
 ### Testing Strategy

--- a/_bmad-output/implementation-artifacts/tech-spec-frontend-pipeline-polling.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-frontend-pipeline-polling.md
@@ -6,10 +6,10 @@ status: 'ready-for-dev'
 stepsCompleted: [1, 2, 3, 4]
 tech_stack: ['NestJS', 'MikroORM', 'PostgreSQL', 'BullMQ', 'Zod', 'Jest', 'Passport JWT']
 files_to_modify:
+  - 'src/entities/base.entity.ts'
   - 'src/modules/analysis/dto/pipeline-status.dto.ts'
   - 'src/modules/analysis/services/pipeline-orchestrator.service.ts'
   - 'src/modules/analysis/services/pipeline-orchestrator.service.spec.ts'
-  - 'src/modules/analysis/analysis.controller.spec.ts'
 code_patterns:
   - 'PascalCase public service methods'
   - 'Zod schemas for response DTOs'
@@ -18,7 +18,7 @@ code_patterns:
 test_patterns:
   - 'Test.createTestingModule with useValue mocks'
   - 'jest.fn() for service/repo method mocks'
-  - 'makeMockPipeline() factory pattern for test data'
+  - 'makeMockPipeline() factory in controller spec; service spec builds mocks inline'
   - 'Tests co-located with source as .spec.ts'
 ---
 
@@ -73,7 +73,8 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 | File | Purpose |
 | ---- | ------- |
 | `src/modules/analysis/dto/pipeline-status.dto.ts` | Zod schema for status response — `pipelineStatusSchema`, `stageStatusSchema`, `PipelineStatusResponse` type |
-| `src/modules/analysis/services/pipeline-orchestrator.service.ts` | `GetPipelineStatus()` at ~line 438 — constructs response from pipeline + run entities (7 DB queries) |
+| `src/entities/base.entity.ts` | `CustomBaseEntity` — needs `onUpdate` hook added to `updatedAt` property |
+| `src/modules/analysis/services/pipeline-orchestrator.service.ts` | `GetPipelineStatus()` at ~line 438 — constructs response from pipeline + run entities (8 DB queries after adding sentiment COUNT) |
 | `src/modules/analysis/analysis.controller.ts` | Status endpoint at line 69 — `GET pipelines/:id/status`, delegates to orchestrator |
 | `src/entities/analysis-pipeline.entity.ts` | Pipeline entity — has `updatedAt` (inherited from CustomBaseEntity), `status`, `commentCount`, `sentimentGateIncluded/Excluded` |
 | `src/entities/sentiment-run.entity.ts` | SentimentRun — `status: RunStatus`, `submissionCount`, has `results` collection |
@@ -82,8 +83,7 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 | `src/entities/recommendation-run.entity.ts` | RecommendationRun — `status: RunStatus` |
 | `src/modules/analysis/enums/pipeline-status.enum.ts` | `PipelineStatus` enum definition |
 | `src/modules/analysis/enums/run-status.enum.ts` | `RunStatus` enum definition |
-| `src/modules/analysis/services/pipeline-orchestrator.service.spec.ts` | Service tests — uses `makeMockPipeline()`, mocked EM fork |
-| `src/modules/analysis/analysis.controller.spec.ts` | Controller tests — mocks orchestrator with `jest.fn()` |
+| `src/modules/analysis/services/pipeline-orchestrator.service.spec.ts` | Service tests — builds mocks inline, mocked EM fork |
 
 ### Technical Decisions
 
@@ -97,6 +97,11 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 ## Implementation Plan
 
 ### Tasks
+
+- [ ] Task 0: Fix `CustomBaseEntity.updatedAt` — add `onUpdate` hook
+  - File: `src/entities/base.entity.ts`
+  - Action: Change the `updatedAt` property decorator from `@Property()` to `@Property({ onUpdate: () => new Date() })`. This ensures MikroORM automatically sets `updatedAt` before every flush that modifies the entity.
+  - Notes: This is a prerequisite for the entire spec. Without it, `updatedAt` is set once at creation and never updated. No migration needed — `onUpdate` is an ORM-layer hook, not a DB schema change. This is a cross-cutting fix that benefits all entities inheriting from `CustomBaseEntity`.
 
 - [ ] Task 1: Reshape `stageStatusSchema` for consistent field presence
   - File: `src/modules/analysis/dto/pipeline-status.dto.ts`
@@ -116,10 +121,11 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 
 - [ ] Task 2: Add `retryable` and `updatedAt` to `pipelineStatusSchema`
   - File: `src/modules/analysis/dto/pipeline-status.dto.ts`
-  - Action: Add two fields to the top-level `pipelineStatusSchema`:
-    - `retryable: z.boolean()` — after `errorMessage`
-    - `updatedAt: z.string().datetime()` — after `createdAt`
-  - Notes: `retryable` is `true` only when status is `FAILED`. `updatedAt` comes from `pipeline.updatedAt` (already on entity via `CustomBaseEntity`).
+  - Action: Add fields and normalize existing ones in `pipelineStatusSchema`:
+    - Add `retryable: z.boolean()` — after `errorMessage`
+    - Add `updatedAt: z.string().datetime()` — after `createdAt`
+    - Change `errorMessage: z.string().nullable().optional()` to `z.string().nullable()` — enforce `null` over omission principle
+  - Notes: `retryable` is `true` only when status is `FAILED`. `updatedAt` comes from `pipeline.updatedAt` (requires Task 0's `onUpdate` hook to be accurate).
 
 - [ ] Task 3: Add sentiment gate fields to `pipelineStatusSchema` stages
   - File: `src/modules/analysis/dto/pipeline-status.dto.ts`
@@ -159,19 +165,29 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
          completedAt: run?.completedAt?.toISOString() ?? null,
        });
        ```
-    2. Update each stage in the return block:
-       - `embeddings`: `buildStage(embeddingStatus.status, null)` — no run entity, no progress
+    2. Derive `gateStatus` before building the return block:
+       ```typescript
+       const gateStatus = pipeline.sentimentGateIncluded != null ? 'completed'
+         : pipeline.status === PipelineStatus.SENTIMENT_GATE ? 'processing'
+         : 'pending';
+       ```
+    3. Update each stage in the return block:
+       - `embeddings`: `buildStage(this.getEmbeddingStageStatus(pipeline), null)` — no run entity, no progress. Note: `startedAt` and `completedAt` will always be `null` for this stage since there is no run entity. Frontend should use `pipeline.confirmedAt` as a proxy if timing is needed.
        - `sentiment`: `buildStage(getRunStatus(sentimentRun), sentimentRun, { current: sentimentCompleted, total: pipeline.commentCount })` — real progress
        - `sentimentGate`: `{ ...buildStage(gateStatus, null), included: pipeline.sentimentGateIncluded ?? null, excluded: pipeline.sentimentGateExcluded ?? null }`
        - `topicModeling`: `buildStage(getRunStatus(topicModelRun), topicModelRun)`
        - `recommendations`: `buildStage(getRunStatus(recommendationRun), recommendationRun)`
     3. Add to the top-level return: `updatedAt: pipeline.updatedAt.toISOString()` and `retryable: pipeline.status === PipelineStatus.FAILED`
-  - Notes: `getRunStatus()` is a simple inline: `(run) => run ? run.status.toLowerCase() : 'pending'`. For `retryable`, all current failure modes are transient (worker timeouts, network errors), so `status === FAILED` is sufficient. Revisit if data validation failures become a distinct failure mode — may need an `errorCategory` field.
+  - Notes:
+    - `getRunStatus()` is a simple inline: `(run) => run ? run.status.toLowerCase() : 'pending'`
+    - For `retryable`, all current failure modes are transient (worker timeouts, network errors), so `status === FAILED` is sufficient. The flag provides intent signaling — when error categories are added later, `retryable` becomes meaningful without a frontend change. Revisit if data validation failures become a distinct failure mode.
+    - `startedAt` uses `run.createdAt` as a proxy — this is the best available approximation since run entities don't have a dedicated `startedAt` field. Runs are created at enqueue time, which is close to processing start for the polling UI's purposes.
   - **Commit strategy**: Split this task into two commits for reviewability: (a) replace helpers + reshape return block, (b) add `updatedAt` + `retryable` top-level fields.
 
 - [ ] Task 6: Update `getEmbeddingStageStatus()` return type
   - File: `src/modules/analysis/services/pipeline-orchestrator.service.ts`
-  - Action: The private method at line 937 currently returns `{ status }`. Since the `buildStage` helper in Task 5 only needs the status string, change the return type to just return the status string, or adapt the call site to destructure. Simplest: have it return just the status string and call `buildStage(this.getEmbeddingStageStatus(pipeline), null)`.
+  - Action: The private method at line 937 currently returns `{ status }`. Since the `buildStage` helper in Task 5 only needs the status string, change the return type to just return the status string. Call site becomes `buildStage(this.getEmbeddingStageStatus(pipeline), null)`.
+  - Notes: **Before changing**, verify this method has only one call site (currently line 518). Grep for `getEmbeddingStageStatus` to confirm no other callers depend on the object shape.
 
 - [ ] Task 7: Update service tests for reshaped response
   - File: `src/modules/analysis/services/pipeline-orchestrator.service.spec.ts`
@@ -183,10 +199,10 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
     5. Add a test case verifying sentiment `progress.current` equals the mocked count
     6. Add a test case for sentiment start: `sentimentRun` exists with status `PROCESSING` and zero results → `progress: { current: 0, total: N }`
 
-- [ ] Task 8 (low priority): Update controller tests for reshaped response
+- [ ] Task 8 (optional): Update controller tests for reshaped response
   - File: `src/modules/analysis/analysis.controller.spec.ts`
   - Action: Update the `GetPipelineStatus` test's `mockStatus` object to match the new response shape (add `retryable`, `updatedAt`, update stage shapes). The controller test is a pass-through, so this is mainly updating the mock data shape.
-  - Notes: Low priority — the controller is a pure pass-through. This test only verifies delegation, not response correctness. Skip if time-constrained.
+  - Notes: **Optional** — the controller is a pure pass-through. This test only verifies delegation, not response correctness. Not listed in `files_to_modify` — skip unless the test fails due to type changes.
 
 ### Acceptance Criteria
 
@@ -208,13 +224,15 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 
 - [ ] AC 9: Given a pipeline that does not exist, when `GET /analysis/pipelines/:id/status` is called, then a `404 Not Found` is returned (existing behavior preserved).
 
+- [ ] AC 10: Given a pipeline in `CANCELLED` status, when `GET /analysis/pipelines/:id/status` is called, then `retryable` is `false` and `stages.embeddings.status` is `"skipped"`.
+
 ## Additional Context
 
 ### Dependencies
 
 - No new packages required. All changes use existing NestJS, MikroORM, and Zod infrastructure.
-- Sentiment progress count requires a `COUNT` query on `SentimentResult` for the active run — this is a new query addition to `GetPipelineStatus()`.
-- `AnalysisPipeline.updatedAt` already exists via `CustomBaseEntity` and is auto-managed by MikroORM's `onUpdate` hook — no entity changes needed.
+- Sentiment progress count requires a `COUNT` query on `SentimentResult` for the active run — this is a new query addition to `GetPipelineStatus()` (total: 8 DB queries per poll). The COUNT scopes to the latest run via `{ run: sentimentRun }`, so progress cannot regress across retries (new runs get new result rows).
+- **Task 0 is a prerequisite**: `CustomBaseEntity.updatedAt` currently has no `onUpdate` hook — it is set once at creation and never updated. Task 0 fixes this by adding `onUpdate: () => new Date()` to the property decorator. No migration needed.
 
 ### Testing Strategy
 
@@ -240,12 +258,14 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 
 ### Notes
 
-- **Breaking change**: The response shape of `GET /analysis/pipelines/:id/status` changes. The old `total`, `completed`, `processed` fields on stages are replaced with a `progress: { current, total } | null` object, and `startedAt`/`completedAt` are added. **Atomic deploy recommended** — backend and frontend should deploy together to avoid runtime mismatches.
-- **No migration needed**: No entity or database schema changes. All changes are in the DTO and service layer.
+- **Breaking change**: The response shape of `GET /analysis/pipelines/:id/status` changes. The old `total`, `completed`, `processed` fields on stages are replaced with a `progress: { current, total } | null` object, and `startedAt`/`completedAt` are added. **Atomic deploy required** — backend and frontend must deploy in the same release window. Deploying backend first will break active polling sessions immediately.
+- **No migration needed**: No database schema changes. Task 0 modifies `CustomBaseEntity` (ORM-layer `onUpdate` hook), and the rest are DTO/service layer changes.
 - **Frontend null-safety**: The frontend must null-check `progress` before accessing `.current`/`.total`. Consider sharing the Zod schema or generating OpenAPI types to keep the contract in sync.
 - **Staleness detection (frontend concern)**: The frontend should compute staleness from `updatedAt` and `stages.*.startedAt` — e.g., if a stage has been `processing` for >10 minutes with no `updatedAt` change, display a "pipeline may be stuck" warning. No backend changes needed for this.
+- **Embedding stage timing**: The embedding stage has no run entity, so `startedAt` and `completedAt` will always be `null`. The frontend should use `confirmedAt` from the top-level response as a proxy if timing info is needed for this stage.
+- **`startedAt` approximation**: For stages with run entities, `startedAt` uses `run.createdAt` (entity creation time) as a proxy since runs don't have a dedicated `startedAt` field. This is close to processing start and sufficient for the polling UI.
 - **Future scaling**: If pipeline comment counts grow beyond ~5K, the per-poll `SentimentResult` COUNT query should be revisited (cache on `SentimentRun.completedCount`). Current volumes don't warrant this.
-- Frontend polling pattern (for reference, not in backend scope):
+- Frontend polling pattern (illustrative only, not a contract — frontend implementation is out of scope):
   ```typescript
   const { data } = useQuery({
     queryKey: ['pipeline-status', pipelineId],

--- a/_bmad-output/implementation-artifacts/tech-spec-frontend-pipeline-polling.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-frontend-pipeline-polling.md
@@ -2,9 +2,10 @@
 title: 'Frontend Pipeline Polling'
 slug: 'frontend-pipeline-polling'
 created: '2026-03-31'
-status: 'ready-for-dev'
+status: 'implementation-complete'
 stepsCompleted: [1, 2, 3, 4]
-tech_stack: ['NestJS', 'MikroORM', 'PostgreSQL', 'BullMQ', 'Zod', 'Jest', 'Passport JWT']
+tech_stack:
+  ['NestJS', 'MikroORM', 'PostgreSQL', 'BullMQ', 'Zod', 'Jest', 'Passport JWT']
 files_to_modify:
   - 'src/entities/analysis-pipeline.entity.ts'
   - 'src/modules/analysis/dto/pipeline-status.dto.ts'
@@ -40,6 +41,7 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 ### Scope
 
 **In Scope:**
+
 - Reshape status endpoint response DTO for polling consistency
 - Add `progress: { current, total } | null` per stage (sentiment gets real counts via result row count)
 - Add `retryable: boolean` on pipeline-level failures
@@ -47,6 +49,7 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 - Document the frontend polling contract (React Query + Axios pattern)
 
 **Out of Scope:**
+
 - Frontend UI implementation (stepper component, animations)
 - WebSocket/SSE infrastructure
 - Batch multi-pipeline status endpoint
@@ -71,20 +74,20 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 
 ### Files to Reference
 
-| File | Purpose |
-| ---- | ------- |
-| `src/modules/analysis/dto/pipeline-status.dto.ts` | Zod schema for status response — `pipelineStatusSchema`, `stageStatusSchema`, `PipelineStatusResponse` type |
-| `src/entities/base.entity.ts` | `CustomBaseEntity` — defines shared `updatedAt` without `onUpdate` hook (Task 0 overrides on pipeline entity instead) |
-| `src/modules/analysis/services/pipeline-orchestrator.service.ts` | `GetPipelineStatus()` at ~line 438 — constructs response from pipeline + run entities (up to 7 DB queries after adding sentiment COUNT; some conditional) |
-| `src/modules/analysis/analysis.controller.ts` | Status endpoint at line 69 — `GET pipelines/:id/status`, delegates to orchestrator |
-| `src/entities/analysis-pipeline.entity.ts` | Pipeline entity — has `updatedAt` (inherited from CustomBaseEntity), `status`, `commentCount`, `sentimentGateIncluded/Excluded` |
-| `src/entities/sentiment-run.entity.ts` | SentimentRun — `status: RunStatus`, `submissionCount`, has `results` collection |
-| `src/entities/sentiment-result.entity.ts` | Individual result per submission — COUNT of these gives sentiment progress |
-| `src/entities/topic-model-run.entity.ts` | TopicModelRun — `status: RunStatus` |
-| `src/entities/recommendation-run.entity.ts` | RecommendationRun — `status: RunStatus` |
-| `src/modules/analysis/enums/pipeline-status.enum.ts` | `PipelineStatus` enum definition |
-| `src/modules/analysis/enums/run-status.enum.ts` | `RunStatus` enum definition |
-| `src/modules/analysis/services/pipeline-orchestrator.service.spec.ts` | Service tests — builds mocks inline, mocked EM fork |
+| File                                                                  | Purpose                                                                                                                                                   |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/modules/analysis/dto/pipeline-status.dto.ts`                     | Zod schema for status response — `pipelineStatusSchema`, `stageStatusSchema`, `PipelineStatusResponse` type                                               |
+| `src/entities/base.entity.ts`                                         | `CustomBaseEntity` — defines shared `updatedAt` without `onUpdate` hook (Task 0 overrides on pipeline entity instead)                                     |
+| `src/modules/analysis/services/pipeline-orchestrator.service.ts`      | `GetPipelineStatus()` at ~line 438 — constructs response from pipeline + run entities (up to 7 DB queries after adding sentiment COUNT; some conditional) |
+| `src/modules/analysis/analysis.controller.ts`                         | Status endpoint at line 69 — `GET pipelines/:id/status`, delegates to orchestrator                                                                        |
+| `src/entities/analysis-pipeline.entity.ts`                            | Pipeline entity — has `updatedAt` (inherited from CustomBaseEntity), `status`, `commentCount`, `sentimentGateIncluded/Excluded`                           |
+| `src/entities/sentiment-run.entity.ts`                                | SentimentRun — `status: RunStatus`, `submissionCount`, has `results` collection                                                                           |
+| `src/entities/sentiment-result.entity.ts`                             | Individual result per submission — COUNT of these gives sentiment progress                                                                                |
+| `src/entities/topic-model-run.entity.ts`                              | TopicModelRun — `status: RunStatus`                                                                                                                       |
+| `src/entities/recommendation-run.entity.ts`                           | RecommendationRun — `status: RunStatus`                                                                                                                   |
+| `src/modules/analysis/enums/pipeline-status.enum.ts`                  | `PipelineStatus` enum definition                                                                                                                          |
+| `src/modules/analysis/enums/run-status.enum.ts`                       | `RunStatus` enum definition                                                                                                                               |
+| `src/modules/analysis/services/pipeline-orchestrator.service.spec.ts` | Service tests — builds mocks inline, mocked EM fork                                                                                                       |
 
 ### Technical Decisions
 
@@ -100,7 +103,7 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 
 ### Tasks
 
-- [ ] Task 0: Fix `AnalysisPipeline.updatedAt` — add `onUpdate` hook (scoped to pipeline only)
+- [x] Task 0: Fix `AnalysisPipeline.updatedAt` — add `onUpdate` hook (scoped to pipeline only)
   - File: `src/entities/analysis-pipeline.entity.ts`
   - Action: Override `updatedAt` on `AnalysisPipeline` with `onUpdate`:
     ```typescript
@@ -109,23 +112,31 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
     ```
   - Notes: This is a prerequisite for the entire spec. Without it, `updatedAt` is set once at creation and never updated. Scoped to `AnalysisPipeline` only (not `CustomBaseEntity`) to avoid cross-cutting impact — other entities like `Enrollment` use `updatedAt` for sync tracking and could be affected by unrelated cascade flushes. Promoting `onUpdate` to `CustomBaseEntity` can be done as a separate, properly-analyzed change. No migration needed — `onUpdate` is an ORM-layer hook, not a DB schema change.
 
-- [ ] Task 1: Reshape `stageStatusSchema` for consistent field presence
+- [x] Task 1: Reshape `stageStatusSchema` for consistent field presence
   - File: `src/modules/analysis/dto/pipeline-status.dto.ts`
   - Action: Replace all optional fields in `stageStatusSchema` with consistent, always-present fields using `null` for absent values:
     ```typescript
     const stageStatusSchema = z.object({
-      status: z.enum(['pending', 'processing', 'completed', 'failed', 'skipped']),
-      progress: z.object({
-        current: z.number().int(),
-        total: z.number().int(),
-      }).nullable(),
+      status: z.enum([
+        'pending',
+        'processing',
+        'completed',
+        'failed',
+        'skipped',
+      ]),
+      progress: z
+        .object({
+          current: z.number().int(),
+          total: z.number().int(),
+        })
+        .nullable(),
       startedAt: z.string().datetime().nullable(),
       completedAt: z.string().datetime().nullable(),
     });
     ```
   - Notes: This removes the old `total`, `completed`, `processed`, `included`, `excluded` optional fields. The `progress` object is either fully present or `null`. `startedAt` and `completedAt` give the frontend elapsed-time signal. **Preserve all existing top-level fields** (`confirmedAt`, `completedAt`, `createdAt`, `scope`, `coverage`, `warnings`). Only the `stages` shape, `errorMessage` optionality, and new fields (`retryable`, `updatedAt`) change.
 
-- [ ] Task 2: Add `retryable` and `updatedAt` to `pipelineStatusSchema`
+- [x] Task 2: Add `retryable` and `updatedAt` to `pipelineStatusSchema`
   - File: `src/modules/analysis/dto/pipeline-status.dto.ts`
   - Action: Add fields and normalize existing ones in `pipelineStatusSchema`:
     - Add `retryable: z.boolean()` — after `errorMessage`
@@ -133,7 +144,7 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
     - Change `errorMessage: z.string().nullable().optional()` to `z.string().nullable()` — enforce `null` over omission principle
   - Notes: `retryable` is `true` only when status is `FAILED`. `updatedAt` comes from `pipeline.updatedAt` (requires Task 0's `onUpdate` hook to be accurate).
 
-- [ ] Task 3: Add sentiment gate fields to `pipelineStatusSchema` stages
+- [x] Task 3: Add sentiment gate fields to `pipelineStatusSchema` stages
   - File: `src/modules/analysis/dto/pipeline-status.dto.ts`
   - Action: The sentiment gate's `included`/`excluded` counts no longer fit in the generic `stageStatusSchema` (which now uses `progress`). Add a dedicated `sentimentGate` schema:
     ```typescript
@@ -153,18 +164,20 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
     }),
     ```
 
-- [ ] Task 4: Update `GetPipelineStatus()` — add sentiment progress count query
+- [x] Task 4: Update `GetPipelineStatus()` — add sentiment progress count query
   - File: `src/modules/analysis/services/pipeline-orchestrator.service.ts`
   - Action: After the existing `sentimentRun` query (~line 461), add a conditional `COUNT` query:
     ```typescript
     let sentimentCompleted = 0;
     if (sentimentRun && sentimentRun.status !== RunStatus.PENDING) {
-      sentimentCompleted = await fork.count(SentimentResult, { run: sentimentRun });
+      sentimentCompleted = await fork.count(SentimentResult, {
+        run: sentimentRun,
+      });
     }
     ```
   - Notes: Only queries when a run exists and has started. Returns 0 when pending. This is a cheap indexed COUNT on `sentiment_result.run_id` (index confirmed on entity). If pipelines scale beyond ~5K comments, consider caching the count on `SentimentRun.completedCount` — out of scope for now.
 
-- [ ] Task 5: Update `GetPipelineStatus()` — reshape return object to match new DTO
+- [x] Task 5: Update `GetPipelineStatus()` — reshape return object to match new DTO
   - File: `src/modules/analysis/services/pipeline-orchestrator.service.ts`
   - **Ordering dependency**: Tasks 1-3 (DTO changes) must be completed before Tasks 4-5 (service changes). Do not implement in isolation — the intermediate state where the schema is updated but the service is not (or vice versa) will produce a compile error.
   - Action: Replace the `stageStatus` helper, update `getEmbeddingStageStatus()`, and reshape the return object. Key changes:
@@ -185,8 +198,16 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
     3. Add a `getRunStatus` helper with a comment about enum coupling:
        ```typescript
        // If RunStatus gains new values, update this mapping to match the stage status union
-       const getRunStatus = (run: SentimentRun | TopicModelRun | RecommendationRun | null) =>
-         run ? (run.status.toLowerCase() as 'pending' | 'processing' | 'completed' | 'failed') : 'pending';
+       const getRunStatus = (
+         run: SentimentRun | TopicModelRun | RecommendationRun | null,
+       ) =>
+         run
+           ? (run.status.toLowerCase() as
+               | 'pending'
+               | 'processing'
+               | 'completed'
+               | 'failed')
+           : 'pending';
        ```
     4. Derive `gateStatus` before building the return block (handles terminal pipeline states):
        ```typescript
@@ -194,10 +215,14 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
        // handles failure attribution — no per-stage failure tracking for MVP.
        // FAILED pipelines: gate shows 'pending' (never completed) which is correct.
        // CANCELLED pipelines: gate shows 'skipped' (explicitly not attempted).
-       const gateStatus = pipeline.sentimentGateIncluded != null ? 'completed'
-         : pipeline.status === PipelineStatus.SENTIMENT_GATE ? 'processing'
-         : pipeline.status === PipelineStatus.CANCELLED ? 'skipped'
-         : 'pending';
+       const gateStatus =
+         pipeline.sentimentGateIncluded != null
+           ? 'completed'
+           : pipeline.status === PipelineStatus.SENTIMENT_GATE
+             ? 'processing'
+             : pipeline.status === PipelineStatus.CANCELLED
+               ? 'skipped'
+               : 'pending';
        ```
     5. Update each stage in the return block:
        - `embeddings`: `buildStage(this.getEmbeddingStageStatus(pipeline), null)` — no run entity, no progress. Note: `startedAt` and `completedAt` will always be `null` for this stage since there is no run entity. Frontend should use `pipeline.confirmedAt` as a proxy if timing is needed.
@@ -212,7 +237,7 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
     - `startedAt` uses `run.createdAt` as a proxy — this is the best available approximation since run entities don't have a dedicated `startedAt` field. Runs are created at enqueue time, which is close to processing start for the polling UI's purposes.
   - **Commit strategy**: Split this task into two commits for reviewability: (a) replace helpers + reshape return block, (b) add `updatedAt` + `retryable` top-level fields.
 
-- [ ] Task 6: Update service tests for reshaped response
+- [x] Task 6: Update service tests for reshaped response
   - File: `src/modules/analysis/services/pipeline-orchestrator.service.spec.ts`
   - Action: Update the `GetPipelineStatus` test cases:
     1. Add mock for `fork.count(SentimentResult, ...)` returning a number (e.g., `47`)
@@ -222,7 +247,7 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
     5. Add a test case verifying sentiment `progress.current` equals the mocked count
     6. Add a test case for sentiment start: `sentimentRun` exists with status `PROCESSING` and zero results → `progress: { current: 0, total: N }`
 
-- [ ] Task 7: Update controller tests for reshaped response
+- [x] Task 7: Update controller tests for reshaped response
   - File: `src/modules/analysis/analysis.controller.spec.ts`
   - Action: Update the `GetPipelineStatus` test's `mockStatus` object to match the new response shape (add `retryable`, `updatedAt`, update stage shapes). The controller test is a pass-through, but the `PipelineStatusResponse` type change will cause TypeScript compile errors in mock data.
   - Notes: Required because `PipelineStatusResponse` (inferred from the reshaped Zod schema) is used to type mock data in the controller spec.
@@ -247,7 +272,7 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 
 - [ ] AC 9: Given a pipeline that does not exist, when `GET /analysis/pipelines/:id/status` is called, then a `404 Not Found` is returned (existing behavior preserved).
 
-- [ ] AC 10: Given a pipeline in `CANCELLED` status with `sentimentGateIncluded` as `null` (gate never completed), when `GET /analysis/pipelines/:id/status` is called, then `retryable` is `false`, `stages.embeddings.status` is `"skipped"`, and `stages.sentimentGate.status` is `"skipped"`. (Note: if a pipeline is cancelled *after* the gate completed, `sentimentGate.status` would correctly be `"completed"` since the gate data is real.)
+- [ ] AC 10: Given a pipeline in `CANCELLED` status with `sentimentGateIncluded` as `null` (gate never completed), when `GET /analysis/pipelines/:id/status` is called, then `retryable` is `false`, `stages.embeddings.status` is `"skipped"`, and `stages.sentimentGate.status` is `"skipped"`. (Note: if a pipeline is cancelled _after_ the gate completed, `sentimentGate.status` would correctly be `"completed"` since the gate data is real.)
 
 ## Additional Context
 
@@ -260,6 +285,7 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 ### Testing Strategy
 
 **Unit Tests (Jest):**
+
 - `pipeline-orchestrator.service.spec.ts`:
   - Test reshaped response has all fields present (no undefined keys)
   - Test sentiment `progress.current` matches mocked `SentimentResult` count
@@ -274,6 +300,7 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
   - Verify pass-through behavior unchanged
 
 **Manual Testing:**
+
 - Start a pipeline via `POST /analysis/pipelines` + confirm
 - Poll `GET /analysis/pipelines/:id/status` and verify response shape consistency across stage transitions
 - Verify sentiment progress increments as results are processed

--- a/_bmad-output/implementation-artifacts/tech-spec-frontend-pipeline-polling.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-frontend-pipeline-polling.md
@@ -2,8 +2,8 @@
 title: 'Frontend Pipeline Polling'
 slug: 'frontend-pipeline-polling'
 created: '2026-03-31'
-status: 'review'
-stepsCompleted: [1, 2, 3]
+status: 'ready-for-dev'
+stepsCompleted: [1, 2, 3, 4]
 tech_stack: ['NestJS', 'MikroORM', 'PostgreSQL', 'BullMQ', 'Zod', 'Jest', 'Passport JWT']
 files_to_modify:
   - 'src/modules/analysis/dto/pipeline-status.dto.ts'

--- a/_bmad-output/implementation-artifacts/tech-spec-frontend-pipeline-polling.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-frontend-pipeline-polling.md
@@ -6,7 +6,7 @@ status: 'ready-for-dev'
 stepsCompleted: [1, 2, 3, 4]
 tech_stack: ['NestJS', 'MikroORM', 'PostgreSQL', 'BullMQ', 'Zod', 'Jest', 'Passport JWT']
 files_to_modify:
-  - 'src/entities/base.entity.ts'
+  - 'src/entities/analysis-pipeline.entity.ts'
   - 'src/modules/analysis/dto/pipeline-status.dto.ts'
   - 'src/modules/analysis/services/pipeline-orchestrator.service.ts'
   - 'src/modules/analysis/services/pipeline-orchestrator.service.spec.ts'
@@ -73,8 +73,8 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 | File | Purpose |
 | ---- | ------- |
 | `src/modules/analysis/dto/pipeline-status.dto.ts` | Zod schema for status response — `pipelineStatusSchema`, `stageStatusSchema`, `PipelineStatusResponse` type |
-| `src/entities/base.entity.ts` | `CustomBaseEntity` — needs `onUpdate` hook added to `updatedAt` property |
-| `src/modules/analysis/services/pipeline-orchestrator.service.ts` | `GetPipelineStatus()` at ~line 438 — constructs response from pipeline + run entities (8 DB queries after adding sentiment COUNT) |
+| `src/entities/base.entity.ts` | `CustomBaseEntity` — defines shared `updatedAt` without `onUpdate` hook (Task 0 overrides on pipeline entity instead) |
+| `src/modules/analysis/services/pipeline-orchestrator.service.ts` | `GetPipelineStatus()` at ~line 438 — constructs response from pipeline + run entities (up to 8 DB queries after adding sentiment COUNT) |
 | `src/modules/analysis/analysis.controller.ts` | Status endpoint at line 69 — `GET pipelines/:id/status`, delegates to orchestrator |
 | `src/entities/analysis-pipeline.entity.ts` | Pipeline entity — has `updatedAt` (inherited from CustomBaseEntity), `status`, `commentCount`, `sentimentGateIncluded/Excluded` |
 | `src/entities/sentiment-run.entity.ts` | SentimentRun — `status: RunStatus`, `submissionCount`, has `results` collection |
@@ -91,17 +91,22 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 - **No denormalization** — query run tables directly on each poll. With only a handful of privileged users polling concurrently, the join cost is negligible.
 - **No WebSocket/SSE** — pipelines run for minutes. A 3-second REST polling interval via React Query is simpler, more resilient, and operationally trivial.
 - **`null` over omission** — every field in the response is always present. Use `null` for absent optional values. This ensures React Query's referential comparison works correctly and avoids unnecessary re-renders from shape changes.
-- **Sentiment gets real progress, others are binary** — derive sentiment `progress.current` from `SentimentResult` row count vs `progress.total` from pipeline comment count. Topic modeling and recommendations are single-batch, so progress is effectively `null` (binary processing/done).
-- **`retryable` flag** — top-level boolean on failed pipelines so the frontend knows whether to show "Retry" vs "Contact admin".
+- **Sentiment gets real progress, others are binary** — derive sentiment `progress.current` from `SentimentResult` row count vs `progress.total` from `sentimentRun.submissionCount`. Topic modeling and recommendations are single-batch, so progress is effectively `null` (binary processing/done).
+- **`retryable` flag** — top-level boolean on failed pipelines so the frontend knows whether to show "Retry" vs "Contact admin". Currently equivalent to `status === FAILED` but provides intent signaling for future error categorization.
+- **Pre-existing DTO issue (out of scope)**: The top-level `status` field in `pipelineStatusSchema` is `z.string()` instead of `z.nativeEnum(PipelineStatus)`. This predates this spec and should be addressed separately.
 
 ## Implementation Plan
 
 ### Tasks
 
-- [ ] Task 0: Fix `CustomBaseEntity.updatedAt` — add `onUpdate` hook
-  - File: `src/entities/base.entity.ts`
-  - Action: Change the `updatedAt` property decorator from `@Property()` to `@Property({ onUpdate: () => new Date() })`. This ensures MikroORM automatically sets `updatedAt` before every flush that modifies the entity.
-  - Notes: This is a prerequisite for the entire spec. Without it, `updatedAt` is set once at creation and never updated. No migration needed — `onUpdate` is an ORM-layer hook, not a DB schema change. This is a cross-cutting fix that benefits all entities inheriting from `CustomBaseEntity`.
+- [ ] Task 0: Fix `AnalysisPipeline.updatedAt` — add `onUpdate` hook (scoped to pipeline only)
+  - File: `src/entities/analysis-pipeline.entity.ts`
+  - Action: Override `updatedAt` on `AnalysisPipeline` with `onUpdate`:
+    ```typescript
+    @Property({ onUpdate: () => new Date() })
+    override updatedAt: Date & Opt = new Date();
+    ```
+  - Notes: This is a prerequisite for the entire spec. Without it, `updatedAt` is set once at creation and never updated. Scoped to `AnalysisPipeline` only (not `CustomBaseEntity`) to avoid cross-cutting impact — other entities like `Enrollment` use `updatedAt` for sync tracking and could be affected by unrelated cascade flushes. Promoting `onUpdate` to `CustomBaseEntity` can be done as a separate, properly-analyzed change. No migration needed — `onUpdate` is an ORM-layer hook, not a DB schema change.
 
 - [ ] Task 1: Reshape `stageStatusSchema` for consistent field presence
   - File: `src/modules/analysis/dto/pipeline-status.dto.ts`
@@ -151,12 +156,13 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 
 - [ ] Task 5: Update `GetPipelineStatus()` — reshape return object to match new DTO
   - File: `src/modules/analysis/services/pipeline-orchestrator.service.ts`
+  - **Ordering dependency**: Tasks 1-3 (DTO changes) must be completed before Tasks 4-6 (service changes). Do not implement in isolation — the intermediate state where the schema is updated but the service is not (or vice versa) will produce a compile error.
   - Action: Replace the `stageStatus` helper and reshape the return object. Key changes:
     1. Remove the `stageStatus()` and `getRunStageStatus()` helpers. Replace with a new helper:
        ```typescript
        const buildStage = (
          status: 'pending' | 'processing' | 'completed' | 'failed' | 'skipped',
-         run: { createdAt: Date; completedAt?: Date } | null,
+         run: { createdAt: Date; completedAt?: Date | null } | null,
          progress: { current: number; total: number } | null = null,
        ) => ({
          status,
@@ -165,22 +171,29 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
          completedAt: run?.completedAt?.toISOString() ?? null,
        });
        ```
-    2. Derive `gateStatus` before building the return block:
+    2. Add a `getRunStatus` helper with a comment about enum coupling:
+       ```typescript
+       // If RunStatus gains new values, update this mapping to match the stage status union
+       const getRunStatus = (run: SentimentRun | TopicModelRun | RecommendationRun | null) =>
+         run ? (run.status.toLowerCase() as 'pending' | 'processing' | 'completed' | 'failed') : 'pending';
+       ```
+    3. Derive `gateStatus` before building the return block (handles terminal pipeline states):
        ```typescript
        const gateStatus = pipeline.sentimentGateIncluded != null ? 'completed'
          : pipeline.status === PipelineStatus.SENTIMENT_GATE ? 'processing'
+         : pipeline.status === PipelineStatus.CANCELLED ? 'skipped'
          : 'pending';
        ```
-    3. Update each stage in the return block:
+    4. Update each stage in the return block:
        - `embeddings`: `buildStage(this.getEmbeddingStageStatus(pipeline), null)` — no run entity, no progress. Note: `startedAt` and `completedAt` will always be `null` for this stage since there is no run entity. Frontend should use `pipeline.confirmedAt` as a proxy if timing is needed.
-       - `sentiment`: `buildStage(getRunStatus(sentimentRun), sentimentRun, { current: sentimentCompleted, total: pipeline.commentCount })` — real progress
-       - `sentimentGate`: `{ ...buildStage(gateStatus, null), included: pipeline.sentimentGateIncluded ?? null, excluded: pipeline.sentimentGateExcluded ?? null }`
+       - `sentiment`: `buildStage(getRunStatus(sentimentRun), sentimentRun, { current: sentimentCompleted, total: sentimentRun?.submissionCount ?? pipeline.commentCount })` — real progress, uses run's own `submissionCount` as total for tighter coupling
+       - `sentimentGate`: `{ ...buildStage(gateStatus, null), included: pipeline.sentimentGateIncluded ?? null, excluded: pipeline.sentimentGateExcluded ?? null }` — note: `startedAt`/`completedAt` always `null` (no run entity, same as embeddings)
        - `topicModeling`: `buildStage(getRunStatus(topicModelRun), topicModelRun)`
        - `recommendations`: `buildStage(getRunStatus(recommendationRun), recommendationRun)`
-    3. Add to the top-level return: `updatedAt: pipeline.updatedAt.toISOString()` and `retryable: pipeline.status === PipelineStatus.FAILED`
+    5. Add to the top-level return: `updatedAt: pipeline.updatedAt.toISOString()` and `retryable: pipeline.status === PipelineStatus.FAILED`
+    6. Optional runtime safety net — add `return pipelineStatusSchema.parse(response)` at the end to catch schema/implementation drift at runtime (the Zod schema is currently only used for type inference via `z.infer`, not runtime validation)
   - Notes:
-    - `getRunStatus()` is a simple inline: `(run) => run ? run.status.toLowerCase() : 'pending'`
-    - For `retryable`, all current failure modes are transient (worker timeouts, network errors), so `status === FAILED` is sufficient. The flag provides intent signaling — when error categories are added later, `retryable` becomes meaningful without a frontend change. Revisit if data validation failures become a distinct failure mode.
+    - For `retryable`, all current failure modes are transient (worker timeouts, network errors), so `status === FAILED` is sufficient. The flag provides intent signaling — when error categories are added later, `retryable` becomes meaningful without a frontend change. Add a code comment: `// Intent signal for future error categorization — currently equivalent to status === FAILED`
     - `startedAt` uses `run.createdAt` as a proxy — this is the best available approximation since run entities don't have a dedicated `startedAt` field. Runs are created at enqueue time, which is close to processing start for the polling UI's purposes.
   - **Commit strategy**: Split this task into two commits for reviewability: (a) replace helpers + reshape return block, (b) add `updatedAt` + `retryable` top-level fields.
 
@@ -224,15 +237,15 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 
 - [ ] AC 9: Given a pipeline that does not exist, when `GET /analysis/pipelines/:id/status` is called, then a `404 Not Found` is returned (existing behavior preserved).
 
-- [ ] AC 10: Given a pipeline in `CANCELLED` status, when `GET /analysis/pipelines/:id/status` is called, then `retryable` is `false` and `stages.embeddings.status` is `"skipped"`.
+- [ ] AC 10: Given a pipeline in `CANCELLED` status, when `GET /analysis/pipelines/:id/status` is called, then `retryable` is `false`, `stages.embeddings.status` is `"skipped"`, and `stages.sentimentGate.status` is `"skipped"`.
 
 ## Additional Context
 
 ### Dependencies
 
 - No new packages required. All changes use existing NestJS, MikroORM, and Zod infrastructure.
-- Sentiment progress count requires a `COUNT` query on `SentimentResult` for the active run — this is a new query addition to `GetPipelineStatus()` (total: 8 DB queries per poll). The COUNT scopes to the latest run via `{ run: sentimentRun }`, so progress cannot regress across retries (new runs get new result rows).
-- **Task 0 is a prerequisite**: `CustomBaseEntity.updatedAt` currently has no `onUpdate` hook — it is set once at creation and never updated. Task 0 fixes this by adding `onUpdate: () => new Date()` to the property decorator. No migration needed.
+- Sentiment progress count requires a `COUNT` query on `SentimentResult` for the active run — this is a new query addition to `GetPipelineStatus()` (up to 8 DB queries per poll; fewer when conditional queries are skipped, e.g., no courseIds → enrollment query skipped). The COUNT scopes to the latest run via `{ run: sentimentRun }`, so progress cannot regress across retries (new runs get new result rows).
+- **Task 0 is a prerequisite**: `CustomBaseEntity.updatedAt` currently has no `onUpdate` hook — it is set once at creation and never updated. Task 0 fixes this by overriding `updatedAt` on `AnalysisPipeline` with `onUpdate: () => new Date()`. Scoped to pipeline only to avoid cross-cutting impact on entities like `Enrollment` whose `updatedAt` is used for sync tracking. No migration needed.
 
 ### Testing Strategy
 
@@ -240,7 +253,7 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 - `pipeline-orchestrator.service.spec.ts`:
   - Test reshaped response has all fields present (no undefined keys)
   - Test sentiment `progress.current` matches mocked `SentimentResult` count
-  - Test sentiment `progress.total` matches `pipeline.commentCount`
+  - Test sentiment `progress.total` matches `sentimentRun.submissionCount` (falls back to `pipeline.commentCount` if no run)
   - Test binary stages (embedding, topicModeling, recommendations) have `progress: null`
   - Test `retryable: true` when `FAILED`, `false` otherwise
   - Test `updatedAt` is present and matches pipeline entity
@@ -259,10 +272,10 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 ### Notes
 
 - **Breaking change**: The response shape of `GET /analysis/pipelines/:id/status` changes. The old `total`, `completed`, `processed` fields on stages are replaced with a `progress: { current, total } | null` object, and `startedAt`/`completedAt` are added. **Atomic deploy required** — backend and frontend must deploy in the same release window. Deploying backend first will break active polling sessions immediately.
-- **No migration needed**: No database schema changes. Task 0 modifies `CustomBaseEntity` (ORM-layer `onUpdate` hook), and the rest are DTO/service layer changes.
+- **No migration needed**: No database schema changes. Task 0 overrides `updatedAt` on `AnalysisPipeline` only (ORM-layer `onUpdate` hook), and the rest are DTO/service layer changes.
 - **Frontend null-safety**: The frontend must null-check `progress` before accessing `.current`/`.total`. Consider sharing the Zod schema or generating OpenAPI types to keep the contract in sync.
 - **Staleness detection (frontend concern)**: The frontend should compute staleness from `updatedAt` and `stages.*.startedAt` — e.g., if a stage has been `processing` for >10 minutes with no `updatedAt` change, display a "pipeline may be stuck" warning. No backend changes needed for this.
-- **Embedding stage timing**: The embedding stage has no run entity, so `startedAt` and `completedAt` will always be `null`. The frontend should use `confirmedAt` from the top-level response as a proxy if timing info is needed for this stage.
+- **Embedding and sentiment gate timing**: Both the embedding stage and sentiment gate stage have no run entity, so `startedAt` and `completedAt` will always be `null` for these stages. The frontend should use `confirmedAt` from the top-level response as a proxy if timing info is needed.
 - **`startedAt` approximation**: For stages with run entities, `startedAt` uses `run.createdAt` (entity creation time) as a proxy since runs don't have a dedicated `startedAt` field. This is close to processing start and sufficient for the polling UI.
 - **Future scaling**: If pipeline comment counts grow beyond ~5K, the per-poll `SentimentResult` COUNT query should be revisited (cache on `SentimentRun.completedCount`). Current volumes don't warrant this.
 - Frontend polling pattern (illustrative only, not a contract — frontend implementation is out of scope):

--- a/_bmad-output/implementation-artifacts/tech-spec-wip.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-wip.md
@@ -3,11 +3,23 @@ title: 'Frontend Pipeline Polling'
 slug: 'frontend-pipeline-polling'
 created: '2026-03-31'
 status: 'in-progress'
-stepsCompleted: [1]
-tech_stack: []
-files_to_modify: []
-code_patterns: []
-test_patterns: []
+stepsCompleted: [1, 2]
+tech_stack: ['NestJS', 'MikroORM', 'PostgreSQL', 'BullMQ', 'Zod', 'Jest', 'Passport JWT']
+files_to_modify:
+  - 'src/modules/analysis/dto/pipeline-status.dto.ts'
+  - 'src/modules/analysis/services/pipeline-orchestrator.service.ts'
+  - 'src/modules/analysis/services/pipeline-orchestrator.service.spec.ts'
+  - 'src/modules/analysis/analysis.controller.spec.ts'
+code_patterns:
+  - 'PascalCase public service methods'
+  - 'Zod schemas for response DTOs'
+  - 'EntityManager.fork() for isolated DB context'
+  - 'CustomBaseEntity provides id, createdAt, updatedAt, deletedAt'
+test_patterns:
+  - 'Test.createTestingModule with useValue mocks'
+  - 'jest.fn() for service/repo method mocks'
+  - 'makeMockPipeline() factory pattern for test data'
+  - 'Tests co-located with source as .spec.ts'
 ---
 
 # Tech-Spec: Frontend Pipeline Polling
@@ -44,14 +56,34 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 
 ### Codebase Patterns
 
-_To be filled in Step 2_
+- **Response DTOs use Zod schemas** — `pipeline-status.dto.ts` defines `pipelineStatusSchema` and `stageStatusSchema` with Zod, then exports inferred TypeScript types. Changes to the response shape must update both the Zod schema and the service that constructs the response.
+- **PascalCase public methods** — `GetPipelineStatus()`, `CreatePipeline()`, etc.
+- **EntityManager.fork()** — `GetPipelineStatus()` forks the EM at the start for an isolated DB context, then runs all queries on the fork.
+- **Stage status derivation** — stage statuses are computed from run entity statuses (or defaulted to `'pending'` if no run exists). There is a private `getEmbeddingStageStatus()` method for embedding-specific logic.
+- **Current `StageStatus` shape uses optional fields** — `total?`, `completed?`, `processed?`, `included?`, `excluded?`. These fields appear/disappear depending on the stage, which is the core polling consistency problem to fix.
+
+### Enums
+
+- **`PipelineStatus`** (9 values): `AWAITING_CONFIRMATION`, `EMBEDDING_CHECK`, `SENTIMENT_ANALYSIS`, `SENTIMENT_GATE`, `TOPIC_MODELING`, `GENERATING_RECOMMENDATIONS`, `COMPLETED`, `FAILED`, `CANCELLED`
+- **`RunStatus`** (4 values): `PENDING`, `PROCESSING`, `COMPLETED`, `FAILED`
+- Terminal statuses: `COMPLETED`, `FAILED`, `CANCELLED`
 
 ### Files to Reference
 
 | File | Purpose |
 | ---- | ------- |
-
-_To be filled in Step 2_
+| `src/modules/analysis/dto/pipeline-status.dto.ts` | Zod schema for status response — `pipelineStatusSchema`, `stageStatusSchema`, `PipelineStatusResponse` type |
+| `src/modules/analysis/services/pipeline-orchestrator.service.ts` | `GetPipelineStatus()` at ~line 438 — constructs response from pipeline + run entities (7 DB queries) |
+| `src/modules/analysis/analysis.controller.ts` | Status endpoint at line 69 — `GET pipelines/:id/status`, delegates to orchestrator |
+| `src/entities/analysis-pipeline.entity.ts` | Pipeline entity — has `updatedAt` (inherited from CustomBaseEntity), `status`, `commentCount`, `sentimentGateIncluded/Excluded` |
+| `src/entities/sentiment-run.entity.ts` | SentimentRun — `status: RunStatus`, `submissionCount`, has `results` collection |
+| `src/entities/sentiment-result.entity.ts` | Individual result per submission — COUNT of these gives sentiment progress |
+| `src/entities/topic-model-run.entity.ts` | TopicModelRun — `status: RunStatus` |
+| `src/entities/recommendation-run.entity.ts` | RecommendationRun — `status: RunStatus` |
+| `src/modules/analysis/enums/pipeline-status.enum.ts` | `PipelineStatus` enum definition |
+| `src/modules/analysis/enums/run-status.enum.ts` | `RunStatus` enum definition |
+| `src/modules/analysis/services/pipeline-orchestrator.service.spec.ts` | Service tests — uses `makeMockPipeline()`, mocked EM fork |
+| `src/modules/analysis/analysis.controller.spec.ts` | Controller tests — mocks orchestrator with `jest.fn()` |
 
 ### Technical Decisions
 
@@ -76,7 +108,9 @@ _To be filled in Step 3_
 
 ### Dependencies
 
-_To be filled in Step 2_
+- No new packages required. All changes use existing NestJS, MikroORM, and Zod infrastructure.
+- Sentiment progress count requires a `COUNT` query on `SentimentResult` for the active run — this is a new query addition to `GetPipelineStatus()`.
+- `AnalysisPipeline.updatedAt` already exists via `CustomBaseEntity` and is auto-managed by MikroORM's `onUpdate` hook — no entity changes needed.
 
 ### Testing Strategy
 

--- a/_bmad-output/implementation-artifacts/tech-spec-wip.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-wip.md
@@ -167,6 +167,7 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
        - `recommendations`: `buildStage(getRunStatus(recommendationRun), recommendationRun)`
     3. Add to the top-level return: `updatedAt: pipeline.updatedAt.toISOString()` and `retryable: pipeline.status === PipelineStatus.FAILED`
   - Notes: `getRunStatus()` is a simple inline: `(run) => run ? run.status.toLowerCase() : 'pending'`. For `retryable`, all current failure modes are transient (worker timeouts, network errors), so `status === FAILED` is sufficient. Revisit if data validation failures become a distinct failure mode — may need an `errorCategory` field.
+  - **Commit strategy**: Split this task into two commits for reviewability: (a) replace helpers + reshape return block, (b) add `updatedAt` + `retryable` top-level fields.
 
 - [ ] Task 6: Update `getEmbeddingStageStatus()` return type
   - File: `src/modules/analysis/services/pipeline-orchestrator.service.ts`
@@ -180,10 +181,12 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
     3. Add a test case for `retryable: true` when pipeline status is `FAILED`
     4. Add a test case for `retryable: false` when pipeline status is not `FAILED`
     5. Add a test case verifying sentiment `progress.current` equals the mocked count
+    6. Add a test case for sentiment start: `sentimentRun` exists with status `PROCESSING` and zero results → `progress: { current: 0, total: N }`
 
-- [ ] Task 8: Update controller tests for reshaped response
+- [ ] Task 8 (low priority): Update controller tests for reshaped response
   - File: `src/modules/analysis/analysis.controller.spec.ts`
   - Action: Update the `GetPipelineStatus` test's `mockStatus` object to match the new response shape (add `retryable`, `updatedAt`, update stage shapes). The controller test is a pass-through, so this is mainly updating the mock data shape.
+  - Notes: Low priority — the controller is a pure pass-through. This test only verifies delegation, not response correctness. Skip if time-constrained.
 
 ### Acceptance Criteria
 
@@ -233,6 +236,7 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 - Start a pipeline via `POST /analysis/pipelines` + confirm
 - Poll `GET /analysis/pipelines/:id/status` and verify response shape consistency across stage transitions
 - Verify sentiment progress increments as results are processed
+- **Transition test**: Poll across a stage transition (e.g., `SENTIMENT_ANALYSIS` → `SENTIMENT_GATE`) and verify that the previous stage flips to `completed` and the next stage updates correctly in the subsequent poll response
 
 ### Notes
 

--- a/_bmad-output/implementation-artifacts/tech-spec-wip.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-wip.md
@@ -1,0 +1,98 @@
+---
+title: 'Frontend Pipeline Polling'
+slug: 'frontend-pipeline-polling'
+created: '2026-03-31'
+status: 'in-progress'
+stepsCompleted: [1]
+tech_stack: []
+files_to_modify: []
+code_patterns: []
+test_patterns: []
+---
+
+# Tech-Spec: Frontend Pipeline Polling
+
+**Created:** 2026-03-31
+
+## Overview
+
+### Problem Statement
+
+The frontend has no way to track analysis pipeline progress in real-time. There is no existing pipeline status UI, and the current `GET /analysis/pipelines/:id/status` response isn't optimized for polling — it lacks consistent field presence, per-stage progress tracking, and a retryable flag for failed states.
+
+### Solution
+
+Reshape the existing status endpoint response into a lean, polling-friendly DTO with consistent field presence (`null` over omission), per-stage progress counts (real for sentiment, `null` for binary stages), and a top-level `retryable` flag. The frontend uses React Query's `refetchInterval` for 3-second polling that auto-stops on terminal states. No new endpoints, no WebSockets, no denormalization.
+
+### Scope
+
+**In Scope:**
+- Reshape status endpoint response DTO for polling consistency
+- Add `progress: { current, total } | null` per stage (sentiment gets real counts via result row count)
+- Add `retryable: boolean` on pipeline-level failures
+- Ensure `updatedAt` is always accurate on pipeline entity
+- Document the frontend polling contract (React Query + Axios pattern)
+
+**Out of Scope:**
+- Frontend UI implementation (stepper component, animations)
+- WebSocket/SSE infrastructure
+- Batch multi-pipeline status endpoint
+- Denormalization of stage status onto pipeline entity
+- ETag / conditional request support
+
+## Context for Development
+
+### Codebase Patterns
+
+_To be filled in Step 2_
+
+### Files to Reference
+
+| File | Purpose |
+| ---- | ------- |
+
+_To be filled in Step 2_
+
+### Technical Decisions
+
+- **Single endpoint, no new routes** — reshape existing `GET /analysis/pipelines/:id/status` response rather than adding a separate polling endpoint. Avoids coordination complexity on the frontend.
+- **No denormalization** — query run tables directly on each poll. With only a handful of privileged users polling concurrently, the join cost is negligible.
+- **No WebSocket/SSE** — pipelines run for minutes. A 3-second REST polling interval via React Query is simpler, more resilient, and operationally trivial.
+- **`null` over omission** — every field in the response is always present. Use `null` for absent optional values. This ensures React Query's referential comparison works correctly and avoids unnecessary re-renders from shape changes.
+- **Sentiment gets real progress, others are binary** — derive sentiment `progress.current` from `SentimentResult` row count vs `progress.total` from pipeline comment count. Topic modeling and recommendations are single-batch, so progress is effectively `null` (binary processing/done).
+- **`retryable` flag** — top-level boolean on failed pipelines so the frontend knows whether to show "Retry" vs "Contact admin".
+
+## Implementation Plan
+
+### Tasks
+
+_To be filled in Step 3_
+
+### Acceptance Criteria
+
+_To be filled in Step 3_
+
+## Additional Context
+
+### Dependencies
+
+_To be filled in Step 2_
+
+### Testing Strategy
+
+_To be filled in Step 3_
+
+### Notes
+
+- Frontend polling pattern (for reference, not in backend scope):
+  ```typescript
+  const { data } = useQuery({
+    queryKey: ['pipeline-status', pipelineId],
+    queryFn: () => axios.get(`/analysis/pipelines/${pipelineId}/status`),
+    refetchInterval: (query) => {
+      const status = query.state.data?.data.status;
+      const isTerminal = ['COMPLETED', 'FAILED', 'CANCELLED'].includes(status);
+      return isTerminal ? false : 3000;
+    },
+  });
+  ```

--- a/_bmad-output/implementation-artifacts/tech-spec-wip.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-wip.md
@@ -2,8 +2,8 @@
 title: 'Frontend Pipeline Polling'
 slug: 'frontend-pipeline-polling'
 created: '2026-03-31'
-status: 'in-progress'
-stepsCompleted: [1, 2]
+status: 'review'
+stepsCompleted: [1, 2, 3]
 tech_stack: ['NestJS', 'MikroORM', 'PostgreSQL', 'BullMQ', 'Zod', 'Jest', 'Passport JWT']
 files_to_modify:
   - 'src/modules/analysis/dto/pipeline-status.dto.ts'
@@ -98,11 +98,112 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 
 ### Tasks
 
-_To be filled in Step 3_
+- [ ] Task 1: Reshape `stageStatusSchema` for consistent field presence
+  - File: `src/modules/analysis/dto/pipeline-status.dto.ts`
+  - Action: Replace all optional fields in `stageStatusSchema` with consistent, always-present fields using `null` for absent values:
+    ```typescript
+    const stageStatusSchema = z.object({
+      status: z.enum(['pending', 'processing', 'completed', 'failed', 'skipped']),
+      progress: z.object({
+        current: z.number().int(),
+        total: z.number().int(),
+      }).nullable(),
+      startedAt: z.string().datetime().nullable(),
+      completedAt: z.string().datetime().nullable(),
+    });
+    ```
+  - Notes: This removes the old `total`, `completed`, `processed`, `included`, `excluded` optional fields. The `progress` object is either fully present or `null`. `startedAt` and `completedAt` give the frontend elapsed-time signal.
+
+- [ ] Task 2: Add `retryable` and `updatedAt` to `pipelineStatusSchema`
+  - File: `src/modules/analysis/dto/pipeline-status.dto.ts`
+  - Action: Add two fields to the top-level `pipelineStatusSchema`:
+    - `retryable: z.boolean()` — after `errorMessage`
+    - `updatedAt: z.string().datetime()` — after `createdAt`
+  - Notes: `retryable` is `true` only when status is `FAILED`. `updatedAt` comes from `pipeline.updatedAt` (already on entity via `CustomBaseEntity`).
+
+- [ ] Task 3: Add sentiment gate fields to `pipelineStatusSchema` stages
+  - File: `src/modules/analysis/dto/pipeline-status.dto.ts`
+  - Action: The sentiment gate's `included`/`excluded` counts no longer fit in the generic `stageStatusSchema` (which now uses `progress`). Add a dedicated `sentimentGate` schema:
+    ```typescript
+    const sentimentGateSchema = stageStatusSchema.extend({
+      included: z.number().int().nullable(),
+      excluded: z.number().int().nullable(),
+    });
+    ```
+  - Update `stages` in `pipelineStatusSchema` to use `sentimentGateSchema` for the `sentimentGate` field.
+
+- [ ] Task 4: Update `GetPipelineStatus()` — add sentiment progress count query
+  - File: `src/modules/analysis/services/pipeline-orchestrator.service.ts`
+  - Action: After the existing `sentimentRun` query (~line 461), add a conditional `COUNT` query:
+    ```typescript
+    let sentimentCompleted = 0;
+    if (sentimentRun && sentimentRun.status !== RunStatus.PENDING) {
+      sentimentCompleted = await fork.count(SentimentResult, { run: sentimentRun });
+    }
+    ```
+  - Notes: Only queries when a run exists and has started. Returns 0 when pending. This is a cheap indexed COUNT on `sentiment_result.run_id`.
+
+- [ ] Task 5: Update `GetPipelineStatus()` — reshape return object to match new DTO
+  - File: `src/modules/analysis/services/pipeline-orchestrator.service.ts`
+  - Action: Replace the `stageStatus` helper and reshape the return object. Key changes:
+    1. Remove the `stageStatus()` and `getRunStageStatus()` helpers. Replace with a new helper:
+       ```typescript
+       const buildStage = (
+         status: 'pending' | 'processing' | 'completed' | 'failed' | 'skipped',
+         run: { createdAt: Date; completedAt?: Date } | null,
+         progress: { current: number; total: number } | null = null,
+       ) => ({
+         status,
+         progress,
+         startedAt: run?.createdAt?.toISOString() ?? null,
+         completedAt: run?.completedAt?.toISOString() ?? null,
+       });
+       ```
+    2. Update each stage in the return block:
+       - `embeddings`: `buildStage(embeddingStatus.status, null)` — no run entity, no progress
+       - `sentiment`: `buildStage(getRunStatus(sentimentRun), sentimentRun, { current: sentimentCompleted, total: pipeline.commentCount })` — real progress
+       - `sentimentGate`: `{ ...buildStage(gateStatus, null), included: pipeline.sentimentGateIncluded ?? null, excluded: pipeline.sentimentGateExcluded ?? null }`
+       - `topicModeling`: `buildStage(getRunStatus(topicModelRun), topicModelRun)`
+       - `recommendations`: `buildStage(getRunStatus(recommendationRun), recommendationRun)`
+    3. Add to the top-level return: `updatedAt: pipeline.updatedAt.toISOString()` and `retryable: pipeline.status === PipelineStatus.FAILED`
+  - Notes: `getRunStatus()` is a simple inline: `(run) => run ? run.status.toLowerCase() : 'pending'`
+
+- [ ] Task 6: Update `getEmbeddingStageStatus()` return type
+  - File: `src/modules/analysis/services/pipeline-orchestrator.service.ts`
+  - Action: The private method at line 937 currently returns `{ status }`. Since the `buildStage` helper in Task 5 only needs the status string, change the return type to just return the status string, or adapt the call site to destructure. Simplest: have it return just the status string and call `buildStage(this.getEmbeddingStageStatus(pipeline), null)`.
+
+- [ ] Task 7: Update service tests for reshaped response
+  - File: `src/modules/analysis/services/pipeline-orchestrator.service.spec.ts`
+  - Action: Update the `GetPipelineStatus` test cases:
+    1. Add mock for `fork.count(SentimentResult, ...)` returning a number (e.g., `47`)
+    2. Update expected response shape in assertions to match new DTO: `progress` objects instead of `total`/`completed`, `startedAt`/`completedAt` fields, `retryable`, `updatedAt`
+    3. Add a test case for `retryable: true` when pipeline status is `FAILED`
+    4. Add a test case for `retryable: false` when pipeline status is not `FAILED`
+    5. Add a test case verifying sentiment `progress.current` equals the mocked count
+
+- [ ] Task 8: Update controller tests for reshaped response
+  - File: `src/modules/analysis/analysis.controller.spec.ts`
+  - Action: Update the `GetPipelineStatus` test's `mockStatus` object to match the new response shape (add `retryable`, `updatedAt`, update stage shapes). The controller test is a pass-through, so this is mainly updating the mock data shape.
 
 ### Acceptance Criteria
 
-_To be filled in Step 3_
+- [ ] AC 1: Given a pipeline in `SENTIMENT_ANALYSIS` status with 120 comments and 47 sentiment results, when `GET /analysis/pipelines/:id/status` is called, then the response `stages.sentiment.progress` is `{ current: 47, total: 120 }` and `stages.sentiment.status` is `"processing"`.
+
+- [ ] AC 2: Given a pipeline in `TOPIC_MODELING` status, when `GET /analysis/pipelines/:id/status` is called, then `stages.topicModeling.progress` is `null` and `stages.topicModeling.status` is `"processing"`.
+
+- [ ] AC 3: Given a pipeline in `FAILED` status, when `GET /analysis/pipelines/:id/status` is called, then `retryable` is `true`.
+
+- [ ] AC 4: Given a pipeline in `COMPLETED` status, when `GET /analysis/pipelines/:id/status` is called, then `retryable` is `false`.
+
+- [ ] AC 5: Given any pipeline status, when `GET /analysis/pipelines/:id/status` is called, then every stage object contains `status`, `progress`, `startedAt`, and `completedAt` fields (no missing keys — values may be `null`).
+
+- [ ] AC 6: Given any pipeline status, when `GET /analysis/pipelines/:id/status` is called, then the response contains `updatedAt` as an ISO 8601 datetime string.
+
+- [ ] AC 7: Given a pipeline in `SENTIMENT_ANALYSIS` status with a `SentimentRun` that has `createdAt` set, when the status is polled, then `stages.sentiment.startedAt` is the ISO 8601 representation of that run's `createdAt`.
+
+- [ ] AC 8: Given a pipeline with completed sentiment gate (included=80, excluded=40), when `GET /analysis/pipelines/:id/status` is called, then `stages.sentimentGate.included` is `80`, `stages.sentimentGate.excluded` is `40`, and `stages.sentimentGate.status` is `"completed"`.
+
+- [ ] AC 9: Given a pipeline that does not exist, when `GET /analysis/pipelines/:id/status` is called, then a `404 Not Found` is returned (existing behavior preserved).
 
 ## Additional Context
 
@@ -114,10 +215,29 @@ _To be filled in Step 3_
 
 ### Testing Strategy
 
-_To be filled in Step 3_
+**Unit Tests (Jest):**
+- `pipeline-orchestrator.service.spec.ts`:
+  - Test reshaped response has all fields present (no undefined keys)
+  - Test sentiment `progress.current` matches mocked `SentimentResult` count
+  - Test sentiment `progress.total` matches `pipeline.commentCount`
+  - Test binary stages (embedding, topicModeling, recommendations) have `progress: null`
+  - Test `retryable: true` when `FAILED`, `false` otherwise
+  - Test `updatedAt` is present and matches pipeline entity
+  - Test `startedAt`/`completedAt` populated from run entities
+  - Test sentiment gate `included`/`excluded` still present
+- `analysis.controller.spec.ts`:
+  - Update mock data shape to match new DTO
+  - Verify pass-through behavior unchanged
+
+**Manual Testing:**
+- Start a pipeline via `POST /analysis/pipelines` + confirm
+- Poll `GET /analysis/pipelines/:id/status` and verify response shape consistency across stage transitions
+- Verify sentiment progress increments as results are processed
 
 ### Notes
 
+- **Breaking change**: The response shape of `GET /analysis/pipelines/:id/status` changes. The old `total`, `completed`, `processed` fields on stages are replaced with a `progress: { current, total } | null` object, and `startedAt`/`completedAt` are added. Coordinate frontend deployment.
+- **No migration needed**: No entity or database schema changes. All changes are in the DTO and service layer.
 - Frontend polling pattern (for reference, not in backend scope):
   ```typescript
   const { data } = useQuery({

--- a/_bmad-output/implementation-artifacts/tech-spec-wip.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-wip.md
@@ -141,7 +141,7 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
       sentimentCompleted = await fork.count(SentimentResult, { run: sentimentRun });
     }
     ```
-  - Notes: Only queries when a run exists and has started. Returns 0 when pending. This is a cheap indexed COUNT on `sentiment_result.run_id`.
+  - Notes: Only queries when a run exists and has started. Returns 0 when pending. This is a cheap indexed COUNT on `sentiment_result.run_id` (index confirmed on entity). If pipelines scale beyond ~5K comments, consider caching the count on `SentimentRun.completedCount` — out of scope for now.
 
 - [ ] Task 5: Update `GetPipelineStatus()` — reshape return object to match new DTO
   - File: `src/modules/analysis/services/pipeline-orchestrator.service.ts`
@@ -166,7 +166,7 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
        - `topicModeling`: `buildStage(getRunStatus(topicModelRun), topicModelRun)`
        - `recommendations`: `buildStage(getRunStatus(recommendationRun), recommendationRun)`
     3. Add to the top-level return: `updatedAt: pipeline.updatedAt.toISOString()` and `retryable: pipeline.status === PipelineStatus.FAILED`
-  - Notes: `getRunStatus()` is a simple inline: `(run) => run ? run.status.toLowerCase() : 'pending'`
+  - Notes: `getRunStatus()` is a simple inline: `(run) => run ? run.status.toLowerCase() : 'pending'`. For `retryable`, all current failure modes are transient (worker timeouts, network errors), so `status === FAILED` is sufficient. Revisit if data validation failures become a distinct failure mode — may need an `errorCategory` field.
 
 - [ ] Task 6: Update `getEmbeddingStageStatus()` return type
   - File: `src/modules/analysis/services/pipeline-orchestrator.service.ts`
@@ -236,8 +236,11 @@ Reshape the existing status endpoint response into a lean, polling-friendly DTO 
 
 ### Notes
 
-- **Breaking change**: The response shape of `GET /analysis/pipelines/:id/status` changes. The old `total`, `completed`, `processed` fields on stages are replaced with a `progress: { current, total } | null` object, and `startedAt`/`completedAt` are added. Coordinate frontend deployment.
+- **Breaking change**: The response shape of `GET /analysis/pipelines/:id/status` changes. The old `total`, `completed`, `processed` fields on stages are replaced with a `progress: { current, total } | null` object, and `startedAt`/`completedAt` are added. **Atomic deploy recommended** — backend and frontend should deploy together to avoid runtime mismatches.
 - **No migration needed**: No entity or database schema changes. All changes are in the DTO and service layer.
+- **Frontend null-safety**: The frontend must null-check `progress` before accessing `.current`/`.total`. Consider sharing the Zod schema or generating OpenAPI types to keep the contract in sync.
+- **Staleness detection (frontend concern)**: The frontend should compute staleness from `updatedAt` and `stages.*.startedAt` — e.g., if a stage has been `processing` for >10 minutes with no `updatedAt` change, display a "pipeline may be stuck" warning. No backend changes needed for this.
+- **Future scaling**: If pipeline comment counts grow beyond ~5K, the per-poll `SentimentResult` COUNT query should be revisited (cache on `SentimentRun.completedCount`). Current volumes don't warrant this.
 - Frontend polling pattern (for reference, not in backend scope):
   ```typescript
   const { data } = useQuery({

--- a/src/entities/analysis-pipeline.entity.ts
+++ b/src/entities/analysis-pipeline.entity.ts
@@ -25,6 +25,9 @@ import { RecommendationRun } from './recommendation-run.entity';
 @Entity({ repository: () => AnalysisPipelineRepository })
 @Index({ properties: ['semester', 'status'] })
 export class AnalysisPipeline extends CustomBaseEntity {
+  @Property({ onUpdate: () => new Date() })
+  override updatedAt: Date & Opt = new Date();
+
   @ManyToOne(() => Semester)
   semester!: Semester;
 

--- a/src/modules/analysis/analysis.controller.spec.ts
+++ b/src/modules/analysis/analysis.controller.spec.ts
@@ -143,6 +143,42 @@ describe('AnalysisController', () => {
         status: PipelineStatus.SENTIMENT_ANALYSIS,
         scope: { semester: 'S2026' },
         coverage: { totalEnrolled: 100, submissionCount: 50 },
+        stages: {
+          embeddings: {
+            status: 'completed',
+            progress: null,
+            startedAt: null,
+            completedAt: null,
+          },
+          sentiment: {
+            status: 'processing',
+            progress: { current: 10, total: 50 },
+            startedAt: '2026-03-13T10:00:00.000Z',
+            completedAt: null,
+          },
+          sentimentGate: {
+            status: 'pending',
+            progress: null,
+            startedAt: null,
+            completedAt: null,
+            included: null,
+            excluded: null,
+          },
+          topicModeling: {
+            status: 'pending',
+            progress: null,
+            startedAt: null,
+            completedAt: null,
+          },
+          recommendations: {
+            status: 'pending',
+            progress: null,
+            startedAt: null,
+            completedAt: null,
+          },
+        },
+        retryable: false,
+        updatedAt: '2026-03-13T12:00:00.000Z',
       };
       mockOrchestrator.GetPipelineStatus.mockResolvedValue(mockStatus);
 

--- a/src/modules/analysis/dto/pipeline-status.dto.ts
+++ b/src/modules/analysis/dto/pipeline-status.dto.ts
@@ -2,11 +2,19 @@ import { z } from 'zod';
 
 const stageStatusSchema = z.object({
   status: z.enum(['pending', 'processing', 'completed', 'failed', 'skipped']),
-  total: z.number().int().optional(),
-  completed: z.number().int().optional(),
-  processed: z.number().int().optional(),
-  included: z.number().int().nullable().optional(),
-  excluded: z.number().int().nullable().optional(),
+  progress: z
+    .object({
+      current: z.number().int(),
+      total: z.number().int(),
+    })
+    .nullable(),
+  startedAt: z.string().datetime().nullable(),
+  completedAt: z.string().datetime().nullable(),
+});
+
+const sentimentGateSchema = stageStatusSchema.extend({
+  included: z.number().int().nullable(),
+  excluded: z.number().int().nullable(),
 });
 
 export const pipelineStatusSchema = z.object({
@@ -31,13 +39,15 @@ export const pipelineStatusSchema = z.object({
   stages: z.object({
     embeddings: stageStatusSchema,
     sentiment: stageStatusSchema,
-    sentimentGate: stageStatusSchema,
+    sentimentGate: sentimentGateSchema,
     topicModeling: stageStatusSchema,
     recommendations: stageStatusSchema,
   }),
   warnings: z.array(z.string()),
-  errorMessage: z.string().nullable().optional(),
+  errorMessage: z.string().nullable(),
+  retryable: z.boolean(),
   createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
   confirmedAt: z.string().datetime().nullable(),
   completedAt: z.string().datetime().nullable(),
 });

--- a/src/modules/analysis/services/pipeline-orchestrator.service.spec.ts
+++ b/src/modules/analysis/services/pipeline-orchestrator.service.spec.ts
@@ -454,6 +454,32 @@ describe('PipelineOrchestratorService', () => {
   });
 
   describe('GetPipelineStatus', () => {
+    const basePipeline = {
+      id: 'p1',
+      status: PipelineStatus.SENTIMENT_ANALYSIS,
+      semester: { id: 's1', code: 'S2026' },
+      faculty: null,
+      questionnaireVersion: null,
+      department: { code: 'CCS' },
+      program: null,
+      campus: null,
+      course: null,
+      totalEnrolled: 100,
+      submissionCount: 50,
+      commentCount: 40,
+      responseRate: 0.5,
+      warnings: [],
+      errorMessage: null,
+      sentimentGateIncluded: null,
+      sentimentGateExcluded: null,
+      createdAt: new Date('2026-03-13'),
+      updatedAt: new Date('2026-03-13T12:00:00Z'),
+      confirmedAt: new Date('2026-03-13'),
+      completedAt: null,
+    };
+
+    const sentimentRunCreatedAt = new Date('2026-03-13T10:00:00Z');
+
     it('should throw NotFoundException if pipeline not found', async () => {
       mockFork.findOne.mockResolvedValue(null);
 
@@ -462,36 +488,24 @@ describe('PipelineOrchestratorService', () => {
       );
     });
 
-    it('should return composed pipeline status', async () => {
-      const pipeline = {
-        id: 'p1',
-        status: PipelineStatus.SENTIMENT_ANALYSIS,
-        semester: { id: 's1', code: 'S2026' },
-        faculty: null,
-        questionnaireVersion: null,
-        department: { code: 'CCS' },
-        program: null,
-        campus: null,
-        course: null,
-        totalEnrolled: 100,
-        submissionCount: 50,
-        commentCount: 40,
-        responseRate: 0.5,
-        warnings: [],
-        errorMessage: null,
-        sentimentGateIncluded: null,
-        sentimentGateExcluded: null,
-        createdAt: new Date('2026-03-13'),
-        confirmedAt: new Date('2026-03-13'),
+    it('should return reshaped pipeline status with progress and timestamps', async () => {
+      const pipeline = { ...basePipeline };
+      const sentimentRun = {
+        status: RunStatus.PROCESSING,
+        submissionCount: 120,
+        createdAt: sentimentRunCreatedAt,
         completedAt: null,
       };
 
       mockFork.findOne
         .mockResolvedValueOnce(pipeline)
-        .mockResolvedValueOnce({ status: RunStatus.PROCESSING })
+        .mockResolvedValueOnce(sentimentRun) // sentiment run
         .mockResolvedValueOnce(null) // topic model run
         .mockResolvedValueOnce(null) // recommendation run
         .mockResolvedValueOnce({ updatedAt: new Date() }); // enrollment for lastSyncAt
+
+      // count: sentiment results
+      mockFork.count.mockResolvedValueOnce(47);
 
       // find: submissions for course scoping
       mockFork.find.mockResolvedValueOnce([{ course: { id: 'c1' } }]);
@@ -503,8 +517,187 @@ describe('PipelineOrchestratorService', () => {
       expect(status.scope.semester).toBe('S2026');
       expect(status.scope.department).toBe('CCS');
       expect(status.coverage.totalEnrolled).toBe(100);
+      expect(status.updatedAt).toBe('2026-03-13T12:00:00.000Z');
+
+      // Sentiment stage: real progress
       expect(status.stages.sentiment.status).toBe('processing');
+      expect(status.stages.sentiment.progress).toEqual({
+        current: 47,
+        total: 120,
+      });
+      expect(status.stages.sentiment.startedAt).toBe(
+        sentimentRunCreatedAt.toISOString(),
+      );
+      expect(status.stages.sentiment.completedAt).toBeNull();
+
+      // Binary stages: null progress
       expect(status.stages.topicModeling.status).toBe('pending');
+      expect(status.stages.topicModeling.progress).toBeNull();
+      expect(status.stages.embeddings.progress).toBeNull();
+      expect(status.stages.recommendations.progress).toBeNull();
+
+      // All stage fields present (no undefined)
+      for (const stage of Object.values(status.stages)) {
+        expect(stage).toHaveProperty('status');
+        expect(stage).toHaveProperty('progress');
+        expect(stage).toHaveProperty('startedAt');
+        expect(stage).toHaveProperty('completedAt');
+      }
+    });
+
+    it('should return retryable: true when pipeline FAILED', async () => {
+      const pipeline = {
+        ...basePipeline,
+        status: PipelineStatus.FAILED,
+        errorMessage: 'Worker crashed',
+      };
+
+      mockFork.findOne
+        .mockResolvedValueOnce(pipeline)
+        .mockResolvedValueOnce(null) // sentiment run
+        .mockResolvedValueOnce(null) // topic model run
+        .mockResolvedValueOnce(null); // recommendation run
+
+      // find: submissions for course scoping (no courses)
+      mockFork.find.mockResolvedValueOnce([]);
+
+      const status = await service.GetPipelineStatus('p1');
+
+      expect(status.retryable).toBe(true);
+    });
+
+    it('should return retryable: false when pipeline not FAILED', async () => {
+      const pipeline = { ...basePipeline, status: PipelineStatus.COMPLETED };
+
+      mockFork.findOne
+        .mockResolvedValueOnce(pipeline)
+        .mockResolvedValueOnce(null) // sentiment run
+        .mockResolvedValueOnce(null) // topic model run
+        .mockResolvedValueOnce(null); // recommendation run
+
+      mockFork.find.mockResolvedValueOnce([]);
+
+      const status = await service.GetPipelineStatus('p1');
+
+      expect(status.retryable).toBe(false);
+    });
+
+    it('should return sentiment progress.current matching result count', async () => {
+      const pipeline = { ...basePipeline };
+      const sentimentRun = {
+        status: RunStatus.PROCESSING,
+        submissionCount: 120,
+        createdAt: sentimentRunCreatedAt,
+        completedAt: null,
+      };
+
+      mockFork.findOne
+        .mockResolvedValueOnce(pipeline)
+        .mockResolvedValueOnce(sentimentRun)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null);
+
+      mockFork.count.mockResolvedValueOnce(47);
+      mockFork.find.mockResolvedValueOnce([]);
+
+      const status = await service.GetPipelineStatus('p1');
+
+      expect(status.stages.sentiment.progress).toEqual({
+        current: 47,
+        total: 120,
+      });
+    });
+
+    it('should return zero progress when sentiment run is PROCESSING with no results yet', async () => {
+      const pipeline = { ...basePipeline };
+      const sentimentRun = {
+        status: RunStatus.PROCESSING,
+        submissionCount: 80,
+        createdAt: sentimentRunCreatedAt,
+        completedAt: null,
+      };
+
+      mockFork.findOne
+        .mockResolvedValueOnce(pipeline)
+        .mockResolvedValueOnce(sentimentRun)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null);
+
+      mockFork.count.mockResolvedValueOnce(0);
+      mockFork.find.mockResolvedValueOnce([]);
+
+      const status = await service.GetPipelineStatus('p1');
+
+      expect(status.stages.sentiment.progress).toEqual({
+        current: 0,
+        total: 80,
+      });
+    });
+
+    it('should return skipped stages and retryable: false for CANCELLED pipeline', async () => {
+      const pipeline = {
+        ...basePipeline,
+        status: PipelineStatus.CANCELLED,
+        sentimentGateIncluded: null,
+        sentimentGateExcluded: null,
+      };
+
+      mockFork.findOne
+        .mockResolvedValueOnce(pipeline)
+        .mockResolvedValueOnce(null) // sentiment run
+        .mockResolvedValueOnce(null) // topic model run
+        .mockResolvedValueOnce(null); // recommendation run
+
+      mockFork.find.mockResolvedValueOnce([]);
+
+      const status = await service.GetPipelineStatus('p1');
+
+      expect(status.retryable).toBe(false);
+      expect(status.stages.embeddings.status).toBe('skipped');
+      expect(status.stages.sentimentGate.status).toBe('skipped');
+    });
+
+    it('should return embeddings failed when pipeline FAILED with no sentiment run', async () => {
+      const pipeline = {
+        ...basePipeline,
+        status: PipelineStatus.FAILED,
+        errorMessage: 'Embedding check failed',
+      };
+
+      mockFork.findOne
+        .mockResolvedValueOnce(pipeline)
+        .mockResolvedValueOnce(null) // sentiment run (none = embedding likely failed)
+        .mockResolvedValueOnce(null) // topic model run
+        .mockResolvedValueOnce(null); // recommendation run
+
+      mockFork.find.mockResolvedValueOnce([]);
+
+      const status = await service.GetPipelineStatus('p1');
+
+      expect(status.stages.embeddings.status).toBe('failed');
+    });
+
+    it('should return sentiment gate included/excluded with completed status', async () => {
+      const pipeline = {
+        ...basePipeline,
+        status: PipelineStatus.TOPIC_MODELING,
+        sentimentGateIncluded: 80,
+        sentimentGateExcluded: 40,
+      };
+
+      mockFork.findOne
+        .mockResolvedValueOnce(pipeline)
+        .mockResolvedValueOnce(null) // sentiment run
+        .mockResolvedValueOnce(null) // topic model run
+        .mockResolvedValueOnce(null); // recommendation run
+
+      mockFork.find.mockResolvedValueOnce([]);
+
+      const status = await service.GetPipelineStatus('p1');
+
+      expect(status.stages.sentimentGate.status).toBe('completed');
+      expect(status.stages.sentimentGate.included).toBe(80);
+      expect(status.stages.sentimentGate.excluded).toBe(40);
     });
   });
 });

--- a/src/modules/analysis/services/pipeline-orchestrator.service.ts
+++ b/src/modules/analysis/services/pipeline-orchestrator.service.ts
@@ -470,6 +470,14 @@ export class PipelineOrchestratorService {
       { orderBy: { createdAt: 'DESC' } },
     );
 
+    // Sentiment progress count
+    let sentimentCompleted = 0;
+    if (sentimentRun && sentimentRun.status !== RunStatus.PENDING) {
+      sentimentCompleted = await fork.count(SentimentResult, {
+        run: sentimentRun,
+      });
+    }
+
     // Compute lastEnrollmentSyncAt by scoping through courses in submission scope
     const scope = buildSubmissionScope(pipeline);
     let lastEnrollmentSyncAt: Date | null = null;
@@ -497,25 +505,41 @@ export class PipelineOrchestratorService {
       }
     }
 
-    const stageStatus = (status: string, extras?: Record<string, unknown>) => ({
-      status: status as
-        | 'pending'
-        | 'processing'
-        | 'completed'
-        | 'failed'
-        | 'skipped',
-      ...extras,
+    const buildStage = (
+      status: 'pending' | 'processing' | 'completed' | 'failed' | 'skipped',
+      run: { createdAt: Date; completedAt?: Date | null } | null,
+      progress: { current: number; total: number } | null = null,
+    ) => ({
+      status,
+      progress,
+      startedAt: run?.createdAt?.toISOString() ?? null,
+      completedAt: run?.completedAt?.toISOString() ?? null,
     });
 
-    const getRunStageStatus = (
+    // If RunStatus gains new values, update this mapping to match the stage status union
+    const getRunStatus = (
       run: SentimentRun | TopicModelRun | RecommendationRun | null,
-    ) => {
-      if (!run) return stageStatus('pending');
-      return stageStatus(run.status.toLowerCase());
-    };
+    ) =>
+      run
+        ? (run.status.toLowerCase() as
+            | 'pending'
+            | 'processing'
+            | 'completed'
+            | 'failed')
+        : 'pending';
 
-    // Determine embedding stage status based on pipeline status
-    const embeddingStatus = this.getEmbeddingStageStatus(pipeline);
+    // Gate either completed (has data) or didn't. Top-level pipeline.status
+    // handles failure attribution — no per-stage failure tracking for MVP.
+    // FAILED pipelines: gate shows 'pending' (never completed) which is correct.
+    // CANCELLED pipelines: gate shows 'skipped' (explicitly not attempted).
+    const gateStatus =
+      pipeline.sentimentGateIncluded != null
+        ? 'completed'
+        : pipeline.status === PipelineStatus.SENTIMENT_GATE
+          ? 'processing'
+          : pipeline.status === PipelineStatus.CANCELLED
+            ? 'skipped'
+            : 'pending';
 
     return {
       id: pipeline.id,
@@ -537,27 +561,36 @@ export class PipelineOrchestratorService {
         lastEnrollmentSyncAt: lastEnrollmentSyncAt?.toISOString() || null,
       },
       stages: {
-        embeddings: embeddingStatus,
-        sentiment: {
-          ...getRunStageStatus(sentimentRun),
-          total: pipeline.commentCount,
-        },
-        sentimentGate: stageStatus(
-          pipeline.sentimentGateIncluded !== null &&
-            pipeline.sentimentGateIncluded !== undefined
-            ? 'completed'
-            : 'pending',
-          {
-            included: pipeline.sentimentGateIncluded ?? null,
-            excluded: pipeline.sentimentGateExcluded ?? null,
-          },
+        embeddings: buildStage(
+          this.getEmbeddingStageStatus(pipeline, sentimentRun),
+          null,
         ),
-        topicModeling: getRunStageStatus(topicModelRun),
-        recommendations: getRunStageStatus(recommendationRun),
+        sentiment: sentimentRun
+          ? buildStage(getRunStatus(sentimentRun), sentimentRun, {
+              current: Math.min(
+                sentimentCompleted,
+                sentimentRun.submissionCount,
+              ),
+              total: sentimentRun.submissionCount,
+            })
+          : buildStage('pending', null),
+        sentimentGate: {
+          ...buildStage(gateStatus, null),
+          included: pipeline.sentimentGateIncluded ?? null,
+          excluded: pipeline.sentimentGateExcluded ?? null,
+        },
+        topicModeling: buildStage(getRunStatus(topicModelRun), topicModelRun),
+        recommendations: buildStage(
+          getRunStatus(recommendationRun),
+          recommendationRun,
+        ),
       },
       warnings: pipeline.warnings,
-      errorMessage: pipeline.errorMessage || null,
+      errorMessage: pipeline.errorMessage ?? null,
+      // Intent signal for future error categorization — currently equivalent to status === FAILED
+      retryable: pipeline.status === PipelineStatus.FAILED,
       createdAt: pipeline.createdAt.toISOString(),
+      updatedAt: pipeline.updatedAt.toISOString(),
       confirmedAt: pipeline.confirmedAt?.toISOString() || null,
       completedAt: pipeline.completedAt?.toISOString() || null,
     };
@@ -934,19 +967,24 @@ export class PipelineOrchestratorService {
     this.logger.error(`Pipeline ${pipeline.id} failed: ${error}`);
   }
 
-  private getEmbeddingStageStatus(pipeline: AnalysisPipeline): {
-    status: 'pending' | 'processing' | 'completed' | 'failed' | 'skipped';
-  } {
+  private getEmbeddingStageStatus(
+    pipeline: AnalysisPipeline,
+    sentimentRun: SentimentRun | null,
+  ): 'pending' | 'processing' | 'completed' | 'failed' | 'skipped' {
     if (pipeline.status === PipelineStatus.EMBEDDING_CHECK) {
-      return { status: 'processing' };
+      return 'processing';
     }
     if (pipeline.status === PipelineStatus.AWAITING_CONFIRMATION) {
-      return { status: 'pending' };
+      return 'pending';
     }
     if (pipeline.status === PipelineStatus.CANCELLED) {
-      return { status: 'skipped' };
+      return 'skipped';
+    }
+    // If pipeline failed and never created a sentiment run, embedding is the likely failure point
+    if (pipeline.status === PipelineStatus.FAILED && !sentimentRun) {
+      return 'failed';
     }
     // Past embedding check (sentiment, topic modeling, recommendations, completed, or failed later)
-    return { status: 'completed' };
+    return 'completed';
   }
 }


### PR DESCRIPTION
## Summary

Closes #226

Reshapes `GET /analysis/pipelines/:id/status` response for frontend polling consistency:

- Replace optional stage fields with `progress: { current, total } | null` + `startedAt`/`completedAt` per stage
- Add dedicated `sentimentGateSchema` with `included`/`excluded` fields
- Add top-level `retryable: boolean` and `updatedAt: string` fields
- Add sentiment progress COUNT query (`SentimentResult` row count vs `sentimentRun.submissionCount`)
- Fix `AnalysisPipeline.updatedAt` with `onUpdate` hook (scoped, no migration)
- Fix embedding stage status for FAILED pipelines (sentimentRun heuristic)
- Clamp sentiment progress to prevent `current > total`

## Breaking Change

Response shape of `GET /analysis/pipelines/:id/status` changes. Old `total`, `completed`, `processed` optional fields on stages are removed. **Frontend must deploy atomically with this backend change.**

## Files Changed

| File | Change |
|------|--------|
| `src/entities/analysis-pipeline.entity.ts` | `updatedAt` override with `onUpdate` hook |
| `src/modules/analysis/dto/pipeline-status.dto.ts` | Reshaped `stageStatusSchema`, new `sentimentGateSchema`, added `retryable`/`updatedAt` |
| `src/modules/analysis/services/pipeline-orchestrator.service.ts` | New helpers, sentiment COUNT query, reshaped return, embedding failure heuristic |
| `src/modules/analysis/services/pipeline-orchestrator.service.spec.ts` | 8 new test cases |
| `src/modules/analysis/analysis.controller.spec.ts` | Updated mock data for new DTO shape |
| `_bmad-output/.../tech-spec-frontend-pipeline-polling.md` | Marked tasks complete, status → implementation-complete |

## Test Plan

- [x] All 629 unit tests pass
- [x] Lint passes clean
- [x] Sentiment progress returns `{ current: 47, total: 120 }` with mocked COUNT
- [x] Binary stages return `progress: null`
- [x] `retryable: true` only for FAILED, `false` otherwise
- [x] CANCELLED pipeline: embeddings + sentimentGate show `skipped`
- [x] FAILED pipeline with no sentimentRun: embeddings show `failed`
- [x] Sentiment gate `included`/`excluded` preserved with `completed` status
- [x] All stage objects have consistent field presence (no undefined keys)
- [ ] Manual: poll across stage transitions to verify real-time shape consistency