### PR TITLE
FAC-104 feat: expose semester context for dean faculty evaluation flow

### DIFF
--- a/src/modules/index.module.ts
+++ b/src/modules/index.module.ts
@@ -22,6 +22,7 @@ import { FacultyModule } from './faculty/faculty.module';
 import { CurriculumModule } from './curriculum/curriculum.module';
 import { AdminModule } from './admin/admin.module';
 import { AuditModule } from './audit/audit.module';
+import { SemestersModule } from './semesters/semesters.module';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { ThrottlerStorageRedisService } from '@nest-lab/throttler-storage-redis';
 import { LoggerModule } from 'nestjs-pino';
@@ -45,6 +46,7 @@ export const ApplicationModules = [
   CurriculumModule,
   AdminModule,
   AuditModule,
+  SemestersModule,
 ];
 
 export const InfrastructureModules = [

--- a/src/modules/semesters/dto/requests/list-semesters-query.dto.ts
+++ b/src/modules/semesters/dto/requests/list-semesters-query.dto.ts
@@ -1,0 +1,9 @@
+import { IsOptional, IsUUID } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ListSemestersQueryDto {
+  @ApiPropertyOptional({ description: 'Filter by campus UUID' })
+  @IsUUID()
+  @IsOptional()
+  campusId?: string;
+}

--- a/src/modules/semesters/dto/responses/campus-short.response.dto.ts
+++ b/src/modules/semesters/dto/responses/campus-short.response.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+export class CampusShortResponseDto {
+  @ApiProperty()
+  @IsString()
+  id: string;
+
+  @ApiProperty()
+  @IsString()
+  code: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  name?: string;
+}

--- a/src/modules/semesters/dto/responses/semester-item.response.dto.ts
+++ b/src/modules/semesters/dto/responses/semester-item.response.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { CampusShortResponseDto } from './campus-short.response.dto';
+
+export class SemesterItemResponseDto {
+  @ApiProperty()
+  @IsString()
+  id: string;
+
+  @ApiProperty()
+  @IsString()
+  code: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  label?: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  academicYear?: string;
+
+  @ApiProperty({ type: CampusShortResponseDto })
+  @ValidateNested()
+  @Type(() => CampusShortResponseDto)
+  campus: CampusShortResponseDto;
+}

--- a/src/modules/semesters/dto/responses/semester-list.response.dto.ts
+++ b/src/modules/semesters/dto/responses/semester-list.response.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { SemesterItemResponseDto } from './semester-item.response.dto';
+
+export class SemesterListResponseDto {
+  @ApiProperty({ type: [SemesterItemResponseDto] })
+  @ValidateNested({ each: true })
+  @Type(() => SemesterItemResponseDto)
+  data: SemesterItemResponseDto[];
+}

--- a/src/modules/semesters/semesters.controller.ts
+++ b/src/modules/semesters/semesters.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { UseJwtGuard } from '../../security/decorators';
 import { SemestersService } from './semesters.service';
-import { SemesterShortResponseDto } from '../enrollments/dto/responses/semester-short.response.dto';
+import { SemesterListResponseDto } from './dto/responses/semester-list.response.dto';
 
 @ApiTags('semesters')
 @Controller('semesters')
@@ -10,11 +10,10 @@ import { SemesterShortResponseDto } from '../enrollments/dto/responses/semester-
 export class SemestersController {
   constructor(private readonly semestersService: SemestersService) {}
 
-  @Get('current')
-  @ApiOperation({ summary: 'Get the current (latest active) semester' })
-  @ApiResponse({ status: 200, type: SemesterShortResponseDto })
-  @ApiResponse({ status: 404, description: 'No active semester found' })
-  async getCurrent(): Promise<SemesterShortResponseDto> {
-    return this.semestersService.getCurrentSemester();
+  @Get()
+  @ApiOperation({ summary: 'List all semesters with campus info' })
+  @ApiResponse({ status: 200, type: SemesterListResponseDto })
+  async list(): Promise<SemesterListResponseDto> {
+    return this.semestersService.listSemesters();
   }
 }

--- a/src/modules/semesters/semesters.controller.ts
+++ b/src/modules/semesters/semesters.controller.ts
@@ -1,8 +1,9 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Query } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { UseJwtGuard } from '../../security/decorators';
 import { SemestersService } from './semesters.service';
 import { SemesterListResponseDto } from './dto/responses/semester-list.response.dto';
+import { ListSemestersQueryDto } from './dto/requests/list-semesters-query.dto';
 
 @ApiTags('semesters')
 @Controller('semesters')
@@ -13,7 +14,9 @@ export class SemestersController {
   @Get()
   @ApiOperation({ summary: 'List all semesters with campus info' })
   @ApiResponse({ status: 200, type: SemesterListResponseDto })
-  async list(): Promise<SemesterListResponseDto> {
-    return this.semestersService.listSemesters();
+  async list(
+    @Query() query: ListSemestersQueryDto,
+  ): Promise<SemesterListResponseDto> {
+    return this.semestersService.listSemesters(query);
   }
 }

--- a/src/modules/semesters/semesters.controller.ts
+++ b/src/modules/semesters/semesters.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { UseJwtGuard } from '../../security/decorators';
+import { SemestersService } from './semesters.service';
+import { SemesterShortResponseDto } from '../enrollments/dto/responses/semester-short.response.dto';
+
+@ApiTags('semesters')
+@Controller('semesters')
+@UseJwtGuard()
+export class SemestersController {
+  constructor(private readonly semestersService: SemestersService) {}
+
+  @Get('current')
+  @ApiOperation({ summary: 'Get the current (latest active) semester' })
+  @ApiResponse({ status: 200, type: SemesterShortResponseDto })
+  @ApiResponse({ status: 404, description: 'No active semester found' })
+  async getCurrent(): Promise<SemesterShortResponseDto> {
+    return this.semestersService.getCurrentSemester();
+  }
+}

--- a/src/modules/semesters/semesters.module.ts
+++ b/src/modules/semesters/semesters.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { MikroOrmModule } from '@mikro-orm/nestjs';
+import { Semester } from '../../entities/semester.entity';
+import { SemestersController } from './semesters.controller';
+import { SemestersService } from './semesters.service';
+
+@Module({
+  imports: [MikroOrmModule.forFeature([Semester])],
+  controllers: [SemestersController],
+  providers: [SemestersService],
+})
+export class SemestersModule {}

--- a/src/modules/semesters/semesters.service.spec.ts
+++ b/src/modules/semesters/semesters.service.spec.ts
@@ -1,0 +1,71 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EntityManager } from '@mikro-orm/core';
+import { NotFoundException } from '@nestjs/common';
+import { SemestersService } from './semesters.service';
+import { Semester } from '../../entities/semester.entity';
+
+describe('SemestersService', () => {
+  let service: SemestersService;
+  let em: { findOne: jest.Mock };
+
+  beforeEach(async () => {
+    em = { findOne: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SemestersService, { provide: EntityManager, useValue: em }],
+    }).compile();
+
+    service = module.get<SemestersService>(SemestersService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getCurrentSemester', () => {
+    it('should return the latest semester', async () => {
+      const mockSemester = {
+        id: 'semester-uuid-1',
+        code: 'S22526',
+        label: 'Semester 2',
+        academicYear: '2025-2026',
+      };
+
+      em.findOne.mockResolvedValue(mockSemester);
+
+      const result = await service.getCurrentSemester();
+
+      expect(result).toEqual({
+        id: 'semester-uuid-1',
+        code: 'S22526',
+        label: 'Semester 2',
+        academicYear: '2025-2026',
+      });
+    });
+
+    it('should call findOne with correct entity and ordering', async () => {
+      em.findOne.mockResolvedValue({
+        id: 'id',
+        code: 'S12526',
+        label: 'Semester 1',
+        academicYear: '2025-2026',
+      });
+
+      await service.getCurrentSemester();
+
+      expect(em.findOne).toHaveBeenCalledWith(
+        Semester,
+        {},
+        { orderBy: { createdAt: 'DESC' } },
+      );
+    });
+
+    it('should throw NotFoundException when no semester exists', async () => {
+      em.findOne.mockResolvedValue(null);
+
+      await expect(service.getCurrentSemester()).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/src/modules/semesters/semesters.service.spec.ts
+++ b/src/modules/semesters/semesters.service.spec.ts
@@ -42,7 +42,7 @@ describe('SemestersService', () => {
     it('should return all semesters with campus info', async () => {
       em.find.mockResolvedValue(mockSemesters);
 
-      const result = await service.listSemesters();
+      const result = await service.listSemesters({});
 
       expect(result.data).toHaveLength(2);
       expect(result.data[0]).toEqual({
@@ -55,10 +55,10 @@ describe('SemestersService', () => {
       expect(result.data[1].campus.code).toBe('UCB');
     });
 
-    it('should call find with correct options', async () => {
+    it('should call find without campus filter when campusId is omitted', async () => {
       em.find.mockResolvedValue([]);
 
-      await service.listSemesters();
+      await service.listSemesters({});
 
       expect(em.find).toHaveBeenCalledWith(
         Semester,
@@ -70,10 +70,27 @@ describe('SemestersService', () => {
       );
     });
 
+    it('should filter by campus when campusId is provided', async () => {
+      em.find.mockResolvedValue([mockSemesters[0]]);
+
+      const result = await service.listSemesters({ campusId: 'campus-1' });
+
+      expect(em.find).toHaveBeenCalledWith(
+        Semester,
+        { campus: 'campus-1' },
+        {
+          populate: ['campus'],
+          orderBy: { createdAt: 'DESC' },
+        },
+      );
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].campus.code).toBe('UCMN');
+    });
+
     it('should return empty data when no semesters exist', async () => {
       em.find.mockResolvedValue([]);
 
-      const result = await service.listSemesters();
+      const result = await service.listSemesters({});
 
       expect(result.data).toEqual([]);
     });

--- a/src/modules/semesters/semesters.service.spec.ts
+++ b/src/modules/semesters/semesters.service.spec.ts
@@ -1,15 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { EntityManager } from '@mikro-orm/core';
-import { NotFoundException } from '@nestjs/common';
 import { SemestersService } from './semesters.service';
 import { Semester } from '../../entities/semester.entity';
 
 describe('SemestersService', () => {
   let service: SemestersService;
-  let em: { findOne: jest.Mock };
+  let em: { find: jest.Mock };
 
   beforeEach(async () => {
-    em = { findOne: jest.fn() };
+    em = { find: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [SemestersService, { provide: EntityManager, useValue: em }],
@@ -22,50 +21,61 @@ describe('SemestersService', () => {
     expect(service).toBeDefined();
   });
 
-  describe('getCurrentSemester', () => {
-    it('should return the latest semester', async () => {
-      const mockSemester = {
-        id: 'semester-uuid-1',
+  describe('listSemesters', () => {
+    const mockSemesters = [
+      {
+        id: 'sem-1',
         code: 'S22526',
         label: 'Semester 2',
         academicYear: '2025-2026',
-      };
-
-      em.findOne.mockResolvedValue(mockSemester);
-
-      const result = await service.getCurrentSemester();
-
-      expect(result).toEqual({
-        id: 'semester-uuid-1',
+        campus: { id: 'campus-1', code: 'UCMN', name: 'UC Main' },
+      },
+      {
+        id: 'sem-2',
         code: 'S22526',
         label: 'Semester 2',
         academicYear: '2025-2026',
+        campus: { id: 'campus-2', code: 'UCB', name: 'UC Banilad' },
+      },
+    ];
+
+    it('should return all semesters with campus info', async () => {
+      em.find.mockResolvedValue(mockSemesters);
+
+      const result = await service.listSemesters();
+
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0]).toEqual({
+        id: 'sem-1',
+        code: 'S22526',
+        label: 'Semester 2',
+        academicYear: '2025-2026',
+        campus: { id: 'campus-1', code: 'UCMN', name: 'UC Main' },
       });
+      expect(result.data[1].campus.code).toBe('UCB');
     });
 
-    it('should call findOne with correct entity and ordering', async () => {
-      em.findOne.mockResolvedValue({
-        id: 'id',
-        code: 'S12526',
-        label: 'Semester 1',
-        academicYear: '2025-2026',
-      });
+    it('should call find with correct options', async () => {
+      em.find.mockResolvedValue([]);
 
-      await service.getCurrentSemester();
+      await service.listSemesters();
 
-      expect(em.findOne).toHaveBeenCalledWith(
+      expect(em.find).toHaveBeenCalledWith(
         Semester,
         {},
-        { orderBy: { createdAt: 'DESC' } },
+        {
+          populate: ['campus'],
+          orderBy: { createdAt: 'DESC' },
+        },
       );
     });
 
-    it('should throw NotFoundException when no semester exists', async () => {
-      em.findOne.mockResolvedValue(null);
+    it('should return empty data when no semesters exist', async () => {
+      em.find.mockResolvedValue([]);
 
-      await expect(service.getCurrentSemester()).rejects.toThrow(
-        NotFoundException,
-      );
+      const result = await service.listSemesters();
+
+      expect(result.data).toEqual([]);
     });
   });
 });

--- a/src/modules/semesters/semesters.service.ts
+++ b/src/modules/semesters/semesters.service.ts
@@ -1,21 +1,25 @@
 import { Injectable } from '@nestjs/common';
-import { EntityManager } from '@mikro-orm/core';
+import { EntityManager, FilterQuery } from '@mikro-orm/core';
 import { Semester } from '../../entities/semester.entity';
 import { SemesterListResponseDto } from './dto/responses/semester-list.response.dto';
+import { ListSemestersQueryDto } from './dto/requests/list-semesters-query.dto';
 
 @Injectable()
 export class SemestersService {
   constructor(private readonly em: EntityManager) {}
 
-  async listSemesters(): Promise<SemesterListResponseDto> {
-    const semesters = await this.em.find(
-      Semester,
-      {},
-      {
-        populate: ['campus'],
-        orderBy: { createdAt: 'DESC' },
-      },
-    );
+  async listSemesters(
+    query: ListSemestersQueryDto,
+  ): Promise<SemesterListResponseDto> {
+    const filter: FilterQuery<Semester> = {};
+    if (query.campusId) {
+      filter.campus = query.campusId;
+    }
+
+    const semesters = await this.em.find(Semester, filter, {
+      populate: ['campus'],
+      orderBy: { createdAt: 'DESC' },
+    });
 
     return {
       data: semesters.map((s) => ({

--- a/src/modules/semesters/semesters.service.ts
+++ b/src/modules/semesters/semesters.service.ts
@@ -1,28 +1,34 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { EntityManager } from '@mikro-orm/core';
 import { Semester } from '../../entities/semester.entity';
-import { SemesterShortResponseDto } from '../enrollments/dto/responses/semester-short.response.dto';
+import { SemesterListResponseDto } from './dto/responses/semester-list.response.dto';
 
 @Injectable()
 export class SemestersService {
   constructor(private readonly em: EntityManager) {}
 
-  async getCurrentSemester(): Promise<SemesterShortResponseDto> {
-    const semester = await this.em.findOne(
+  async listSemesters(): Promise<SemesterListResponseDto> {
+    const semesters = await this.em.find(
       Semester,
       {},
-      { orderBy: { createdAt: 'DESC' } },
+      {
+        populate: ['campus'],
+        orderBy: { createdAt: 'DESC' },
+      },
     );
 
-    if (!semester) {
-      throw new NotFoundException('No active semester found');
-    }
-
     return {
-      id: semester.id,
-      code: semester.code,
-      label: semester.label,
-      academicYear: semester.academicYear,
+      data: semesters.map((s) => ({
+        id: s.id,
+        code: s.code,
+        label: s.label,
+        academicYear: s.academicYear,
+        campus: {
+          id: s.campus.id,
+          code: s.campus.code,
+          name: s.campus.name,
+        },
+      })),
     };
   }
 }

--- a/src/modules/semesters/semesters.service.ts
+++ b/src/modules/semesters/semesters.service.ts
@@ -1,0 +1,28 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { EntityManager } from '@mikro-orm/core';
+import { Semester } from '../../entities/semester.entity';
+import { SemesterShortResponseDto } from '../enrollments/dto/responses/semester-short.response.dto';
+
+@Injectable()
+export class SemestersService {
+  constructor(private readonly em: EntityManager) {}
+
+  async getCurrentSemester(): Promise<SemesterShortResponseDto> {
+    const semester = await this.em.findOne(
+      Semester,
+      {},
+      { orderBy: { createdAt: 'DESC' } },
+    );
+
+    if (!semester) {
+      throw new NotFoundException('No active semester found');
+    }
+
+    return {
+      id: semester.id,
+      code: semester.code,
+      label: semester.label,
+      academicYear: semester.academicYear,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
This PR introduces a new semesters module that provides an API endpoint to list semesters with associated campus information. The implementation includes filtering capabilities by campus ID and follows the existing NestJS architecture patterns.

## Key Changes
- **New Semesters Module**: Created `SemestersModule` with controller, service, and DTOs
- **List Semesters Endpoint**: Added `GET /semesters` endpoint with optional campus filtering
- **Service Implementation**: `SemestersService` handles semester retrieval with campus population and sorting by creation date (descending)
- **DTOs**: 
  - `ListSemestersQueryDto` for query parameters (optional `campusId` filter)
  - `SemesterListResponseDto` for list response structure
  - `SemesterItemResponseDto` for individual semester items
  - `CampusShortResponseDto` for campus information in responses
- **JWT Protection**: Endpoint is protected with `@UseJwtGuard()` decorator
- **Comprehensive Tests**: Added full test suite for `SemestersService` covering all scenarios (with/without campus filter, empty results, etc.)
- **Module Registration**: Integrated `SemestersModule` into the main modules index

## Notable Implementation Details
- Uses MikroORM's `EntityManager` for database queries with proper population of campus relations
- Supports optional campus filtering via `campusId` query parameter
- Results are ordered by creation date in descending order
- Includes proper Swagger documentation with `@ApiTags`, `@ApiOperation`, and `@ApiResponse` decorators
- Test coverage includes mocking EntityManager and verifying correct filter queries are constructed

https://claude.ai/code/session_015zAeByh3G1YxLc6cEtniGn