### PR TITLE
FAC-105 feat: report generation infrastructure — faculty evaluation PDF

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -93,3 +93,17 @@ OPENAI_API_KEY=
 # TOPIC_MODEL_CONCURRENCY=1
 # RECOMMENDATIONS_CONCURRENCY=1
 # RECOMMENDATIONS_MODEL=gpt-4o-mini
+
+# ──────────────────────────────────────────────
+# Optional: Report Generation (R2 Storage)
+# App starts without these — report endpoints return 503
+# ──────────────────────────────────────────────
+
+# CF_ACCOUNT_ID=
+# R2_ACCESS_KEY_ID=
+# R2_SECRET_ACCESS_KEY=
+# R2_BUCKET_NAME=faculytics-reports
+# REPORT_GENERATION_CONCURRENCY=2
+# REPORT_PRESIGNED_URL_EXPIRY_SECONDS=3600
+# REPORT_BATCH_MAX_SIZE=100
+# REPORT_RETENTION_DAYS=7

--- a/_bmad-output/implementation-artifacts/tech-spec-report-generation-faculty-pdf.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-report-generation-faculty-pdf.md
@@ -1,0 +1,763 @@
+---
+title: 'Report Generation Infrastructure — Faculty Evaluation PDF'
+slug: 'report-generation-faculty-pdf'
+created: '2026-04-01'
+status: 'completed'
+stepsCompleted: [1, 2, 3, 4]
+tech_stack:
+  [
+    'NestJS',
+    'MikroORM',
+    'PostgreSQL',
+    'BullMQ',
+    'Redis',
+    'Puppeteer',
+    'Handlebars',
+    '@aws-sdk/client-s3',
+    '@aws-sdk/s3-request-presigner',
+    'Zod',
+  ]
+files_to_modify:
+  - 'src/configurations/common/queue-names.ts'
+  - 'src/configurations/env/bullmq.env.ts'
+  - 'src/configurations/env/index.ts'
+  - 'src/modules/index.module.ts'
+  - 'src/modules/analytics/analytics.module.ts'
+  - 'src/entities/index.entity.ts'
+  - '.env.sample'
+files_to_create:
+  - 'src/modules/reports/reports.module.ts'
+  - 'src/modules/reports/reports.controller.ts'
+  - 'src/modules/reports/reports.service.ts'
+  - 'src/modules/reports/processors/report-generation.processor.ts'
+  - 'src/modules/reports/services/pdf.service.ts'
+  - 'src/modules/reports/services/r2-storage.service.ts'
+  - 'src/modules/reports/interfaces/storage-provider.interface.ts'
+  - 'src/modules/reports/templates/faculty-evaluation.hbs'
+  - 'src/modules/reports/templates/report.css'
+  - 'src/modules/reports/dto/generate-report.dto.ts'
+  - 'src/modules/reports/dto/generate-batch-report.dto.ts'
+  - 'src/modules/reports/dto/report-status.response.dto.ts'
+  - 'src/modules/reports/dto/batch-status.response.dto.ts'
+  - 'src/entities/report-job.entity.ts'
+  - 'src/repositories/report-job.repository.ts'
+  - 'src/modules/reports/jobs/report-cleanup.job.ts'
+  - 'src/configurations/env/r2.env.ts'
+  - 'src/configurations/env/report.env.ts'
+code_patterns:
+  [
+    'AuditProcessor (WorkerHost + @Processor)',
+    'ScopeResolverService for auth scoping',
+    'CustomBaseEntity for entities',
+    'Zod env schemas',
+    'PascalCase public methods',
+    'em.fork() for processor DB ops',
+    'CurrentUserService via CLS for user context',
+    '@InjectQueue for job enqueuing',
+  ]
+test_patterns:
+  [
+    'TestingModule with jest.fn() mocks',
+    '.spec.ts alongside source',
+    'mock EntityManager and Queue',
+  ]
+---
+
+# Tech-Spec: Report Generation Infrastructure — Faculty Evaluation PDF
+
+**Created:** 2026-04-01
+
+## Overview
+
+### Problem Statement
+
+Faculty admins, deans, and chairpersons need to export per-faculty evaluation reports as downloadable PDFs matching the institution's official format. Generating these synchronously isn't viable due to Puppeteer rendering time and potential batch sizes across departments/campuses (5 campuses, potentially hundreds of faculty).
+
+### Solution
+
+Async PDF report generation via BullMQ, with Puppeteer + Handlebars rendering existing analytics data into the official evaluation form layout. Reports stored in Cloudflare R2 with time-limited presigned download URLs. Batch support via scope filters delegated to `ScopeResolverService`. One `ReportJob` per faculty, linked by `batchId` for batch requests.
+
+### Scope
+
+**In Scope:**
+
+- Single faculty evaluation PDF generation (`POST /reports/generate`)
+- Batch PDF generation with scope filters — departmentId, programId (`POST /reports/generate/batch`)
+- BullMQ async processing — one `ReportJob` per faculty, linked by `batchId` for batches
+- Cloudflare R2 storage with presigned download URLs (1hr expiry)
+- Puppeteer (persistent browser instance) + Handlebars template matching the official evaluation form
+- `ReportJob` entity with user ownership tracking (`requestedById`)
+- Job status polling endpoints (single + batch)
+- Cleanup cron for expired reports and R2 objects
+- Role-agnostic design — delegates entirely to `ScopeResolverService`
+- Batch size cap as safety valve
+- Thin `StorageProvider` abstraction for testability
+
+**Out of Scope:**
+
+- Excel export (future phase)
+- Department summary rollup report (future phase)
+- New user roles (campus head, VP — separate auth feature)
+- Report scheduling (cron-based)
+- Frontend report viewer (download only)
+- Real-time/streaming report generation
+- Per-course filtered reports (v1 always generates aggregate across all courses for a faculty/semester)
+
+## Context for Development
+
+### Codebase Patterns
+
+**Processor Pattern (follow AuditProcessor):**
+
+- Extend `WorkerHost` from `@nestjs/bullmq`
+- Decorate with `@Processor(QueueName.REPORT_GENERATION, { concurrency: 2 })`
+- Implement `async process(job: Job<ReportJobMessage>)`
+- Use `this.em.fork()` for isolated DB context in each job
+- Handle failures via `@OnWorkerEvent('failed')` decorator
+- Import: `Processor, WorkerHost, OnWorkerEvent` from `@nestjs/bullmq`, `Job` from `bullmq`
+
+**Service Pattern (follow AuditService):**
+
+- Inject queue via `@InjectQueue(QueueName.REPORT_GENERATION) private readonly reportQueue: Queue`
+- Enqueue with `this.reportQueue.add('report', payload, { attempts, removeOnComplete, removeOnFail })`
+- Wrap enqueue in try-catch, log warnings on failure
+
+**Module Pattern (follow AuditModule):**
+
+- Register queue: `BullModule.registerQueue({ name: QueueName.REPORT_GENERATION })`
+- Register entities: `MikroOrmModule.forFeature([ReportJob])`
+- Import `CommonModule` for `ScopeResolverService`
+- Import `AnalyticsModule` for `AnalyticsService` (data source)
+- Export `ReportsService` (not Processor — internal concern)
+
+**Authorization Pattern:**
+
+- Controller: `@UseJwtGuard(UserRole.SUPER_ADMIN, UserRole.DEAN, UserRole.CHAIRPERSON)`
+- Apply `@UseInterceptors(CurrentUserInterceptor)` for CLS user context
+- **CLS flow**: `CurrentUserInterceptor` loads the full User entity into CLS _before_ the service method runs. `ScopeResolverService` reads the user from CLS internally — it does NOT accept a userId parameter. The `userId` passed from the controller to the service is for entity ownership tracking (`requestedBy`), NOT for scope resolution.
+- Access user: `req.user!.userId` from `AuthenticatedRequest` in controller (for passing to service), `CurrentUserService.getOrFail()` in service internals (for scope resolution via CLS)
+- Scope: `ScopeResolverService.ResolveDepartmentIds(semesterId)` returns `null` (unrestricted) or `string[]`
+
+**Data Source (existing AnalyticsService methods):**
+
+- `GetFacultyReport(facultyId, { semesterId, questionnaireTypeCode })` → `FacultyReportResponseDto`
+- `GetFacultyReportComments(facultyId, { semesterId, questionnaireTypeCode, page, limit })` → `FacultyReportCommentsResponseDto`
+- Comments are paginated (max 100 per page) — processor must loop pages or add internal unpaginated method
+- Scope validation (`validateFacultyScope`) runs inside these methods — processor calls must run within a user context or bypass scope validation via a dedicated internal method
+
+**Entity Pattern:**
+
+- Extend `CustomBaseEntity` (UUID pk, timestamps, soft delete)
+- Declare repository: `@Entity({ repository: () => ReportJobRepository })`
+- Repository in `src/repositories/`
+
+**Env Config Pattern:**
+
+- Zod schema per concern in `src/configurations/env/`
+- Merge via spread in `src/configurations/env/index.ts`
+- Access via `import { env } from 'src/configurations/index.config'`
+
+**Cron Job Pattern (follow RefreshTokenCleanupJob):**
+
+- Extend `BaseJob`, call `super(schedulerRegistry, ClassName.name)`
+- Use `@Cron('expression', { name: ClassName.name })` on handler
+- Implement `isRunning` guard against concurrent execution
+- Record results via `StartupJobRegistry.record()`
+- Note: `ReportCleanupJob` lives INSIDE `ReportsModule` (not in `AllCronJobs`) because it needs `STORAGE_PROVIDER` and `ReportJobRepository` from that module's DI context. The `@Cron()` decorator works from any module.
+
+### Files to Reference
+
+| File                                                                          | Purpose                                                                |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `src/modules/audit/audit.processor.ts`                                        | Processor pattern to follow (WorkerHost, concurrency, em.fork)         |
+| `src/modules/audit/audit.service.ts`                                          | Service pattern for @InjectQueue and job enqueuing                     |
+| `src/modules/audit/audit.module.ts`                                           | Module registration pattern (queue, entity, exports)                   |
+| `src/modules/analytics/analytics.service.ts`                                  | Data source — `GetFacultyReport()`, `GetFacultyReportComments()`       |
+| `src/modules/analytics/dto/responses/faculty-report.response.dto.ts`          | Report data structure (sections, questions, averages, interpretations) |
+| `src/modules/analytics/dto/responses/faculty-report-comments.response.dto.ts` | Comments data structure (paginated items + meta)                       |
+| `src/modules/analytics/lib/interpretation.util.ts`                            | Score-to-label interpretation mapping                                  |
+| `src/modules/common/services/scope-resolver.service.ts`                       | Scope resolution by role (returns dept IDs or null)                    |
+| `src/modules/common/cls/current-user.service.ts`                              | CLS-based user context access                                          |
+| `src/modules/common/common.module.ts`                                         | Exports ScopeResolverService, CurrentUserService                       |
+| `src/security/decorators/index.ts`                                            | `UseJwtGuard()` decorator with role params                             |
+| `src/modules/common/interceptors/current-user.interceptor.ts`                 | Loads full User entity into CLS                                        |
+| `src/entities/base.entity.ts`                                                 | CustomBaseEntity (UUID, timestamps, soft delete)                       |
+| `src/configurations/common/queue-names.ts`                                    | QueueName const object — add REPORT_GENERATION                         |
+| `src/configurations/env/bullmq.env.ts`                                        | Zod schema for BullMQ env vars — add report concurrency                |
+| `src/configurations/env/index.ts`                                             | Env schema merge point — add r2.env.ts                                 |
+| `src/crons/jobs/auth-jobs/refresh-token-cleanup.job.ts`                       | Cleanup cron pattern (BaseJob, @Cron, isRunning guard)                 |
+| `src/crons/base.job.ts`                                                       | Abstract base class for cron jobs                                      |
+| `src/crons/index.jobs.ts`                                                     | AllCronJobs registration array                                         |
+| `src/modules/index.module.ts`                                                 | ApplicationModules array — add ReportsModule                           |
+| `src/entities/user.entity.ts`                                                 | User entity — roles, campus/department/program associations            |
+| `src/entities/department.entity.ts`                                           | Department entity — ManyToOne Semester                                 |
+| `src/entities/campus.entity.ts`                                               | Campus entity — OneToMany Semester                                     |
+
+### Technical Decisions
+
+- **Puppeteer over lighter PDF libs**: The official evaluation form requires precise table rendering with cell borders, weighted section headers, and formatted layout. Puppeteer + Handlebars is the pragmatic choice for this form factor.
+- **AuditProcessor pattern over BaseAnalysisProcessor**: PDF rendering happens in-process — no external worker needed. Matches the audit processor's self-contained model.
+- **One ReportJob per faculty with batchId**: Allows individual report downloads as they complete during batch processing. If one faculty report fails, others still succeed. Status endpoint aggregates by batchId.
+- **Scope filters over role-based endpoints**: The batch endpoint accepts optional `departmentId` and `programId` filters. `campusId` was intentionally excluded because `Semester` has a `ManyToOne` to `Campus` — each semester belongs to exactly one campus, so providing `semesterId` already implicitly scopes to a campus. `ScopeResolverService` enforces the ceiling. Future roles (campus head, VP) only require changes to `ScopeResolverService`, not the reports module.
+- **Thin StorageProvider abstraction**: Interface with `Upload(key, buffer, contentType)` and `GetPresignedUrl(key, expiresInSeconds)`. R2 implementation behind it. Testability without leaking SDK types into domain layer.
+- **Persistent Puppeteer browser instance**: Launched in `OnModuleInit`, closed in `OnModuleDestroy`. Avoids per-job browser launch overhead.
+- **Processor scope bypass**: The processor runs in a background worker context without HTTP request/CLS user context. The service layer must resolve faculty list and validate scope _before_ enqueuing. The processor receives pre-validated `facultyId` + query params and calls analytics methods directly (bypassing scope checks, since authorization was already performed at enqueue time).
+- **R2 key convention**: `reports/{reportType}/{semesterId}/{batchId}/{facultyId}.pdf` — enables easy batch cleanup and listing.
+- **No courseId filter in v1**: The `FacultyReportQueryDto` supports optional `courseId`, but the report system deliberately omits it. Faculty evaluation PDFs always show the aggregate across all courses for a given semester — matching the physical form format (one form per faculty per semester). Per-course filtered reports are a future enhancement.
+- **Deduplication at enqueue time**: Before creating a `ReportJob`, check for an existing job with the same `{ facultyId, semesterId, questionnaireTypeCode, reportType }` in `'waiting'` or `'active'` status. Return the existing `jobId` instead of creating a duplicate. A unique partial index enforces this at the DB level for race conditions.
+
+## Implementation Plan
+
+### Tasks
+
+#### Layer 0: Configuration & Environment
+
+- [ ] Task 1: Add R2 environment schema
+  - File: `src/configurations/env/r2.env.ts` (create)
+  - Action: Create Zod schema with **all credentials optional** (follows the pattern of `SENTIMENT_WORKER_URL` etc.):
+    - `CF_ACCOUNT_ID` → `z.string().optional()`
+    - `R2_ACCESS_KEY_ID` → `z.string().optional()`
+    - `R2_SECRET_ACCESS_KEY` → `z.string().optional()`
+    - `R2_BUCKET_NAME` → `z.string().default('faculytics-reports')`
+  - Notes: Making credentials optional ensures local dev, CI, and non-report environments can start without R2 configured. The `R2StorageService` handles the runtime guard (see Task 11).
+  - Reference: `src/configurations/env/redis.env.ts` for pattern
+
+- [ ] Task 2a: Add report processor concurrency to BullMQ schema
+  - File: `src/configurations/env/bullmq.env.ts` (modify)
+  - Action: Add `REPORT_GENERATION_CONCURRENCY` (coerce number, default `2`) — this IS a BullMQ concern (processor concurrency)
+
+- [ ] Task 2b: Create report-specific env schema
+  - File: `src/configurations/env/report.env.ts` (create)
+  - Action: Create Zod schema with domain-specific report config (NOT BullMQ concerns):
+    - `REPORT_PRESIGNED_URL_EXPIRY_SECONDS` (coerce number, default `3600`)
+    - `REPORT_BATCH_MAX_SIZE` (coerce number, default `100`)
+    - `REPORT_RETENTION_DAYS` (coerce number, default `7`)
+  - Notes: Follows the "Zod schema per concern" pattern — these are application-domain config, not BullMQ config.
+
+- [ ] Task 3: Register new env schemas
+  - File: `src/configurations/env/index.ts` (modify)
+  - Action: Import and spread both `r2EnvSchema` and `reportEnvSchema` into the merged schema object
+
+- [ ] Task 4: Add REPORT_GENERATION queue name
+  - File: `src/configurations/common/queue-names.ts` (modify)
+  - Action: Add `REPORT_GENERATION: 'report-generation'` to the `QueueName` object
+
+#### Layer 1: Entity, Repository & Migration
+
+- [ ] Task 5: Create ReportJob entity
+  - File: `src/entities/report-job.entity.ts` (create)
+  - Action: Create entity extending `CustomBaseEntity` with:
+    - `reportType: string` — e.g. `'faculty_evaluation'`
+    - `status: string` — `'waiting' | 'active' | 'completed' | 'failed' | 'skipped'`
+    - `requestedBy: User` — `@ManyToOne(() => User)`, the requesting user
+    - `facultyId: string` — target faculty UUID
+    - `facultyName: string` — snapshot of faculty name at generation time
+    - `semesterId: string` — semester UUID
+    - `questionnaireTypeCode: string` — questionnaire type filter
+    - `batchId?: string` — nullable, links batch jobs together; indexed
+    - `storageKey?: string` — nullable, R2 object key (set on completion)
+    - `error?: string` — nullable, error message (set on failure)
+    - `completedAt?: Date` — nullable, completion timestamp
+  - Notes: Do NOT store `downloadUrl` — generate presigned URLs on-the-fly from `storageKey` at query time. Index on `batchId` and `requestedBy` for efficient queries.
+  - **Critical**: Also add `ReportJob` to the exports and `entities` array in `src/entities/index.entity.ts`. MikroORM discovers entities from this central registry — without it, migrations won't see the entity and all ORM operations will fail. `MikroOrmModule.forFeature([ReportJob])` in the module only scopes injection, it does NOT substitute for global registration.
+  - Reference: `src/entities/base.entity.ts` for base class pattern, `src/entities/index.entity.ts` for registration
+
+- [ ] Task 6: Create ReportJobRepository
+  - File: `src/repositories/report-job.repository.ts` (create)
+  - Action: Create custom repository with:
+    - `FindByJobId(jobId: string)` — find single job by ID
+    - `FindByBatchId(batchId: string)` — find all jobs in a batch
+    - `FindExpiredCompleted(cutoffDate: Date)` — find completed jobs older than cutoff (for cleanup)
+    - `FindByRequestedBy(userId: string)` — find all jobs by requesting user
+  - Reference: existing repository files in `src/repositories/`
+
+- [ ] Task 7: Create migration for report_job table
+  - Action: Run `npx mikro-orm migration:create` to generate migration, then populate with:
+    - `report_job` table with all columns from entity
+    - Index on `batch_id` (partial: `WHERE batch_id IS NOT NULL`)
+    - Index on `requested_by_id`
+    - Index on `status`
+    - Index on `(status, completed_at)` for cleanup queries
+    - **Unique partial index for dedup**: `CREATE UNIQUE INDEX uq_report_job_pending ON report_job (faculty_id, semester_id, questionnaire_type_code, report_type) WHERE status IN ('waiting', 'active')` — prevents duplicate pending/active jobs for the same faculty+semester+type combination at the DB level
+
+#### Layer 2: DTOs
+
+- [ ] Task 8: Create request DTOs
+  - File: `src/modules/reports/dto/generate-report.dto.ts` (create)
+  - Action: Create `GenerateReportDto` with:
+    - `facultyId: string` — `@IsUUID()`
+    - `semesterId: string` — `@IsUUID()`
+    - `questionnaireTypeCode: string` — `@IsString() @IsNotEmpty()`
+  - File: `src/modules/reports/dto/generate-batch-report.dto.ts` (create)
+  - Action: Create `GenerateBatchReportDto` with:
+    - `semesterId: string` — `@IsUUID()`
+    - `questionnaireTypeCode: string` — `@IsString() @IsNotEmpty()`
+    - `departmentId?: string` — `@IsUUID() @IsOptional()`
+    - `programId?: string` — `@IsUUID() @IsOptional()`
+  - Notes: `campusId` intentionally excluded — `Semester` belongs to exactly one `Campus`, so `semesterId` already implicitly scopes to a campus.
+
+- [ ] Task 9: Create response DTOs
+  - File: `src/modules/reports/dto/report-status.response.dto.ts` (create)
+  - Action: Create `ReportStatusResponseDto` with:
+    - `jobId: string`
+    - `status: 'waiting' | 'active' | 'completed' | 'failed' | 'skipped'`
+    - `facultyName: string`
+    - `downloadUrl?: string` — present only when `status === 'completed'`
+    - `expiresAt?: string` — ISO timestamp of URL expiry
+    - `error?: string` — present only when `status === 'failed'`
+    - `message?: string` — present when `status === 'skipped'` (e.g., "No evaluation data found")
+    - `createdAt: string`
+    - `completedAt?: string`
+  - File: `src/modules/reports/dto/batch-status.response.dto.ts` (create)
+  - Action: Create `BatchStatusResponseDto` with:
+    - `batchId: string`
+    - `total: number`
+    - `completed: number`
+    - `failed: number`
+    - `skipped: number`
+    - `active: number`
+    - `waiting: number`
+    - `jobs: ReportStatusResponseDto[]` — paginated subset of jobs for current page
+    - `meta: { totalItems, itemCount, itemsPerPage, totalPages, currentPage }` — pagination metadata (same structure as `FacultyReportCommentsResponseDto.meta`)
+
+#### Layer 3: Interfaces
+
+- [ ] Task 10: Create StorageProvider interface
+  - File: `src/modules/reports/interfaces/storage-provider.interface.ts` (create)
+  - Action: Define interface:
+    ```typescript
+    export interface StorageProvider {
+      Upload(key: string, buffer: Buffer, contentType: string): Promise<void>;
+      GetPresignedUrl(key: string, expiresInSeconds: number): Promise<string>;
+      Delete(key: string): Promise<void>;
+      DeleteByPrefix(prefix: string): Promise<void>;
+    }
+    ```
+  - Notes: `DeleteByPrefix` is needed for batch cleanup (delete all objects under `reports/{type}/{semesterId}/{batchId}/`). Use injection token `STORAGE_PROVIDER` for DI.
+
+#### Layer 4: Services (independent — no inter-service deps)
+
+- [ ] Task 11: Create R2StorageService
+  - File: `src/modules/reports/services/r2-storage.service.ts` (create)
+  - Action: Implement `StorageProvider` interface using `@aws-sdk/client-s3` and `@aws-sdk/s3-request-presigner`:
+    - **Constructor**: Check if `env.CF_ACCOUNT_ID`, `env.R2_ACCESS_KEY_ID`, and `env.R2_SECRET_ACCESS_KEY` are all present. If any are missing, set `this.isConfigured = false` and log a warning: `'R2 storage not configured — report generation will be unavailable'`. If all present, initialize `S3Client` with R2 endpoint, region `'auto'`, and credentials.
+    - **Runtime guard**: All methods (`Upload`, `GetPresignedUrl`, `Delete`, `DeleteByPrefix`) must check `this.isConfigured` first and throw `ServiceUnavailableException('R2 storage is not configured')` if false. This allows the application to start without R2 credentials while failing gracefully at report generation time.
+    - `Upload()`: Use `PutObjectCommand` with `Body: buffer`, `ContentType`, `Key`
+    - `GetPresignedUrl()`: Use `GetObjectCommand` + `getSignedUrl()` from presigner
+    - `Delete()`: Use `DeleteObjectCommand`
+    - `DeleteByPrefix()`: Use `ListObjectsV2Command` in a **paginated loop** (`do...while` on `IsTruncated`, passing `ContinuationToken` from each response) to handle prefixes with >1000 objects. Collect all keys, then batch delete via `DeleteObjectsCommand` (max 1000 keys per call — batch if needed).
+  - Notes: Inject `STORAGE_PROVIDER` token. Register as provider in module with `{ provide: STORAGE_PROVIDER, useClass: R2StorageService }`
+
+- [ ] Task 12: Create PdfService
+  - File: `src/modules/reports/services/pdf.service.ts` (create)
+  - Action: Implement PDF generation with Puppeteer + Handlebars:
+    - `OnModuleInit`: Launch persistent Puppeteer browser with `--no-sandbox`, `--disable-setuid-sandbox`
+    - `OnModuleDestroy`: Close browser instance
+    - `GenerateFacultyEvaluationPdf(data: FacultyReportResponseDto, comments: ReportCommentDto[]): Promise<Buffer>`:
+      1. Read and compile Handlebars template from `templates/faculty-evaluation.hbs`
+      2. Read CSS from `templates/report.css`
+      3. Render HTML with data context (sections, questions, averages, interpretations, comments)
+      4. Create new browser page, set HTML content
+      5. Generate PDF with options: `format: 'A4'`, `printBackground: true`, margins `20mm top/bottom`, `15mm left/right`
+      6. Close page, return PDF buffer
+    - Cache compiled Handlebars template (compile once on first call)
+    - **Browser crash recovery**: Wrap `browser.newPage()` in a try-catch. On failure (Chromium OOM, zombie process, stale ref), attempt to relaunch the browser (`this.browser = await puppeteer.launch(...)`) and retry page creation once. Log the recovery event. If relaunch also fails, throw — the job fails and BullMQ retries it per configured attempts.
+    - **Page-level cleanup**: All page operations (`setContent`, `pdf`) must be wrapped in `try/finally` to ensure `page.close()` is always called, even on partial failure. This prevents page leaks when `page.pdf()` throws or hangs.
+  - Notes: Template context shape matches `FacultyReportResponseDto` + flat comments array. Template will render the exact layout from the reference images.
+
+- [ ] Task 13: Refactor AnalyticsService for shared logic + add unscoped methods, and export it
+  - File: `src/modules/analytics/analytics.service.ts` (modify)
+  - Action: **Refactor to avoid duplicating the ~234-line `GetFacultyReport()` method:**
+    1. Extract the core logic (version resolution, SQL aggregation, schema flattening, weighted calculation, interpretation mapping) into a private method:
+       `private async BuildFacultyReportData(facultyId: string, versionIds: string[], canonicalSchema: QuestionnaireSchemaSnapshot, query: FacultyReportQueryDto): Promise<FacultyReportResponseDto>`
+    2. Refactor `GetFacultyReport()` to: call `validateFacultyScope()` → `resolveVersionIds()` → `BuildFacultyReportData()`
+    3. Add `GetFacultyReportUnscoped(facultyId: string, query: FacultyReportQueryDto): Promise<FacultyReportResponseDto>` — calls `resolveVersionIds()` → `BuildFacultyReportData()` directly (skips scope validation). Thin wrapper, no duplication.
+    4. Extract comment query logic into a shared private method. Add `GetAllFacultyReportComments(facultyId: string, query: BaseFacultyReportQueryDto): Promise<ReportCommentDto[]>` — returns ALL comments (no pagination). Same SQL but without LIMIT/OFFSET.
+  - File: `src/modules/analytics/analytics.module.ts` (modify)
+  - Action: **Add `exports: [AnalyticsService]` to the module decorator.** The module currently has NO exports array — this is a blocking requirement for `ReportsModule` to inject `AnalyticsService`. Do NOT assume it already exists; it does not.
+  - Notes: Unscoped methods are ONLY for use by the report processor, where authorization was already performed at enqueue time. Document with JSDoc: `/** @internal Called by report processor only — scope validation was performed at enqueue time. Do NOT expose via HTTP. */`. The unscoped methods are protected by convention (JSDoc `@internal`), not by runtime enforcement. Since `AnalyticsService` is now exported, any module can technically call them. **Code review must verify these are never called from HTTP-facing code.**
+
+#### Layer 5: Processor
+
+- [ ] Task 14: Create ReportGenerationProcessor
+  - File: `src/modules/reports/processors/report-generation.processor.ts` (create)
+  - Action: Implement BullMQ processor following AuditProcessor pattern:
+    - `@Processor(QueueName.REPORT_GENERATION, { concurrency: env.REPORT_GENERATION_CONCURRENCY })`
+    - Extends `WorkerHost`
+    - Inject: `EntityManager`, `AnalyticsService`, `PdfService`, `@Inject(STORAGE_PROVIDER) StorageProvider`
+    - `process(job: Job<ReportJobMessage>)`:
+      1. Extract `{ reportJobId, facultyId, semesterId, questionnaireTypeCode }` from `job.data`
+      2. Fork EntityManager: `const fork = this.em.fork()`
+      3. Load `ReportJob` entity by `reportJobId`, set `status = 'active'`, flush
+      4. Call `AnalyticsService.GetFacultyReportUnscoped(facultyId, { semesterId, questionnaireTypeCode })`
+      5. **Zero-submissions check**: If `reportData.submissionCount === 0`, skip PDF generation. Set `status = 'skipped'`, `storageKey = null`, `completedAt = new Date()`, flush, and return early. No PDF is generated or uploaded. The `'skipped'` status is semantically distinct from `'completed'` — it signals that the job ran but had no data to render.
+      6. Call `AnalyticsService.GetAllFacultyReportComments(facultyId, { semesterId, questionnaireTypeCode })`
+      7. Call `PdfService.GenerateFacultyEvaluationPdf(reportData, comments)`
+      8. Build storage key: `reports/faculty_evaluation/${semesterId}/${reportJob.batchId ?? reportJob.id}/${facultyId}.pdf`
+      9. Call `StorageProvider.Upload(key, pdfBuffer, 'application/pdf')`
+      10. Update `ReportJob`: `status = 'completed'`, `storageKey = key`, `completedAt = new Date()`, flush
+    - `@OnWorkerEvent('failed')`: Load `ReportJob`, set `status = 'failed'`, `error = failedReason`, flush
+  - Notes:
+    - `ReportJobMessage` type: `{ reportJobId: string; facultyId: string; semesterId: string; questionnaireTypeCode: string }`
+    - **courseId must never be passed**: Construct the query DTO with only `semesterId` and `questionnaireTypeCode`. The unscoped method inherits the optional `courseId` field from `FacultyReportQueryDto`, but it must always be `undefined` for report generation. v1 always generates the aggregate across all courses.
+
+#### Layer 6: Service (orchestration)
+
+- [ ] Task 15: Create ReportsService
+  - File: `src/modules/reports/reports.service.ts` (create)
+  - Action: Implement report orchestration service:
+    - Inject: `@InjectQueue(QueueName.REPORT_GENERATION) Queue`, `ReportJobRepository`, `EntityManager`, `ScopeResolverService`, `@Inject(STORAGE_PROVIDER) StorageProvider`
+    - `GenerateSingle(dto: GenerateReportDto, userId: string): Promise<{ jobId: string }>`:
+      1. **Semester validation**: Query `SELECT id FROM semester WHERE id = $1 AND deleted_at IS NULL`. If not found, throw `NotFoundException('Semester not found')`.
+      2. **Dedup check**: Query for existing `ReportJob` with same `{ facultyId, semesterId, questionnaireTypeCode, reportType }` in `'waiting'` or `'active'` status. If found, return existing `{ jobId }` immediately — no duplicate.
+      3. Validate faculty is in user's scope via `ScopeResolverService.ResolveDepartmentIds(dto.semesterId)` + department check query
+      4. Resolve faculty name via user query
+      5. Create `ReportJob` entity (`status: 'waiting'`, no `batchId`)
+      6. Persist entity (wrap in try-catch for `UniqueConstraintViolationException` from the partial unique index — race condition guard; on conflict, re-query and return existing jobId)
+      7. **Enqueue with orphan protection**: Enqueue BullMQ job with `{ reportJobId, facultyId, semesterId, questionnaireTypeCode }`. Wrap in try-catch — if enqueue fails (Redis down), delete the just-created `ReportJob` entity via `em.nativeDelete()` before re-throwing. This prevents orphaned `'waiting'` jobs that would block dedup forever.
+      8. Return `{ jobId: reportJob.id }`
+    - `GenerateBatch(dto: GenerateBatchReportDto, userId: string): Promise<{ batchId: string; jobCount: number; skippedCount: number }>`:
+      1. **Semester validation**: Query `SELECT id FROM semester WHERE id = $1 AND deleted_at IS NULL`. If not found, throw `NotFoundException('Semester not found')`.
+      2. Resolve allowed department IDs via `ScopeResolverService.ResolveDepartmentIds(dto.semesterId)`
+      3. **Translate department IDs to codes**: If `deptIds` is not null (non-super-admin), query `SELECT DISTINCT code FROM department WHERE id = ANY($1) AND deleted_at IS NULL` to get department codes. If `deptIds` is null (super admin), set `departmentCodes = null` (no department filter). This translation is necessary because `questionnaire_submission.department_code_snapshot` stores codes (e.g. `'CCS'`), not UUIDs.
+      4. **Apply scope filters**:
+         - If `departmentId` provided: resolve to department code, intersect with allowed department codes
+         - If `programId` provided: resolve to program code via `SELECT code FROM program WHERE id = $1 AND deleted_at IS NULL`. This code will be used as an additional filter on `program_code_snapshot` in the faculty query.
+      5. **Resolve faculty via `questionnaire_submission`** — use semester-scoped submission data to find faculty with actual evaluation data. Uses `department_code_snapshot` (not the `department` FK) for historical accuracy — the snapshot preserves the department mapping at submission time:
+         ```sql
+         SELECT DISTINCT qs.faculty_id, u.first_name, u.last_name
+         FROM questionnaire_submission qs
+         JOIN "user" u ON u.id = qs.faculty_id
+         WHERE qs.semester_id = $1
+           AND ($2 IS NULL OR qs.department_code_snapshot = ANY($2))
+           AND ($3 IS NULL OR qs.program_code_snapshot = $3)
+           AND qs.deleted_at IS NULL
+           AND u.deleted_at IS NULL
+         ```
+
+         - `$2`: department codes (null for super admin = unrestricted)
+         - `$3`: program code (null if no `programId` filter provided)
+           This bypasses the problematic `User.department` FK (nullable, not semester-scoped) and only returns faculty who have evaluation data.
+      6. Enforce `env.REPORT_BATCH_MAX_SIZE` cap — throw `BadRequestException` if exceeded
+      7. **Dedup check per faculty**: For each resolved faculty, check for existing pending/active `ReportJob`. Skip already-queued faculty.
+      8. Generate `batchId` (UUID)
+      9. Create N `ReportJob` entities (only for non-skipped faculty) with that `batchId`
+      10. Persist all entities
+      11. **Enqueue with tracked orphan protection**: Enqueue jobs sequentially, maintaining an `enqueuedJobIds: Set<string>` tracking which jobs were successfully enqueued. On failure mid-batch, delete only `ReportJob` entities where `id NOT IN enqueuedJobIds` via `em.nativeDelete()`. Already-enqueued jobs continue processing normally. Log the partial failure.
+      12. Return `{ batchId, jobCount: enqueuedJobIds.size, skippedCount }`
+    - `GetJobStatus(jobId: string, userId: string): Promise<ReportStatusResponseDto>`:
+      1. Find `ReportJob` by ID, verify `requestedBy.id === userId` (or user is SUPER_ADMIN)
+      2. If `status === 'completed'` and `storageKey` exists, generate fresh presigned URL via `StorageProvider.GetPresignedUrl()`
+      3. Map to `ReportStatusResponseDto`
+    - `GetBatchStatus(batchId: string, userId: string, page?: number, limit?: number): Promise<BatchStatusResponseDto>`:
+      1. Find all `ReportJob` entities by `batchId`. Verify ownership by checking the first job's `requestedBy.id === userId` (or user is SUPER_ADMIN). All jobs in a batch are created by the same user in a single request, so checking the first is sufficient. If no jobs found or ownership fails, return 404.
+      2. Aggregate counts (total, completed, failed, skipped, active, waiting) — this is always computed over the full batch
+      3. **Paginate the jobs list**: Apply `page` (default 1) and `limit` (default 20, max 50) to the per-job detail array
+      4. Generate presigned URLs for completed jobs **in the current page only** via `Promise.all()` for concurrency
+      5. Map to `BatchStatusResponseDto` with pagination meta
+
+#### Layer 7: Controller
+
+- [ ] Task 16: Create ReportsController
+  - File: `src/modules/reports/reports.controller.ts` (create)
+  - Action: Implement HTTP endpoints:
+    - `@Controller('reports')`
+    - `@ApiTags('Reports')`
+    - `@UseJwtGuard(UserRole.SUPER_ADMIN, UserRole.DEAN, UserRole.CHAIRPERSON)`
+    - `@UseInterceptors(CurrentUserInterceptor)`
+    - `POST /reports/generate` → `GenerateReport(@Body() dto, @Req() req)` → calls `ReportsService.GenerateSingle()`, returns 202
+    - `POST /reports/generate/batch` → `GenerateBatchReport(@Body() dto, @Req() req)` → calls `ReportsService.GenerateBatch()`, returns 202. Apply `@Throttle({ default: { limit: 3, ttl: 60000 } })` — max 3 batch requests per minute per user to prevent queue flooding.
+    - `GET /reports/status/:jobId` → `GetReportStatus(@Param('jobId') jobId, @Req() req)` → calls `ReportsService.GetJobStatus()`
+    - `GET /reports/batch/:batchId` → `GetBatchStatus(@Param('batchId') batchId, @Query() query, @Req() req)` → calls `ReportsService.GetBatchStatus()` with pagination params (`page`, `limit`)
+  - Notes: Use `@HttpCode(HttpStatus.ACCEPTED)` on POST endpoints. Apply `@ApiOperation()` summaries.
+
+#### Layer 8: Module & Registration
+
+- [ ] Task 17: Create ReportsModule
+  - File: `src/modules/reports/reports.module.ts` (create)
+  - Action: Wire all components:
+    ```
+    imports: [
+      BullModule.registerQueue({ name: QueueName.REPORT_GENERATION }),
+      MikroOrmModule.forFeature([ReportJob]),
+      CommonModule,
+      AnalyticsModule,
+      DataLoaderModule,  // Required for CurrentUserInterceptor → UserLoader DI
+    ]
+    providers: [
+      ReportsService,
+      ReportGenerationProcessor,
+      PdfService,
+      { provide: STORAGE_PROVIDER, useClass: R2StorageService },
+      ReportCleanupJob,  // lives here — has access to STORAGE_PROVIDER and ReportJobRepository
+    ]
+    controllers: [ReportsController]
+    exports: [ReportsService]
+    ```
+  - Notes: `ReportCleanupJob` is registered inside this module (NOT in `AllCronJobs`) because it needs `STORAGE_PROVIDER` and `ReportJobRepository` from this module's DI context. The `@Cron()` decorator works from any NestJS module — it does not need to live in `AppModule`.
+
+- [ ] Task 18: Register module in application
+  - File: `src/modules/index.module.ts` (modify)
+  - Action: Import `ReportsModule` and add to `ApplicationModules` array
+
+#### Layer 9: Handlebars Template & CSS
+
+- [ ] Task 19: Create faculty evaluation PDF template
+  - File: `src/modules/reports/templates/faculty-evaluation.hbs` (create)
+  - Action: Create Handlebars template matching the official evaluation report layout:
+    - Header: "FACULTY EVALUATION REPORT" (left), semester code + academic year (right), "CONFIDENTIAL" banner
+    - Teacher name row
+    - For each section: `{{#each sections}}` — table with header row showing section title + weight, question rows (text | average | interpretation), footer row with section average + interpretation
+    - Overall rating row at bottom
+    - Comments section: `{{#each comments}}` — bullet list of comment text
+    - All CSS inlined via `<style>` tag (read from report.css)
+  - **Security**: All user-supplied data (faculty name, comment text, question text) MUST use double-stache `{{var}}` for automatic HTML escaping. **Never use triple-stache `{{{var}}}`** in this template — Puppeteer runs with `--no-sandbox` in Docker, so unescaped HTML injection could be exploited.
+  - File: `src/modules/reports/templates/report.css` (create)
+  - Action: Styles matching the reference images:
+    - Black bordered tables, bold headers
+    - Font: sans-serif, 10-11pt for table content
+    - `page-break-inside: avoid` on section tables
+    - Print-friendly: no background colors except header bar
+    - A4 page layout
+
+#### Layer 10: Cleanup Cron Job
+
+- [ ] Task 20: Create ReportCleanupJob
+  - File: `src/modules/reports/jobs/report-cleanup.job.ts` (create)
+  - Action: Implement cleanup cron following `RefreshTokenCleanupJob` pattern:
+    - Extend `BaseJob`
+    - `@Cron('0 3 * * *', { name: 'ReportCleanupJob' })` — run daily at 3 AM
+    - `isRunning` guard
+    - Inject: `ReportJobRepository`, `@Inject(STORAGE_PROVIDER) StorageProvider`, `SchedulerRegistry`
+    - Logic:
+      1. **Expired completed jobs**: Find completed `ReportJob` entities older than `env.REPORT_RETENTION_DAYS`
+      2. For each with a `storageKey`, delete R2 object via `StorageProvider.Delete(storageKey)`
+      3. Hard-delete via `em.nativeDelete(ReportJob, { id: { $in: expiredIds } })` — preferred over `em.removeAndFlush()` because it bypasses the ORM identity map and issues a direct `DELETE FROM` statement, avoiding unnecessary entity hydration for bulk cleanup operations. This is intentional — report jobs are ephemeral operational records with a fixed TTL, not auditable domain entities.
+      4. **Orphaned waiting jobs**: Find `ReportJob` entities in `'waiting'` status with `createdAt` older than 1 hour. These are jobs where the BullMQ enqueue failed after entity persist (e.g., Redis was down). Delete them via `nativeDelete` — no R2 cleanup needed since they never generated a PDF.
+      5. Log summary: `Cleaned up N expired + M orphaned report jobs`
+    - `runStartupTask()`: Return `{ status: 'skipped', details: 'Cleanup runs on schedule only' }`
+  - Notes: This job lives inside `ReportsModule` (registered in Task 17's providers), NOT in `AllCronJobs`. This solves the DI problem — it has full access to `STORAGE_PROVIDER` and `ReportJobRepository` from the module context.
+
+#### Layer 11: Install Dependencies & Housekeeping
+
+- [ ] Task 21: Install npm packages
+  - Action: `npm install puppeteer handlebars @aws-sdk/client-s3 @aws-sdk/s3-request-presigner`
+  - Notes: Verify `puppeteer` pulls Chromium automatically. For Docker, may need to switch to `puppeteer-core` + system Chromium.
+
+- [ ] Task 22: Update `.env.sample` with new environment variables
+  - File: `.env.sample` (modify)
+  - Action: Add all new env vars with descriptions:
+    ```
+    # Report Generation (R2 Storage) — optional, reports unavailable without these
+    CF_ACCOUNT_ID=
+    R2_ACCESS_KEY_ID=
+    R2_SECRET_ACCESS_KEY=
+    R2_BUCKET_NAME=faculytics-reports
+    REPORT_GENERATION_CONCURRENCY=2
+    REPORT_PRESIGNED_URL_EXPIRY_SECONDS=3600
+    REPORT_BATCH_MAX_SIZE=100
+    REPORT_RETENTION_DAYS=7
+    ```
+  - Notes: Comment header should clarify that R2 credentials are optional — the app starts without them, but report generation endpoints will return 503.
+
+### Acceptance Criteria
+
+#### Single Report Generation
+
+- [ ] AC 1: Given an authenticated Dean, when they POST `/reports/generate` with a valid `facultyId` in their department scope, `semesterId`, and `questionnaireTypeCode`, then a 202 response is returned with `{ jobId }` and a `ReportJob` entity is created with `status: 'waiting'`.
+
+- [ ] AC 2: Given a queued report job, when the BullMQ processor picks it up, then it sets `status: 'active'`, fetches report data from `AnalyticsService`, generates a PDF via Puppeteer, uploads to R2, and sets `status: 'completed'` with `storageKey` populated.
+
+- [ ] AC 3: Given a completed report job, when the user GETs `/reports/status/:jobId`, then the response includes `status: 'completed'`, a fresh presigned `downloadUrl`, and `expiresAt` timestamp.
+
+- [ ] AC 4: Given a Dean requesting a report for a faculty member outside their department scope, when they POST `/reports/generate`, then a 403 Forbidden response is returned.
+
+- [ ] AC 5: Given a Chairperson, when they POST `/reports/generate` for a faculty in their program's department, then the report is generated successfully (scope resolves through program → department).
+
+#### Batch Report Generation
+
+- [ ] AC 6: Given an authenticated Dean, when they POST `/reports/generate/batch` with `semesterId` and `questionnaireTypeCode`, then N `ReportJob` entities are created (one per faculty in their department scope), linked by `batchId`, and a 202 response returns `{ batchId, jobCount }`.
+
+- [ ] AC 7: Given a Super Admin, when they POST `/reports/generate/batch` with a `departmentId` filter, then only faculty with evaluation data in that specific department are included (scope filter narrows the unrestricted super admin scope).
+
+- [ ] AC 8: Given a batch request exceeding `REPORT_BATCH_MAX_SIZE`, when the service resolves the faculty list, then a 400 Bad Request is returned with a descriptive error.
+
+- [ ] AC 9: Given an in-progress batch, when the user GETs `/reports/batch/:batchId`, then the response includes aggregated progress (`total`, `completed`, `failed`, `skipped`, `active`, `waiting`) and per-job status with download URLs for completed jobs.
+
+- [ ] AC 10: Given a batch where one faculty report fails, when the user checks batch status, then the failed job shows `status: 'failed'` with an `error` message, while other jobs complete independently.
+
+- [ ] AC 11: Given a batch request with `programId` filter, when the service resolves faculty, then only faculty with evaluation data matching that specific `program_code_snapshot` are included — not all faculty in the parent department.
+
+#### PDF Output
+
+- [ ] AC 12: Given valid report data, when the PdfService generates a PDF, then the output matches the official evaluation form layout: header with semester/confidential banner, teacher name, 5 weighted sections with per-question averages and interpretations, section averages, overall rating, and comments section.
+
+- [ ] AC 13: Given a faculty member with no qualitative comments, when the PDF is generated, then the comments section renders as empty or with "No comments submitted" (does not error).
+
+#### Storage & Presigned URLs
+
+- [ ] AC 14: Given a generated PDF buffer, when the R2StorageService uploads it, then the object is stored at key `reports/faculty_evaluation/{semesterId}/{batchId|jobId}/{facultyId}.pdf` and is retrievable via presigned URL.
+
+- [ ] AC 15: Given a presigned URL, when it is accessed after `REPORT_PRESIGNED_URL_EXPIRY_SECONDS`, then R2 returns a 403/expired error.
+
+- [ ] AC 16: Given a completed job, when the status endpoint is polled multiple times, then a fresh presigned URL is generated each time (not a stale cached URL).
+
+#### Cleanup
+
+- [ ] AC 17: Given completed report jobs older than `REPORT_RETENTION_DAYS`, when the cleanup cron runs, then the corresponding R2 objects are deleted and the `ReportJob` entities are hard-deleted.
+
+- [ ] AC 18: Given the cleanup cron is already running, when the cron trigger fires again, then the second execution is skipped (no concurrent runs).
+
+#### Zero Submissions & Edge Cases
+
+- [ ] AC 19: Given a faculty member with zero submissions for the requested semester/type, when the processor runs, then the job is set to `status: 'skipped'` with `storageKey: null` — no PDF is generated or uploaded. The `'skipped'` status is semantically distinct from `'completed'`.
+
+- [ ] AC 20: Given an invalid `semesterId` (valid UUID but no matching record), when `GenerateSingle` or `GenerateBatch` is called, then a 404 Not Found is returned.
+
+#### Failure Modes
+
+- [ ] AC 21: Given R2 credentials are not configured (`isConfigured = false`), when a user POSTs `/reports/generate`, then a 503 Service Unavailable is returned with message `'R2 storage is not configured'`.
+
+- [ ] AC 22: Given Redis is down during enqueue, when `GenerateSingle` fails to add the BullMQ job, then the just-created `ReportJob` entity is deleted via `nativeDelete` (no orphaned waiting job) and an appropriate error is returned.
+
+- [ ] AC 23: Given a `ReportJob` in `'waiting'` status for more than 1 hour, when the cleanup cron runs, then the orphaned job is hard-deleted (it had no corresponding BullMQ job).
+
+#### Deduplication
+
+- [ ] AC 24: Given a pending report job for faculty X in semester Y, when a new request is submitted for the same faculty/semester/questionnaireTypeCode, then the existing `jobId` is returned with no duplicate job created.
+
+- [ ] AC 25: Given two concurrent requests for the same faculty/semester/type (race condition), when both try to insert, then the unique partial index prevents the duplicate and the service handles the `UniqueConstraintViolationException` gracefully by returning the existing job.
+
+- [ ] AC 26: Given a batch request where 5 of 20 faculty already have pending jobs, when the batch is processed, then 15 new jobs are created and the response includes `{ jobCount: 15, skippedCount: 5 }`.
+
+#### Batch Pagination
+
+- [ ] AC 27: Given a batch with 100 jobs, when `GET /reports/batch/:batchId?page=1&limit=20` is called, then the response includes all aggregate counts (total=100, completed, etc.) but only 20 job details in the `jobs` array, with a `meta` pagination object.
+
+#### Authorization & Scope
+
+- [ ] AC 28: Given a user with no SUPER_ADMIN, DEAN, or CHAIRPERSON role, when they access any `/reports` endpoint, then a 403 Forbidden is returned.
+
+- [ ] AC 29: Given a user polling status for a job they did not request (and they are not SUPER_ADMIN), when they GET `/reports/status/:jobId`, then a 404 is returned (do not reveal job existence).
+
+## Additional Context
+
+### Dependencies
+
+**New npm packages:**
+
+- `puppeteer` — Headless Chrome for PDF rendering
+- `handlebars` — Template engine for HTML report generation
+- `@aws-sdk/client-s3` — S3-compatible client for Cloudflare R2
+- `@aws-sdk/s3-request-presigner` — Presigned URL generation for R2
+
+**Existing (already in project):**
+
+- `bullmq` / `@nestjs/bullmq` — Job queue infrastructure
+- `@mikro-orm/core` / `@mikro-orm/postgresql` — ORM and entity management
+- `zod` — Environment variable validation
+- `@nestjs/schedule` — Cron job scheduling (for cleanup job)
+
+**New environment variables:**
+
+- `CF_ACCOUNT_ID` — Cloudflare account ID (**optional** — app starts without it)
+- `R2_ACCESS_KEY_ID` — R2 access key (**optional**)
+- `R2_SECRET_ACCESS_KEY` — R2 secret key (**optional**)
+- `R2_BUCKET_NAME` — R2 bucket name (default: `faculytics-reports`)
+- `REPORT_GENERATION_CONCURRENCY` — Processor concurrency (default: `2`)
+- `REPORT_PRESIGNED_URL_EXPIRY_SECONDS` — Presigned URL lifetime (default: `3600`)
+- `REPORT_BATCH_MAX_SIZE` — Maximum faculty count per batch request (default: `100`)
+- `REPORT_RETENTION_DAYS` — Days before cleanup cron purges completed reports (default: `7`)
+
+**Docker considerations:**
+
+- Puppeteer requires Chromium system dependencies
+- Use `ghcr.io/puppeteer/puppeteer` as base image or install Chromium deps
+- Launch args: `--no-sandbox`, `--disable-setuid-sandbox` (required in containerized environments)
+- **Note**: Dockerfile creation/modification is a separate infrastructure task, not included in this spec. When deploying, ensure the API image includes Chromium dependencies before enabling report generation.
+
+### Testing Strategy
+
+**Unit Tests:**
+
+- `reports.service.spec.ts`:
+  - Mock `Queue`, `ReportJobRepository`, `ScopeResolverService`, `EntityManager`
+  - Test `GenerateSingle()` creates entity, enqueues job, validates scope
+  - Test `GenerateSingle()` throws 403 when faculty is out of scope
+  - Test `GenerateSingle()` returns existing jobId when duplicate pending job exists (dedup)
+  - Test `GenerateSingle()` deletes entity on BullMQ enqueue failure (orphan protection)
+  - Test `GenerateBatch()` translates department IDs to codes before querying submissions
+  - Test `GenerateBatch()` resolves faculty via questionnaire_submission, respects scope filters, enforces batch size cap
+  - Test `GenerateBatch()` skips already-queued faculty and returns correct `skippedCount`
+  - Test `GenerateBatch()` throws 400 when exceeding max batch size
+  - Test `GetJobStatus()` generates fresh presigned URL for completed jobs
+  - Test `GetJobStatus()` returns 404 for jobs not owned by requesting user
+  - Test `GetBatchStatus()` aggregates counts correctly
+
+- `report-generation.processor.spec.ts`:
+  - Mock `EntityManager`, `AnalyticsService`, `PdfService`, `StorageProvider`
+  - Test `process()` happy path: fetches data → generates PDF → uploads → updates entity
+  - Test `process()` skips PDF generation when submissionCount === 0 (sets status completed, storageKey null)
+  - Test `process()` updates entity to `'failed'` on error
+  - Test `@OnWorkerEvent('failed')` handler updates entity status
+
+- `pdf.service.spec.ts`:
+  - Mock Puppeteer browser/page (use `jest.fn()` for `newPage`, `setContent`, `pdf`, `close`)
+  - Test `GenerateFacultyEvaluationPdf()` returns a Buffer
+  - Test template rendering with sections, questions, comments
+  - Test with empty comments array (no error)
+
+- `r2-storage.service.spec.ts`:
+  - Mock `S3Client.send()`
+  - Test `Upload()` sends `PutObjectCommand` with correct params
+  - Test `GetPresignedUrl()` calls presigner with correct expiry
+  - Test `Delete()` sends `DeleteObjectCommand`
+  - Test `DeleteByPrefix()` lists then batch-deletes (with pagination loop)
+  - Test `isConfigured = false` guard throws `ServiceUnavailableException`
+
+- `report-cleanup.job.spec.ts`:
+  - Mock `ReportJobRepository`, `StorageProvider`
+  - Test cleanup finds expired completed jobs, deletes R2 objects, hard-deletes via nativeDelete
+  - Test cleanup finds orphaned waiting jobs (>1hr), hard-deletes them
+  - Test `isRunning` guard prevents concurrent execution
+
+**Integration Tests (E2E):**
+
+- Test full flow: POST generate → poll status → verify completed with downloadUrl
+- Test batch flow: POST batch → poll batch status → verify progress aggregation
+- Test authorization: 403 for out-of-scope faculty, 403 for unauthorized roles
+- Test ownership: 404 when polling another user's job
+
+**Manual Testing Steps:**
+
+1. Start local dev: `docker compose up` (Redis)
+2. Ensure R2 bucket exists with valid credentials in `.env`
+3. POST single report generation, poll status until completed, verify PDF downloads
+4. POST batch generation with department filter, verify all faculty in scope are queued
+5. Verify cleanup cron runs and purges old reports
+
+### Notes
+
+**Report Layout Reference:**
+
+- The official evaluation report format has 5 weighted sections (Preparation 15%, Teaching & Learning Process 35%, Assessment 25%, Learning Environment 10%, Teacher's Professionalism 15%), per-question averages with interpretations, section averages, overall weighted rating, and a comments/remarks section at the bottom.
+- Interpretation scale: 4.5-5.0 = "EXCELLENT PERFORMANCE", 3.5-4.49 = "VERY SATISFACTORY PERFORMANCE", 2.5-3.49 = "SATISFACTORY PERFORMANCE", 1.5-2.49 = "FAIR PERFORMANCE", 1.0-1.49 = "NEEDS IMPROVEMENT"
+- Existing interpretation logic at `src/modules/analytics/lib/interpretation.util.ts`
+
+**High-Risk Items:**
+
+- **Puppeteer in Docker**: Chromium dependency adds significant image size. May need `@sparticuz/chromium` (~50MB) instead of full Puppeteer (~300MB). Test PDF rendering in the Docker build early.
+- **Memory pressure**: Puppeteer browser instance holds ~100MB+ RAM. With `concurrency: 2`, two simultaneous pages could peak at ~300MB. Monitor memory on VPS during batch runs.
+- **Puppeteer crash recovery**: If Chromium OOM-kills mid-batch, the browser ref goes stale. `PdfService` has a relaunch-and-retry mechanism, but a persistent Chromium instability issue would require process-level restart.
+- **R2 connectivity**: If R2 upload fails after PDF generation, the PDF is lost and must be regenerated. Consider retrying the upload step before marking as failed.
+- **AnalyticsService coupling**: The refactored `BuildFacultyReportData()` private method and `GetFacultyReportUnscoped()` wrapper bypass authorization. Document clearly with JSDoc and ensure they're never exposed via HTTP.
+- **Orphaned jobs**: If Redis is down during enqueue, the compensating delete protects against orphans. The cleanup cron also catches any that slip through (waiting >1hr). But a sustained Redis outage during heavy batch usage could still cause transient issues.
+
+**Future Considerations (out of scope):**
+
+- Excel export can reuse the same data flow — add `ExcelService` alongside `PdfService`, dispatch based on `reportType`
+- Department summary rollup would need a new data aggregation path (not just per-faculty)
+- Campus head / VP roles: when added, only `ScopeResolverService` changes — the reports module is already role-agnostic
+- Report scheduling (cron-based): could reuse `GenerateBatch()` triggered by a scheduled job instead of HTTP request
+- Batch ZIP download: bundle all completed PDFs in a batch into a single ZIP file for convenience
+- Campus-level batch filter: A super admin operating across 5 campuses currently must know which `semesterId` belongs to which campus. A `campusId` filter (or campus-aware semester picker on the frontend) would improve UX for cross-campus users. Deferred because it's a frontend/UX concern.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,7 +13,7 @@ Provide a robust, analytics-driven bridge between Moodle learning environments a
 | Phase 1. Foundation & Core Synchronization    | Complete        | Core auth, Moodle sync, hydration, scheduling, and resilience are in place.                                                        |
 | Phase 2. Questionnaire & Ingestion Engine     | Mostly complete | Questionnaire management, draft/submit flows, and CSV ingestion are live; self-serve file mapping is still pending.                |
 | Phase 3. AI & Inference Pipeline              | Mostly complete | End-to-end pipeline is shipped; production worker rollout and operator monitoring remain open.                                     |
-| Phase 4. Analytics & Reporting Infrastructure | In progress     | Materialized-view analytics and faculty reports are live; exports and long-term analytics scaling are still open.                  |
+| Phase 4. Analytics & Reporting Infrastructure | In progress     | Materialized-view analytics, faculty reports, and PDF export are live; Excel export and long-term analytics scaling remain open.   |
 | Phase 5. Governance & Ecosystem               | In progress     | Scoped access, admin tooling, and audit logging are implemented; finer-grained permissions and ecosystem integrations remain open. |
 
 Cross-cutting platform capabilities already present in the codebase but not treated as separate roadmap phases include Redis-backed caching and throttling, structured health checks, request-scoped CLS metadata, and the authenticated `ChatKit` endpoint.
@@ -71,7 +71,8 @@ Cross-cutting platform capabilities already present in the codebase but not trea
 - [x] **Dashboard APIs:** Department overview, attention list, and faculty trends endpoints are live and scope-aware.
 - [x] **Faculty Evaluation Reports:** Per-question reports and paginated qualitative comment endpoints are implemented.
 - [x] **Analytics Freshness Tracking:** `analytics_last_refreshed_at` is recorded so consumers can show data staleness.
-- [ ] **Exportable Reporting:** PDF and Excel report generation are not implemented yet.
+- [x] **Faculty Evaluation PDF Export:** Async PDF generation via BullMQ + Puppeteer, stored in Cloudflare R2 with presigned download URLs. Single and batch generation with scope-aware authorization.
+- [ ] **Excel Export:** Excel report generation is not implemented yet.
 - [ ] **Long-Term OLAP Path:** A broader warehouse or alternative analytical engine decision is still open if current Postgres views become a bottleneck.
 
 ## Phase 5: Governance & Ecosystem
@@ -92,6 +93,6 @@ Cross-cutting platform capabilities already present in the codebase but not trea
 
 1. Productionize the remaining external inference stages by replacing mock or placeholder worker URLs with deployed sentiment and topic-model endpoints.
 2. Add operator visibility for BullMQ queues, sync runs, analytics refresh failures, and audit review workflows.
-3. Extend the analytics surface from API-only responses into exportable institutional reports (PDF/Excel) and scheduled delivery paths.
+3. Extend the reporting surface with Excel export, department summary rollup reports, and scheduled delivery paths.
 4. Mature governance from coarse role checks into a clearer permission model with explicit review tooling.
 5. Reassess the analytics storage strategy once dashboard scope expands beyond the current faculty- and department-focused materialized views.

--- a/docs/architecture/core-components.md
+++ b/docs/architecture/core-components.md
@@ -21,6 +21,8 @@ This document describes the high-level components, technology stack, and module 
 - **Caching:** `@nestjs/cache-manager` with Redis (`@keyv/redis`)
 - **Job Queue:** BullMQ (`@nestjs/bullmq`) on Redis
 - **Health Checks:** `@nestjs/terminus` with custom indicators
+- **PDF Generation:** Puppeteer (headless Chrome) + Handlebars templates
+- **Object Storage:** Cloudflare R2 via `@aws-sdk/client-s3` with presigned URL downloads
 - **Validation:** Zod (Environment variables), class-validator (DTOs)
 
 ## 3. Module Architecture
@@ -56,6 +58,7 @@ classDiagram
         FacultyModule
         CurriculumModule
         AuditModule
+        ReportsModule
     }
 
     AppModule --> InfrastructureModules : "imports"
@@ -74,6 +77,9 @@ classDiagram
     AnalyticsModule --> CommonModule : "uses ScopeResolverService"
     FacultyModule --> CommonModule : "uses ScopeResolverService"
     CurriculumModule --> CommonModule : "uses ScopeResolverService"
+    ReportsModule --> AnalyticsModule : "uses AnalyticsService"
+    ReportsModule --> CommonModule : "uses ScopeResolverService"
+    ReportsModule --> BullModule : "uses BullMQ queue"
 
     class AnalysisModule {
         +AnalysisService
@@ -128,6 +134,15 @@ classDiagram
         +AuditProcessor
         +AuditInterceptor
     }
+
+    class ReportsModule {
+        +ReportsService
+        +ReportsController
+        +ReportGenerationProcessor
+        +PdfService
+        +R2StorageService
+        +ReportCleanupJob
+    }
 ```
 
 ## 4. Login Strategy Pattern
@@ -160,11 +175,12 @@ Phase dependency: if categories fail, courses and enrollments are skipped. If co
 
 ### Cron Jobs
 
-The only remaining cron job using the `BaseJob` pattern is in `src/crons/jobs/`:
+Cron jobs using the `BaseJob` pattern:
 
-| Job                      | Schedule       | Purpose                                 |
-| ------------------------ | -------------- | --------------------------------------- |
-| `RefreshTokenCleanupJob` | Every 12 hours | Purges refresh tokens older than 7 days |
+| Job                      | Schedule       | Module        | Purpose                                                        |
+| ------------------------ | -------------- | ------------- | -------------------------------------------------------------- |
+| `RefreshTokenCleanupJob` | Every 12 hours | `AllCronJobs` | Purges refresh tokens older than 7 days                        |
+| `ReportCleanupJob`       | Daily at 3 AM  | ReportsModule | Purges expired report jobs + R2 objects, orphaned waiting jobs |
 
 ## 6. Moodle Connectivity & Error Handling
 
@@ -215,7 +231,7 @@ Each stage has a corresponding `RunStatus` (`PENDING` → `PROCESSING` → `COMP
 
 ### Queue Architecture
 
-Seven BullMQ queues with independent concurrency. Queue names are centralized in `src/configurations/common/queue-names.ts`.
+Eight BullMQ queues with independent concurrency. Queue names are centralized in `src/configurations/common/queue-names.ts`.
 
 | Queue               | Processor                   | Concurrency Default | Module          |
 | ------------------- | --------------------------- | ------------------- | --------------- |
@@ -226,6 +242,7 @@ Seven BullMQ queues with independent concurrency. Queue names are centralized in
 | `recommendations`   | `RecommendationsProcessor`  | 1                   | AnalysisModule  |
 | `analytics-refresh` | `AnalyticsRefreshProcessor` | 1                   | AnalyticsModule |
 | `audit`             | `AuditProcessor`            | 1                   | AuditModule     |
+| `report-generation` | `ReportGenerationProcessor` | 2                   | ReportsModule   |
 
 ### REST Endpoints
 
@@ -246,6 +263,17 @@ See [Analytics Module](./analytics.md) for full architecture.
 | GET    | `/analytics/overview`  | Department overview with per-faculty stats        |
 | GET    | `/analytics/attention` | Faculty flagged for review with attention flags   |
 | GET    | `/analytics/trends`    | Faculty trend data with linear regression results |
+
+### Report Generation Endpoints
+
+See [Report Generation Workflow](../workflows/report-generation.md) for the full async flow.
+
+| Method | Path                      | Description                                            |
+| ------ | ------------------------- | ------------------------------------------------------ |
+| POST   | `/reports/generate`       | Queue a single faculty evaluation PDF                  |
+| POST   | `/reports/generate/batch` | Queue batch PDF generation (scope-filtered, throttled) |
+| GET    | `/reports/status/:jobId`  | Poll single report job status + download URL           |
+| GET    | `/reports/batch/:batchId` | Poll batch progress with paginated per-job details     |
 
 **Resilience:** Exponential backoff retries, stall detection, graceful degradation when Redis is unavailable (`ServiceUnavailableException`), HTTP timeout via `AbortController`.
 

--- a/docs/decisions/decisions.md
+++ b/docs/decisions/decisions.md
@@ -267,6 +267,32 @@ Login failure audit events store a fixed reason code (`no_matching_strategy`, `s
 - **Rationale:** Raw error messages may contain connection strings, hostnames, SQL fragments, or stack traces — especially from Moodle connectivity errors or database driver failures. Persisting these in an immutable, append-only table creates a permanent information disclosure risk.
 - **Trade-off:** Less diagnostic detail in audit logs. Full error details are still available in application logs (which are rotatable and not permanent).
 
+## 38. Puppeteer for PDF Generation over Lighter Libraries
+
+Faculty evaluation PDFs require precise table rendering with cell borders, weighted section headers, and formatted layout matching an official institutional form. Puppeteer + Handlebars was chosen over lightweight PDF libraries (PDFKit, jsPDF).
+
+- **Rationale:** The evaluation form has complex table-based layout with section headers, per-question rows, weighted averages, and a comments section. CSS-based rendering via Puppeteer handles this naturally, while programmatic PDF libraries require manual coordinate-based layout.
+- **Persistent browser:** A single Puppeteer browser instance is launched at module init and reused across jobs (`OnModuleInit`/`OnModuleDestroy`). Per-job page creation avoids the ~500ms browser launch overhead.
+- **Crash recovery:** If the browser instance dies (OOM, zombie process), the `PdfService` detects the stale reference on `newPage()` failure and relaunches with a mutex to prevent concurrent relaunches from multiple processor workers.
+- **Trade-off:** Puppeteer adds ~300MB to the Docker image (or ~50MB with `@sparticuz/chromium`). Memory usage peaks at ~300MB with `concurrency: 2`. Production deployments must include Chromium system dependencies.
+
+## 39. Cloudflare R2 with Thin StorageProvider Abstraction
+
+Reports are stored in Cloudflare R2 using the S3-compatible API, injected via a `StorageProvider` abstraction with token-based DI.
+
+- **Rationale:** R2 offers S3-compatible API with zero egress fees. The `StorageProvider` abstract class allows test mocks without S3 SDK dependencies in tests and enables future storage backend changes (e.g., local filesystem for development).
+- **Optional credentials:** All R2 env vars are optional. The `R2StorageService` constructor checks if credentials are present and sets `isConfigured = false` if missing. All methods throw `ServiceUnavailableException` when unconfigured. This allows the application to start in environments without R2 (CI, local dev) while failing gracefully at report generation time.
+- **Trade-off:** Using an abstract class instead of an interface was forced by TypeScript's `isolatedModules` + `emitDecoratorMetadata` — interfaces cannot be used as parameter types in decorated constructors.
+
+## 40. One ReportJob Per Faculty with BatchId Linkage
+
+Batch report generation creates individual `ReportJob` entities per faculty, linked by a shared `batchId`, rather than a single batch entity containing all results.
+
+- **Rationale:** Individual jobs allow per-faculty download as soon as each completes — users don't wait for the entire batch. If one faculty report fails, others still succeed. Status aggregation is a simple `GROUP BY` over the batch's jobs.
+- **Dedup at DB level:** A partial unique index prevents duplicate pending/active jobs for the same faculty+semester+type combination. The service-level dedup check provides fast feedback; the index handles race conditions.
+- **Atomic batch enqueue:** `Queue.addBulk()` ensures all jobs in a batch are enqueued atomically. On failure, all `ReportJob` entities are cleaned up — no orphans.
+- **Trade-off:** Batch status polling requires aggregation over N rows (bounded by `REPORT_BATCH_MAX_SIZE`=100). SQL `GROUP BY` keeps this efficient.
+
 ## 30. Semester Code Parsing for Display Labels
 
 The Moodle category sync now parses semester codes (e.g., `S22526`) into human-readable `label` ("Semester 2") and `academicYear` ("2025-2026") fields on the `Semester` entity.

--- a/docs/workflows/report-generation.md
+++ b/docs/workflows/report-generation.md
@@ -1,0 +1,123 @@
+# Report Generation Workflow
+
+This document describes the async PDF report generation flow for faculty evaluation reports.
+
+## Overview
+
+Faculty evaluation reports are generated asynchronously via BullMQ. Puppeteer renders Handlebars templates into PDFs, which are uploaded to Cloudflare R2 with time-limited presigned download URLs.
+
+## Architecture
+
+```
+POST /reports/generate
+  |
+  v
+ReportsService.GenerateSingle()
+  |-- Semester validation
+  |-- Dedup check (partial unique index)
+  |-- Scope validation (ScopeResolverService)
+  |-- Create ReportJob entity (status: 'waiting')
+  |-- Enqueue BullMQ job (orphan protection on failure)
+  v
+ReportGenerationProcessor.process()
+  |-- Set status: 'active'
+  |-- AnalyticsService.GetFacultyReportUnscoped()
+  |-- Zero-submissions check → status: 'skipped' (early return)
+  |-- AnalyticsService.GetAllFacultyReportComments()
+  |-- PdfService.GenerateFacultyEvaluationPdf()
+  |-- StorageProvider.Upload() → R2
+  |-- Set status: 'completed', storageKey
+  v
+GET /reports/status/:jobId
+  |-- Fresh presigned URL generated on each poll
+```
+
+## Batch Flow
+
+```
+POST /reports/generate/batch
+  |
+  v
+ReportsService.GenerateBatch()
+  |-- Semester validation
+  |-- Resolve department IDs → translate to codes
+  |-- Apply optional departmentId / programId filters
+  |-- Resolve faculty via questionnaire_submission (semester-scoped)
+  |-- Enforce REPORT_BATCH_MAX_SIZE cap
+  |-- Bulk dedup check (single query)
+  |-- Create N ReportJob entities linked by batchId
+  |-- Queue.addBulk() (atomic enqueue)
+  v
+GET /reports/batch/:batchId
+  |-- SQL GROUP BY aggregation for status counts
+  |-- DB-level LIMIT/OFFSET for paginated job details
+  |-- Presigned URLs for completed jobs in current page only
+```
+
+## Key Components
+
+| Component                   | Purpose                                                       |
+| --------------------------- | ------------------------------------------------------------- |
+| `ReportsService`            | Orchestration — scope validation, dedup, entity lifecycle     |
+| `ReportGenerationProcessor` | BullMQ processor — data fetch, PDF render, R2 upload          |
+| `PdfService`                | Puppeteer + Handlebars PDF generation with persistent browser |
+| `R2StorageService`          | S3-compatible R2 storage with presigned URL generation        |
+| `ReportCleanupJob`          | Daily cron — purges expired reports and orphaned jobs         |
+| `ReportJob` entity          | Tracks job lifecycle, ownership, and storage key              |
+
+## Authorization
+
+- **Role gate:** `SUPER_ADMIN`, `DEAN`, `CHAIRPERSON` (via `@UseJwtGuard()`)
+- **Scope enforcement:** `ScopeResolverService.ResolveDepartmentIds()` validates faculty access at enqueue time
+- **Processor bypass:** The processor calls `GetFacultyReportUnscoped()` — scope was already validated when the job was created
+- **Ownership check:** Status endpoints verify `requestedBy` matches the requesting user (super admins bypass)
+
+## Deduplication
+
+A partial unique index on `report_job` prevents duplicate pending/active jobs:
+
+```sql
+CREATE UNIQUE INDEX uq_report_job_pending
+  ON report_job (faculty_id, semester_id, questionnaire_type_code, report_type)
+  WHERE status IN ('waiting', 'active') AND deleted_at IS NULL;
+```
+
+The service checks for existing pending jobs before creating new ones. On `UniqueConstraintViolationException` (race condition), the existing job ID is returned.
+
+## Storage
+
+- **Key convention:** `reports/faculty_evaluation/{semesterId}/{batchId|jobId}/{facultyId}.pdf`
+- **Presigned URLs:** Generated on-the-fly from `storageKey` with configurable expiry (`REPORT_PRESIGNED_URL_EXPIRY_SECONDS`, default 1 hour)
+- **Graceful degradation:** If R2 credentials are not configured, the service starts but report endpoints return `503 Service Unavailable`
+
+## Cleanup
+
+`ReportCleanupJob` runs daily at 3 AM:
+
+1. Finds completed `ReportJob` entities older than `REPORT_RETENTION_DAYS` (default 7)
+2. Batch-deletes R2 objects by prefix via `DeleteByPrefix()`
+3. Hard-deletes expired entities via `nativeDelete()`
+4. Finds orphaned `'waiting'` jobs older than 1 hour (enqueue failed) and hard-deletes them
+
+## Job Status Lifecycle
+
+```
+waiting → active → completed (storageKey set, presigned URL available)
+                 → failed (error message stored)
+                 → skipped (zero submissions — no PDF generated)
+```
+
+The `@OnWorkerEvent('failed')` handler only marks the entity as `'failed'` on the final retry attempt. Intermediate failures leave the status as `'active'` so BullMQ can retry.
+
+## Environment Variables
+
+| Variable                              | Default              | Purpose                            |
+| ------------------------------------- | -------------------- | ---------------------------------- |
+| `CF_ACCOUNT_ID`                       | _(optional)_         | Cloudflare account ID for R2       |
+| `R2_ACCESS_KEY_ID`                    | _(optional)_         | R2 access key                      |
+| `R2_SECRET_ACCESS_KEY`                | _(optional)_         | R2 secret key                      |
+| `R2_BUCKET_NAME`                      | `faculytics-reports` | R2 bucket name                     |
+| `REPORT_GENERATION_CONCURRENCY`       | `2`                  | BullMQ processor concurrency       |
+| `REPORT_PRESIGNED_URL_EXPIRY_SECONDS` | `3600`               | Presigned URL lifetime             |
+| `REPORT_BATCH_MAX_SIZE`               | `100`                | Max faculty per batch request      |
+| `REPORT_RETENTION_DAYS`               | `7`                  | Days before cleanup purges reports |

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -4,6 +4,12 @@
   "sourceRoot": "src",
   "compilerOptions": {
     "deleteOutDir": true,
-    "plugins": ["@nestjs/swagger"]
+    "plugins": ["@nestjs/swagger"],
+    "assets": [
+      {
+        "include": "modules/reports/templates/**/*",
+        "watchAssets": true
+      }
+    ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1021.0",
+        "@aws-sdk/s3-request-presigner": "^3.1021.0",
         "@keyv/redis": "^5.1.6",
         "@mikro-orm/core": "^6.6.11",
         "@mikro-orm/migrations": "^6.6.11",
@@ -39,6 +41,7 @@
         "dataloader": "^2.2.3",
         "dotenv": "^17.2.4",
         "exceljs": "^4.4.0",
+        "handlebars": "^4.7.9",
         "ioredis": "^5.10.0",
         "js-yaml": "^4.1.1",
         "nestjs-cls": "^6.2.0",
@@ -49,6 +52,7 @@
         "pgvector": "^0.2.1",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
+        "puppeteer": "^24.40.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "ua-parser-js": "^2.0.9",
@@ -233,11 +237,895 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1021.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1021.0.tgz",
+      "integrity": "sha512-BCfggq8gYSjlKOZlMSVApix3cgKAQIWGeoJFX/AU5HMvqz1BZBEw83jJFL9LYrqTPCocH8NGl++1Xr70ro+jcg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/credential-provider-node": "^3.972.29",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.8",
+        "@aws-sdk/middleware-expect-continue": "^3.972.8",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.6",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-location-constraint": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.27",
+        "@aws-sdk/middleware-ssec": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.28",
+        "@aws-sdk/region-config-resolver": "^3.972.10",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.15",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.14",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.13",
+        "@smithy/eventstream-serde-browser": "^4.2.12",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.12",
+        "@smithy/eventstream-serde-node": "^4.2.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-blob-browser": "^4.2.13",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/hash-stream-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/md5-js": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.28",
+        "@smithy/middleware-retry": "^4.4.46",
+        "@smithy/middleware-serde": "^4.2.16",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.1",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.44",
+        "@smithy/util-defaults-mode-node": "^4.2.48",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.13",
+        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.973.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.26.tgz",
+      "integrity": "sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/xml-builder": "^3.972.16",
+        "@smithy/core": "^3.23.13",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/crc64-nvme": {
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.5.tgz",
+      "integrity": "sha512-2VbTstbjKdT+yKi8m7b3a9CiVac+pL/IY2PHJwsaGkkHmuuqkJZIErPck1h6P3T9ghQMLSdMPyW6Qp7Di5swFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.24.tgz",
+      "integrity": "sha512-FWg8uFmT6vQM7VuzELzwVo5bzExGaKHdubn0StjgrcU5FvuLExUe+k06kn/40uKv59rYzhez8eFNM4yYE/Yb/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.26.tgz",
+      "integrity": "sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.1",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.21",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.28.tgz",
+      "integrity": "sha512-wXYvq3+uQcZV7k+bE4yDXCTBdzWTU9x/nMiKBfzInmv6yYK1veMK0AKvRfRBd72nGWYKcL6AxwiPg9z/pYlgpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/credential-provider-env": "^3.972.24",
+        "@aws-sdk/credential-provider-http": "^3.972.26",
+        "@aws-sdk/credential-provider-login": "^3.972.28",
+        "@aws-sdk/credential-provider-process": "^3.972.24",
+        "@aws-sdk/credential-provider-sso": "^3.972.28",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.28",
+        "@aws-sdk/nested-clients": "^3.996.18",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.28.tgz",
+      "integrity": "sha512-ZSTfO6jqUTCysbdBPtEX5OUR//3rbD0lN7jO3sQeS2Gjr/Y+DT6SbIJ0oT2cemNw3UzKu97sNONd1CwNMthuZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/nested-clients": "^3.996.18",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.29.tgz",
+      "integrity": "sha512-clSzDcvndpFJAggLDnDb36sPdlZYyEs5Zm6zgZjjUhwsJgSWiWKwFIXUVBcbruidNyBdbpOv2tNDL9sX8y3/0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.24",
+        "@aws-sdk/credential-provider-http": "^3.972.26",
+        "@aws-sdk/credential-provider-ini": "^3.972.28",
+        "@aws-sdk/credential-provider-process": "^3.972.24",
+        "@aws-sdk/credential-provider-sso": "^3.972.28",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.28",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.24.tgz",
+      "integrity": "sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.28.tgz",
+      "integrity": "sha512-IoUlmKMLEITFn1SiCTjPfR6KrE799FBo5baWyk/5Ppar2yXZoUdaRqZzJzK6TcJxx450M8m8DbpddRVYlp5R/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/nested-clients": "^3.996.18",
+        "@aws-sdk/token-providers": "3.1021.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.28.tgz",
+      "integrity": "sha512-d+6h0SD8GGERzKe27v5rOzNGKOl0D+l0bWJdqrxH8WSQzHzjsQFIAPgIeOTUwBHVsKKwtSxc91K/SWax6XgswQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/nested-clients": "^3.996.18",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.8.tgz",
+      "integrity": "sha512-WR525Rr2QJSETa9a050isktyWi/4yIGcmY3BQ1kpHqb0LqUglQHCS8R27dTJxxWNZvQ0RVGtEZjTCbZJpyF3Aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.8.tgz",
+      "integrity": "sha512-5DTBTiotEES1e2jOHAq//zyzCjeMB78lEHd35u15qnrid4Nxm7diqIf9fQQ3Ov0ChH1V3Vvt13thOnrACmfGVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.6.tgz",
+      "integrity": "sha512-YckB8k1ejbyCg/g36gUMFLNzE4W5cERIa4MtsdO+wpTmJEP0+TB7okWIt7d8TDOvnb7SwvxJ21E4TGOBxFpSWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/crc64-nvme": "^3.972.5",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.8.tgz",
+      "integrity": "sha512-KaUoFuoFPziIa98DSQsTPeke1gvGXlc5ZGMhy+b+nLxZ4A7jmJgLzjEF95l8aOQN2T/qlPP3MrAyELm8ExXucw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.9.tgz",
+      "integrity": "sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.27.tgz",
+      "integrity": "sha512-gomO6DZwx+1D/9mbCpcqO5tPBqYBK7DtdgjTIjZ4yvfh/S7ETwAPS0XbJgP2JD8Ycr5CwVrEkV1sFtu3ShXeOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/core": "^3.23.13",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.8.tgz",
+      "integrity": "sha512-wqlK0yO/TxEC2UsY9wIlqeeutF6jjLe0f96Pbm40XscTo57nImUk9lBcw0dPgsm0sppFtAkSlDrfpK+pC30Wqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.28.tgz",
+      "integrity": "sha512-cfWZFlVh7Va9lRay4PN2A9ARFzaBYcA097InT5M2CdRS05ECF5yaz86jET8Wsl2WcyKYEvVr/QNmKtYtafUHtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@smithy/core": "^3.23.13",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-retry": "^4.2.13",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.18.tgz",
+      "integrity": "sha512-c7ZSIXrESxHKx2Mcopgd8AlzZgoXMr20fkx5ViPWPOLBvmyhw9VwJx/Govg8Ef/IhEon5R9l53Z8fdYSEmp6VA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
+        "@aws-sdk/middleware-user-agent": "^3.972.28",
+        "@aws-sdk/region-config-resolver": "^3.972.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.14",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.13",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.28",
+        "@smithy/middleware-retry": "^4.4.46",
+        "@smithy/middleware-serde": "^4.2.16",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.1",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.44",
+        "@smithy/util-defaults-mode-node": "^4.2.48",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.13",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.10.tgz",
+      "integrity": "sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1021.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1021.0.tgz",
+      "integrity": "sha512-kkIzsIAc7wnG7vVRkZFIwJ3noOyF3S6ozOQ9t2KxzPde1LsmpmPwYbmiB91DzdfuGySdk4Hpb0JmHh4KhGECXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "^3.996.15",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-format-url": "^3.972.8",
+        "@smithy/middleware-endpoint": "^4.4.28",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.15.tgz",
+      "integrity": "sha512-Ukw2RpqvaL96CjfH/FgfBmy/ZosHBqoHBCFsN61qGg99F33vpntIVii8aNeh65XuOja73arSduskoa4OJea9RQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.27",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1021.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1021.0.tgz",
+      "integrity": "sha512-TKY6h9spUk3OLs5v1oAgW9mAeBE3LAGNBwJokLy96wwmd4W2v/tYlXseProyed9ValDj2u1jK/4Rg1T+1NXyJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/nested-clients": "^3.996.18",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-endpoints": "^3.3.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.8.tgz",
+      "integrity": "sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.14.tgz",
+      "integrity": "sha512-vNSB/DYaPOyujVZBg/zUznH9QC142MaTHVmaFlF7uzzfg3CgT9f/l4C0Yi+vU/tbBhxVcXVB90Oohk5+o+ZbWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.28",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
+      "integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "fast-xml-parser": "5.5.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -409,7 +1297,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3365,6 +4252,27 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
+      "integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.4",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rushstack/node-core-library": {
       "version": "5.13.0",
       "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.13.0.tgz",
@@ -3546,6 +4454,724 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
+      "integrity": "sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.3.tgz",
+      "integrity": "sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.13.tgz",
+      "integrity": "sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.23.13",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.13.tgz",
+      "integrity": "sha512-J+2TT9D6oGsUVXVEMvz8h2EmdVnkBiy2auCie4aSJMvKlzUtO5hqjEzXhoCUkIMo7gAYjbQcN0g/MMSXEhDs1Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
+      "integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.12.tgz",
+      "integrity": "sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.12.tgz",
+      "integrity": "sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.12.tgz",
+      "integrity": "sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.12.tgz",
+      "integrity": "sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.12.tgz",
+      "integrity": "sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.15",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
+      "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.13.tgz",
+      "integrity": "sha512-YrF4zWKh+ghLuquldj6e/RzE3xZYL8wIPfkt0MqCRphVICjyyjH8OwKD7LLlKpVEbk4FLizFfC1+gwK6XQdR3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/chunked-blob-reader": "^5.2.2",
+        "@smithy/chunked-blob-reader-native": "^4.2.3",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.12.tgz",
+      "integrity": "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.12.tgz",
+      "integrity": "sha512-O3YbmGExeafuM/kP7Y8r6+1y0hIh3/zn6GROx0uNlB54K9oihAL75Qtc+jFfLNliTi6pxOAYZrRKD9A7iA6UFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.12.tgz",
+      "integrity": "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.12.tgz",
+      "integrity": "sha512-W/oIpHCpWU2+iAkfZYyGWE+qkpuf3vEXHLxQQDx9FPNZTTdnul0dZ2d/gUFrtQ5je1G2kp4cjG0/24YueG2LbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.12.tgz",
+      "integrity": "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.28",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.28.tgz",
+      "integrity": "sha512-p1gfYpi91CHcs5cBq982UlGlDrxoYUX6XdHSo91cQ2KFuz6QloHosO7Jc60pJiVmkWrKOV8kFYlGFFbQ2WUKKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.13",
+        "@smithy/middleware-serde": "^4.2.16",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-middleware": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.4.46",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.46.tgz",
+      "integrity": "sha512-SpvWNNOPOrKQGUqZbEPO+es+FRXMWvIyzUKUOYdDgdlA6BdZj/R58p4umoQ76c2oJC44PiM7mKizyyex1IJzow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.13",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.16",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.16.tgz",
+      "integrity": "sha512-beqfV+RZ9RSv+sQqor3xroUUYgRFCGRw6niGstPG8zO9LgTl0B0MCucxjmrH/2WwksQN7UUgI7KNANoZv+KALA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.13",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.12.tgz",
+      "integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.12.tgz",
+      "integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.1.tgz",
+      "integrity": "sha512-ejjxdAXjkPIs9lyYyVutOGNOraqUE9v/NjGMKwwFrfOM354wfSD8lmlj8hVwUzQmlLLF4+udhfCX9Exnbmvfzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.12.tgz",
+      "integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
+      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz",
+      "integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.12.tgz",
+      "integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.12.tgz",
+      "integrity": "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz",
+      "integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
+      "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.8.tgz",
+      "integrity": "sha512-aJaAX7vHe5i66smoSSID7t4rKY08PbD8EBU7DOloixvhOozfYWdcSYE4l6/tjkZ0vBZhGjheWzB2mh31sLgCMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.13",
+        "@smithy/middleware-endpoint": "^4.4.28",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.21",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
+      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.12.tgz",
+      "integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.44",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.44.tgz",
+      "integrity": "sha512-eZg6XzaCbVr2S5cAErU5eGBDaOVTuTo1I65i4tQcHENRcZ8rMWhQy1DaIYUSLyZjsfXvmCqZrstSMYyGFocvHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.48",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.48.tgz",
+      "integrity": "sha512-FqOKTlqSaoV3nzO55pMs5NBnZX8EhoI0DGmn9kbYeXWppgHD6dchyuj2HLqp4INJDJbSrj6OFYJkAh/WhSzZPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.3.tgz",
+      "integrity": "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.12.tgz",
+      "integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.13.tgz",
+      "integrity": "sha512-qQQsIvL0MGIbUjeSrg0/VlQ3jGNKyM3/2iU3FPNgy01z+Sp4OvcaxbgIoFOTvB61ZoohtutuOvOcgmhbD0katQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.21",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.21.tgz",
+      "integrity": "sha512-KzSg+7KKywLnkoKejRtIBXDmwBfjGvg1U1i/etkC7XSWUyFCoLno1IohV2c74IzQqdhX5y3uE44r/8/wuK+A7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.1",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.14.tgz",
+      "integrity": "sha512-2zqq5o/oizvMaFUlNiTyZ7dbgYv1a893aGut2uaxtbzTx/VYYnRxWzDHuD/ftgcw94ffenua+ZNLrbqwUYE+Bg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
@@ -3567,6 +5193,12 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
@@ -3987,6 +5619,16 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.0",
@@ -4770,6 +6412,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -5068,6 +6719,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -5088,6 +6751,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/babel-jest": {
@@ -5195,6 +6872,97 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.6.tgz",
+      "integrity": "sha512-1QovqDrR80Pmt5HPAsMsXTCFcDYr+NSUKW6nd6WO5v0JBmnItc/irNRzm2KOQ5oZ69P37y+AMujNyNtG+1Rggw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.6.tgz",
+      "integrity": "sha512-l8xaNWWb/bXuzgsrlF5jaa5QYDJ9S0ddd54cP6CH+081+5iPrbJiCfBWQqrWYzmUhCbsH+WR6qxo9MeHVCr0MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.12.0.tgz",
+      "integrity": "sha512-w28i8lkBgREV3rPXGbgK+BO66q+ZpKqRWrZLiCdmmUlLPrQ45CzkvRhN+7lnv00Gpi2zy5naRxnUFAxCECDm9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
+      "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -5223,6 +6991,15 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/bcrypt": {
@@ -5301,6 +7078,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/boxen": {
       "version": "5.1.2",
@@ -5648,7 +7431,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5862,6 +7644,28 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/chromium-bidi": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/chromium-bidi/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/ci-info": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -6007,7 +7811,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -6022,7 +7825,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6032,7 +7834,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6045,7 +7846,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -6399,6 +8199,15 @@
       "integrity": "sha512-Zv8KRHccD1q3BJlK4VcQiEn/+suOOp++89g/fpqOxB2U2tU66uC3yM+ZwU6nQQEJp8AqBIiNqB+pUTKNz4QzKg==",
       "license": "MIT"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/dataloader": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.3.tgz",
@@ -6482,6 +8291,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -6549,6 +8372,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1581282",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
+      "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -6754,6 +8583,15 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/environment": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -6771,7 +8609,6 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -6856,6 +8693,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint": {
@@ -7065,7 +8933,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -7075,7 +8942,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -7105,6 +8971,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
       }
     },
     "node_modules/eventsource": {
@@ -7280,6 +9155,41 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fast-copy": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.2.tgz",
@@ -7311,6 +9221,12 @@
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -7376,6 +9292,41 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -7393,6 +9344,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/fdir": {
@@ -7851,6 +9811,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/getopts": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.3.0.tgz",
@@ -8018,7 +9992,6 @@
       "version": "4.7.9",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
       "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
@@ -8040,7 +10013,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -8156,6 +10128,32 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -8237,7 +10235,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -8344,7 +10341,6 @@
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 12"
       }
@@ -8362,7 +10358,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-core-module": {
@@ -9468,7 +11463,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -9507,7 +11501,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -9840,7 +11833,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lint-staged": {
@@ -10515,6 +12507,12 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -10685,7 +12683,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nestjs-cls": {
@@ -10716,6 +12713,15 @@
         "pino": "^7.5.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
         "pino-http": "^6.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
         "rxjs": "^7.1.0"
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/node-abort-controller": {
@@ -11062,6 +13068,38 @@
         "node": ">=6"
       }
     },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -11079,7 +13117,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -11101,7 +13138,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -11170,6 +13206,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-is-absolute": {
@@ -11248,6 +13299,12 @@
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==",
       "peer": true
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
     },
     "node_modules/pg": {
       "version": "8.20.0",
@@ -11387,7 +13444,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -11735,6 +13791,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -11747,6 +13812,40 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.3",
@@ -11766,6 +13865,71 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer": {
+      "version": "24.40.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.40.0.tgz",
+      "integrity": "sha512-IxQbDq93XHVVLWHrAkFP7F7iHvb9o0mgfsSIMlhHb+JM+JjM1V4v4MNSQfcRWJopx9dsNOr9adYv0U5fm9BJBQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.13.0",
+        "chromium-bidi": "14.0.0",
+        "cosmiconfig": "^9.0.0",
+        "devtools-protocol": "0.0.1581282",
+        "puppeteer-core": "24.40.0",
+        "typed-query-selector": "^2.12.1"
+      },
+      "bin": {
+        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.40.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.40.0.tgz",
+      "integrity": "sha512-MWL3XbUCfVgGR0gRsidzT6oKJT2QydPLhMITU6HoVWiiv4gkb6gJi3pcdAa8q4HwjBTbqISOWVP4aJiiyUJvag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.13.0",
+        "chromium-bidi": "14.0.0",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1581282",
+        "typed-query-selector": "^2.12.1",
+        "webdriver-bidi-protocol": "0.4.1",
+        "ws": "^8.19.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer/node_modules/cosmiconfig": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/pure-rand": {
@@ -11967,7 +14131,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12029,7 +14192,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -12465,6 +14627,44 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
@@ -12573,6 +14773,17 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
       }
     },
     "node_modules/string_decoder": {
@@ -12796,6 +15007,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/strtok3": {
       "version": "10.3.5",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
@@ -12921,6 +15144,32 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-fs/node_modules/tar-stream": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -12944,6 +15193,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
       }
     },
     "node_modules/terser": {
@@ -13147,6 +15405,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/thread-stream": {
@@ -13483,6 +15750,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
+      "integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==",
+      "license": "MIT"
+    },
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -13493,7 +15766,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -13582,7 +15855,6 @@
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
@@ -13895,6 +16167,12 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webpack": {
       "version": "5.105.2",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
@@ -14138,7 +16416,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {
@@ -14281,7 +16558,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -14314,7 +16590,6 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -14333,10 +16608,19 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     ]
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1021.0",
+    "@aws-sdk/s3-request-presigner": "^3.1021.0",
     "@keyv/redis": "^5.1.6",
     "@mikro-orm/core": "^6.6.11",
     "@mikro-orm/migrations": "^6.6.11",
@@ -61,6 +63,7 @@
     "dataloader": "^2.2.3",
     "dotenv": "^17.2.4",
     "exceljs": "^4.4.0",
+    "handlebars": "^4.7.9",
     "ioredis": "^5.10.0",
     "js-yaml": "^4.1.1",
     "nestjs-cls": "^6.2.0",
@@ -71,6 +74,7 @@
     "pgvector": "^0.2.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
+    "puppeteer": "^24.40.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "ua-parser-js": "^2.0.9",
@@ -121,7 +125,7 @@
     "brace-expansion@^2.0.1": "2.0.3",
     "brace-expansion@^2.0.2": "2.0.3",
     "brace-expansion@^5.0.2": "5.0.5",
-    "handlebars": "^4.7.9",
+    "handlebars@<4.7.9": "^4.7.9",
     "picomatch@^2.0.4": "2.3.2",
     "picomatch@^2.3.1": "2.3.2",
     "picomatch@^4.0.2": "4.0.4",

--- a/src/configurations/common/queue-names.ts
+++ b/src/configurations/common/queue-names.ts
@@ -6,6 +6,7 @@ export const QueueName = {
   MOODLE_SYNC: 'moodle-sync',
   ANALYTICS_REFRESH: 'analytics-refresh',
   AUDIT: 'audit',
+  REPORT_GENERATION: 'report-generation',
 } as const;
 
 export type QueueName = (typeof QueueName)[keyof typeof QueueName];

--- a/src/configurations/env/bullmq.env.ts
+++ b/src/configurations/env/bullmq.env.ts
@@ -18,6 +18,7 @@ export const bullmqEnvSchema = z.object({
   RECOMMENDATIONS_WORKER_URL: z.url().optional(),
   RECOMMENDATIONS_CONCURRENCY: z.coerce.number().default(1),
   RECOMMENDATIONS_MODEL: z.string().default('gpt-4o-mini'),
+  REPORT_GENERATION_CONCURRENCY: z.coerce.number().default(2),
 });
 
 export type BullMqEnv = z.infer<typeof bullmqEnvSchema>;

--- a/src/configurations/env/index.ts
+++ b/src/configurations/env/index.ts
@@ -11,6 +11,8 @@ import { adminEnvSchema } from './admin.env';
 import { redisEnvSchema } from './redis.env';
 import { bullmqEnvSchema } from './bullmq.env';
 import { throttleEnvSchema } from './throttle.env';
+import { r2EnvSchema } from './r2.env';
+import { reportEnvSchema } from './report.env';
 
 export const envSchema = z.object({
   ...databaseEnvSchema.shape,
@@ -23,6 +25,8 @@ export const envSchema = z.object({
   ...redisEnvSchema.shape,
   ...bullmqEnvSchema.shape,
   ...throttleEnvSchema.shape,
+  ...r2EnvSchema.shape,
+  ...reportEnvSchema.shape,
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/src/configurations/env/r2.env.ts
+++ b/src/configurations/env/r2.env.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const r2EnvSchema = z.object({
+  CF_ACCOUNT_ID: z.string().optional(),
+  R2_ACCESS_KEY_ID: z.string().optional(),
+  R2_SECRET_ACCESS_KEY: z.string().optional(),
+  R2_BUCKET_NAME: z.string().default('faculytics-reports'),
+});
+
+export type R2Env = z.infer<typeof r2EnvSchema>;

--- a/src/configurations/env/report.env.ts
+++ b/src/configurations/env/report.env.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const reportEnvSchema = z.object({
+  REPORT_PRESIGNED_URL_EXPIRY_SECONDS: z.coerce.number().default(3600),
+  REPORT_BATCH_MAX_SIZE: z.coerce.number().default(100),
+  REPORT_RETENTION_DAYS: z.coerce.number().default(7),
+});
+
+export type ReportEnv = z.infer<typeof reportEnvSchema>;

--- a/src/entities/index.entity.ts
+++ b/src/entities/index.entity.ts
@@ -31,6 +31,7 @@ import { Section } from './section.entity';
 import { TopicModelRun } from './topic-model-run.entity';
 import { SyncLog } from './sync-log.entity';
 import { AuditLog } from './audit-log.entity';
+import { ReportJob } from './report-job.entity';
 
 export {
   ChatKitThread,
@@ -66,6 +67,7 @@ export {
   TopicModelRun,
   SyncLog,
   AuditLog,
+  ReportJob,
 };
 
 export const entities = [
@@ -102,4 +104,5 @@ export const entities = [
   TopicModelRun,
   SyncLog,
   AuditLog,
+  ReportJob,
 ];

--- a/src/entities/report-job.entity.ts
+++ b/src/entities/report-job.entity.ts
@@ -1,0 +1,50 @@
+import { Entity, Index, ManyToOne, Opt, Property } from '@mikro-orm/core';
+import { CustomBaseEntity } from './base.entity';
+import { User } from './user.entity';
+import { ReportJobRepository } from '../repositories/report-job.repository';
+
+export type ReportJobStatus =
+  | 'waiting'
+  | 'active'
+  | 'completed'
+  | 'failed'
+  | 'skipped';
+
+@Entity({ repository: () => ReportJobRepository })
+export class ReportJob extends CustomBaseEntity {
+  @Property()
+  reportType: string;
+
+  @Property()
+  @Index()
+  status: ReportJobStatus & Opt = 'waiting';
+
+  @ManyToOne(() => User)
+  @Index()
+  requestedBy: User;
+
+  @Property()
+  facultyId: string;
+
+  @Property()
+  facultyName: string;
+
+  @Property()
+  semesterId: string;
+
+  @Property()
+  questionnaireTypeCode: string;
+
+  @Property({ nullable: true })
+  @Index()
+  batchId?: string;
+
+  @Property({ nullable: true })
+  storageKey?: string;
+
+  @Property({ nullable: true, type: 'text' })
+  error?: string;
+
+  @Property({ nullable: true })
+  completedAt?: Date;
+}

--- a/src/migrations/.snapshot-faculytics_db.json
+++ b/src/migrations/.snapshot-faculytics_db.json
@@ -11,3400 +11,47 @@
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "action": {
-          "name": "action",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "actor_id": {
-          "name": "actor_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "actor_username": {
-          "name": "actor_username",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "resource_type": {
-          "name": "resource_type",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "resource_id": {
-          "name": "resource_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "mappedType": "json"
-        },
-        "browser_name": {
-          "name": "browser_name",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "os": {
-          "name": "os",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "ip_address": {
-          "name": "ip_address",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "occurred_at": {
-          "name": "occurred_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        }
-      },
-      "name": "audit_log",
-      "schema": "public",
-      "indexes": [
-        {
-          "columnNames": [
-            "action"
-          ],
-          "composite": false,
-          "keyName": "audit_log_action_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "columnNames": [
-            "actor_id"
-          ],
-          "composite": false,
-          "keyName": "audit_log_actor_id_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "columnNames": [
-            "occurred_at"
-          ],
-          "composite": false,
-          "keyName": "audit_log_occurred_at_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "audit_log_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
           "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {},
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
           "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "moodle_category_id": {
-          "name": "moodle_category_id",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "integer"
-        },
-        "code": {
-          "name": "code",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        }
-      },
-      "name": "campus",
-      "schema": "public",
-      "indexes": [
-        {
-          "columnNames": [
-            "moodle_category_id"
-          ],
-          "composite": false,
-          "keyName": "campus_moodle_category_id_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "columnNames": [
-            "moodle_category_id"
-          ],
-          "composite": false,
-          "keyName": "campus_moodle_category_id_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "campus_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {},
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "moodle_category_id": {
-          "name": "moodle_category_id",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "integer"
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "description": {
-          "name": "description",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "parent_moodle_category_id": {
-          "name": "parent_moodle_category_id",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "integer"
-        },
-        "depth": {
-          "name": "depth",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "integer"
-        },
-        "path": {
-          "name": "path",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "sort_order": {
-          "name": "sort_order",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "integer"
-        },
-        "is_visible": {
-          "name": "is_visible",
-          "type": "boolean",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "boolean"
-        },
-        "time_modified": {
-          "name": "time_modified",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        }
-      },
-      "name": "moodle_category",
-      "schema": "public",
-      "indexes": [
-        {
-          "columnNames": [
-            "moodle_category_id"
-          ],
-          "composite": false,
-          "keyName": "moodle_category_moodle_category_id_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "columnNames": [
-            "moodle_category_id"
-          ],
-          "composite": false,
-          "keyName": "moodle_category_moodle_category_id_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "moodle_category_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {},
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "code": {
-          "name": "code",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "description": {
-          "name": "description",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "is_system": {
-          "name": "is_system",
-          "type": "boolean",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "default": "false",
-          "mappedType": "boolean"
-        }
-      },
-      "name": "questionnaire_type",
-      "schema": "public",
-      "indexes": [
-        {
-          "columnNames": [
-            "code"
-          ],
-          "composite": false,
-          "keyName": "questionnaire_type_code_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "questionnaire_type_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {},
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "title": {
-          "name": "title",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "default": "'DRAFT'",
-          "enumItems": [
-            "DRAFT",
-            "ACTIVE",
-            "DEPRECATED",
-            "ARCHIVED"
-          ],
-          "mappedType": "enum"
-        },
-        "type_id": {
-          "name": "type_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        }
-      },
-      "name": "questionnaire",
-      "schema": "public",
-      "indexes": [
-        {
-          "keyName": "questionnaire_type_id_unique",
-          "columnNames": [
-            "type_id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "questionnaire_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "questionnaire_type_id_foreign": {
-          "constraintName": "questionnaire_type_id_foreign",
-          "columnNames": [
-            "type_id"
-          ],
-          "localTableName": "public.questionnaire",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.questionnaire_type",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "code": {
-          "name": "code",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "display_name": {
-          "name": "display_name",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "questionnaire_type_id": {
-          "name": "questionnaire_type_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "active": {
-          "name": "active",
-          "type": "boolean",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "default": "true",
-          "mappedType": "boolean"
-        }
-      },
-      "name": "dimension",
-      "schema": "public",
-      "indexes": [
-        {
-          "columnNames": [
-            "code"
-          ],
-          "composite": false,
-          "keyName": "dimension_code_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "dimension_code_questionnaire_type_id_unique",
-          "columnNames": [
-            "code",
-            "questionnaire_type_id"
-          ],
-          "composite": true,
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "dimension_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "dimension_questionnaire_type_id_foreign": {
-          "constraintName": "dimension_questionnaire_type_id_foreign",
-          "columnNames": [
-            "questionnaire_type_id"
-          ],
-          "localTableName": "public.dimension",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.questionnaire_type",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "questionnaire_id": {
-          "name": "questionnaire_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "version_number": {
-          "name": "version_number",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "integer"
-        },
-        "schema_snapshot": {
-          "name": "schema_snapshot",
-          "type": "jsonb",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "json"
-        },
-        "published_at": {
-          "name": "published_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "is_active": {
-          "name": "is_active",
-          "type": "boolean",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "default": "false",
-          "mappedType": "boolean"
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "default": "'DRAFT'",
-          "enumItems": [
-            "DRAFT",
-            "ACTIVE",
-            "DEPRECATED",
-            "ARCHIVED"
-          ],
-          "mappedType": "enum"
-        }
-      },
-      "name": "questionnaire_version",
-      "schema": "public",
-      "indexes": [
-        {
-          "keyName": "questionnaire_version_questionnaire_id_version_number_unique",
-          "columnNames": [
-            "questionnaire_id",
-            "version_number"
-          ],
-          "composite": true,
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "questionnaire_version_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "questionnaire_version_questionnaire_id_foreign": {
-          "constraintName": "questionnaire_version_questionnaire_id_foreign",
-          "columnNames": [
-            "questionnaire_id"
-          ],
-          "localTableName": "public.questionnaire_version",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.questionnaire",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "token_hash": {
-          "name": "token_hash",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "revoked_at": {
-          "name": "revoked_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "replaced_by_token_id": {
-          "name": "replaced_by_token_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "is_active": {
-          "name": "is_active",
-          "type": "boolean",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "boolean"
-        },
-        "browser_name": {
-          "name": "browser_name",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "os": {
-          "name": "os",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "ip_address": {
-          "name": "ip_address",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        }
-      },
-      "name": "refresh_token",
-      "schema": "public",
-      "indexes": [
-        {
-          "keyName": "refresh_token_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {},
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "moodle_category_id": {
-          "name": "moodle_category_id",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "integer"
-        },
-        "code": {
-          "name": "code",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "label": {
-          "name": "label",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "academic_year": {
-          "name": "academic_year",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "campus_id": {
-          "name": "campus_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "description": {
-          "name": "description",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        }
-      },
-      "name": "semester",
-      "schema": "public",
-      "indexes": [
-        {
-          "columnNames": [
-            "moodle_category_id"
-          ],
-          "composite": false,
-          "keyName": "semester_moodle_category_id_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "columnNames": [
-            "moodle_category_id"
-          ],
-          "composite": false,
-          "keyName": "semester_moodle_category_id_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "semester_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "semester_campus_id_foreign": {
-          "constraintName": "semester_campus_id_foreign",
-          "columnNames": [
-            "campus_id"
-          ],
-          "localTableName": "public.semester",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.campus",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "moodle_category_id": {
-          "name": "moodle_category_id",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "integer"
-        },
-        "code": {
-          "name": "code",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "semester_id": {
-          "name": "semester_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        }
-      },
-      "name": "department",
-      "schema": "public",
-      "indexes": [
-        {
-          "columnNames": [
-            "moodle_category_id"
-          ],
-          "composite": false,
-          "keyName": "department_moodle_category_id_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "columnNames": [
-            "moodle_category_id"
-          ],
-          "composite": false,
-          "keyName": "department_moodle_category_id_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "department_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "department_semester_id_foreign": {
-          "constraintName": "department_semester_id_foreign",
-          "columnNames": [
-            "semester_id"
-          ],
-          "localTableName": "public.department",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.semester",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "moodle_category_id": {
-          "name": "moodle_category_id",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "integer"
-        },
-        "code": {
-          "name": "code",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "department_id": {
-          "name": "department_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        }
-      },
-      "name": "program",
-      "schema": "public",
-      "indexes": [
-        {
-          "columnNames": [
-            "moodle_category_id"
-          ],
-          "composite": false,
-          "keyName": "program_moodle_category_id_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "columnNames": [
-            "moodle_category_id"
-          ],
-          "composite": false,
-          "keyName": "program_moodle_category_id_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "program_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "program_department_id_foreign": {
-          "constraintName": "program_department_id_foreign",
-          "columnNames": [
-            "department_id"
-          ],
-          "localTableName": "public.program",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.department",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "moodle_course_id": {
-          "name": "moodle_course_id",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "integer"
-        },
-        "shortname": {
-          "name": "shortname",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "fullname": {
-          "name": "fullname",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "program_id": {
-          "name": "program_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "start_date": {
-          "name": "start_date",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "end_date": {
-          "name": "end_date",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "is_visible": {
-          "name": "is_visible",
-          "type": "boolean",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "boolean"
-        },
-        "time_modified": {
-          "name": "time_modified",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "is_active": {
-          "name": "is_active",
-          "type": "boolean",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "default": "true",
-          "mappedType": "boolean"
-        },
-        "course_image": {
-          "name": "course_image",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        }
-      },
-      "name": "course",
-      "schema": "public",
-      "indexes": [
-        {
-          "columnNames": [
-            "moodle_course_id"
-          ],
-          "composite": false,
-          "keyName": "course_moodle_course_id_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "columnNames": [
-            "moodle_course_id"
-          ],
-          "composite": false,
-          "keyName": "course_moodle_course_id_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "course_moodle_course_id_unique",
-          "columnNames": [
-            "moodle_course_id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "course_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "course_program_id_foreign": {
-          "constraintName": "course_program_id_foreign",
-          "columnNames": [
-            "program_id"
-          ],
-          "localTableName": "public.course",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.program",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "moodle_group_id": {
-          "name": "moodle_group_id",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "integer"
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "description": {
-          "name": "description",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "course_id": {
-          "name": "course_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        }
-      },
-      "name": "section",
-      "schema": "public",
-      "indexes": [
-        {
-          "columnNames": [
-            "moodle_group_id"
-          ],
-          "composite": false,
-          "keyName": "section_moodle_group_id_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "columnNames": [
-            "moodle_group_id"
-          ],
-          "composite": false,
-          "keyName": "section_moodle_group_id_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "columnNames": [
-            "course_id"
-          ],
-          "composite": false,
-          "keyName": "section_course_id_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "section_moodle_group_id_unique",
-          "columnNames": [
-            "moodle_group_id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "section_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "section_course_id_foreign": {
-          "constraintName": "section_course_id_foreign",
-          "columnNames": [
-            "course_id"
-          ],
-          "localTableName": "public.section",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.course",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "key": {
-          "name": "key",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "value": {
-          "name": "value",
-          "type": "text",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "text"
-        },
-        "description": {
-          "name": "description",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        }
-      },
-      "name": "system_config",
-      "schema": "public",
-      "indexes": [
-        {
-          "columnNames": [
-            "key"
-          ],
-          "composite": false,
-          "keyName": "system_config_key_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "system_config_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {},
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "user_name": {
-          "name": "user_name",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "moodle_user_id": {
-          "name": "moodle_user_id",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "mappedType": "integer"
-        },
-        "password": {
-          "name": "password",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "first_name": {
-          "name": "first_name",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "last_name": {
-          "name": "last_name",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "user_profile_picture": {
-          "name": "user_profile_picture",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "full_name": {
-          "name": "full_name",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "campus_id": {
-          "name": "campus_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "department_id": {
-          "name": "department_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "program_id": {
-          "name": "program_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "last_login_at": {
-          "name": "last_login_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "is_active": {
-          "name": "is_active",
-          "type": "boolean",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "boolean"
-        },
-        "roles": {
-          "name": "roles",
-          "type": "text[]",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "default": "'{}'",
-          "mappedType": "array"
-        }
-      },
-      "name": "user",
-      "schema": "public",
-      "indexes": [
-        {
-          "columnNames": [
-            "user_name"
-          ],
-          "composite": false,
-          "keyName": "user_user_name_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "columnNames": [
-            "moodle_user_id"
-          ],
-          "composite": false,
-          "keyName": "user_moodle_user_id_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "user_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "user_campus_id_foreign": {
-          "constraintName": "user_campus_id_foreign",
-          "columnNames": [
-            "campus_id"
-          ],
-          "localTableName": "public.user",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.campus",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
-        },
-        "user_department_id_foreign": {
-          "constraintName": "user_department_id_foreign",
-          "columnNames": [
-            "department_id"
-          ],
-          "localTableName": "public.user",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.department",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
-        },
-        "user_program_id_foreign": {
-          "constraintName": "user_program_id_foreign",
-          "columnNames": [
-            "program_id"
-          ],
-          "localTableName": "public.user",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.program",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "trigger": {
-          "name": "trigger",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "triggered_by_id": {
-          "name": "triggered_by_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "status": {
-          "name": "status",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "default": "'running'",
-          "mappedType": "string"
-        },
-        "started_at": {
-          "name": "started_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "completed_at": {
-          "name": "completed_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "duration_ms": {
-          "name": "duration_ms",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "mappedType": "integer"
-        },
-        "categories": {
-          "name": "categories",
-          "type": "jsonb",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "mappedType": "json"
-        },
-        "courses": {
-          "name": "courses",
-          "type": "jsonb",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "mappedType": "json"
-        },
-        "enrollments": {
-          "name": "enrollments",
-          "type": "jsonb",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "mappedType": "json"
-        },
-        "error_message": {
-          "name": "error_message",
-          "type": "text",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "mappedType": "text"
-        },
-        "job_id": {
-          "name": "job_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "cron_expression": {
-          "name": "cron_expression",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        }
-      },
-      "name": "sync_log",
-      "schema": "public",
-      "indexes": [
-        {
-          "columnNames": [
-            "started_at"
-          ],
-          "composite": false,
-          "keyName": "sync_log_started_at_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "sync_log_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "sync_log_triggered_by_id_foreign": {
-          "constraintName": "sync_log_triggered_by_id_foreign",
-          "columnNames": [
-            "triggered_by_id"
-          ],
-          "localTableName": "public.sync_log",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.user",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "questionnaire_version_id": {
-          "name": "questionnaire_version_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "respondent_id": {
-          "name": "respondent_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "faculty_id": {
-          "name": "faculty_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "respondent_role": {
-          "name": "respondent_role",
-          "type": "text",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "enumItems": [
-            "STUDENT",
-            "DEAN",
-            "CHAIRPERSON"
-          ],
-          "mappedType": "enum"
-        },
-        "semester_id": {
-          "name": "semester_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "course_id": {
-          "name": "course_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "department_id": {
-          "name": "department_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "program_id": {
-          "name": "program_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "campus_id": {
-          "name": "campus_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "total_score": {
-          "name": "total_score",
-          "type": "numeric(10,2)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "precision": 10,
-          "scale": 2,
-          "mappedType": "decimal"
-        },
-        "normalized_score": {
-          "name": "normalized_score",
-          "type": "numeric(10,2)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "precision": 10,
-          "scale": 2,
-          "mappedType": "decimal"
-        },
-        "qualitative_comment": {
-          "name": "qualitative_comment",
-          "type": "text",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "mappedType": "text"
-        },
-        "cleaned_comment": {
-          "name": "cleaned_comment",
-          "type": "text",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "mappedType": "text"
-        },
-        "submitted_at": {
-          "name": "submitted_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "default": "now()",
-          "mappedType": "datetime"
-        },
-        "faculty_name_snapshot": {
-          "name": "faculty_name_snapshot",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "faculty_employee_number_snapshot": {
-          "name": "faculty_employee_number_snapshot",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "department_code_snapshot": {
-          "name": "department_code_snapshot",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "department_name_snapshot": {
-          "name": "department_name_snapshot",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "program_code_snapshot": {
-          "name": "program_code_snapshot",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "program_name_snapshot": {
-          "name": "program_name_snapshot",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "campus_code_snapshot": {
-          "name": "campus_code_snapshot",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "campus_name_snapshot": {
-          "name": "campus_name_snapshot",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "course_code_snapshot": {
-          "name": "course_code_snapshot",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "course_title_snapshot": {
-          "name": "course_title_snapshot",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "semester_code_snapshot": {
-          "name": "semester_code_snapshot",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "semester_label_snapshot": {
-          "name": "semester_label_snapshot",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "academic_year_snapshot": {
-          "name": "academic_year_snapshot",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        }
-      },
-      "name": "questionnaire_submission",
-      "schema": "public",
-      "indexes": [
-        {
-          "keyName": "questionnaire_submission_questionnaire_version_id_index",
-          "columnNames": [
-            "questionnaire_version_id"
-          ],
-          "composite": false,
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "questionnaire_submission_campus_id_semester_id_index",
-          "columnNames": [
-            "campus_id",
-            "semester_id"
-          ],
-          "composite": true,
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "questionnaire_submission_program_id_semester_id_index",
-          "columnNames": [
-            "program_id",
-            "semester_id"
-          ],
-          "composite": true,
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "questionnaire_submission_department_id_semester_id_index",
-          "columnNames": [
-            "department_id",
-            "semester_id"
-          ],
-          "composite": true,
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "questionnaire_submission_faculty_id_semester_id_index",
-          "columnNames": [
-            "faculty_id",
-            "semester_id"
-          ],
-          "composite": true,
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "questionnaire_submission_respondent_id_faculty_id_46f83_unique",
-          "columnNames": [
-            "respondent_id",
-            "faculty_id",
-            "questionnaire_version_id",
-            "semester_id",
-            "course_id"
-          ],
-          "composite": true,
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "questionnaire_submission_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "questionnaire_submission_questionnaire_version_id_foreign": {
-          "constraintName": "questionnaire_submission_questionnaire_version_id_foreign",
-          "columnNames": [
-            "questionnaire_version_id"
-          ],
-          "localTableName": "public.questionnaire_submission",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.questionnaire_version",
-          "updateRule": "cascade"
-        },
-        "questionnaire_submission_respondent_id_foreign": {
-          "constraintName": "questionnaire_submission_respondent_id_foreign",
-          "columnNames": [
-            "respondent_id"
-          ],
-          "localTableName": "public.questionnaire_submission",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.user",
-          "updateRule": "cascade"
-        },
-        "questionnaire_submission_faculty_id_foreign": {
-          "constraintName": "questionnaire_submission_faculty_id_foreign",
-          "columnNames": [
-            "faculty_id"
-          ],
-          "localTableName": "public.questionnaire_submission",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.user",
-          "updateRule": "cascade"
-        },
-        "questionnaire_submission_semester_id_foreign": {
-          "constraintName": "questionnaire_submission_semester_id_foreign",
-          "columnNames": [
-            "semester_id"
-          ],
-          "localTableName": "public.questionnaire_submission",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.semester",
-          "updateRule": "cascade"
-        },
-        "questionnaire_submission_course_id_foreign": {
-          "constraintName": "questionnaire_submission_course_id_foreign",
-          "columnNames": [
-            "course_id"
-          ],
-          "localTableName": "public.questionnaire_submission",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.course",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
-        },
-        "questionnaire_submission_department_id_foreign": {
-          "constraintName": "questionnaire_submission_department_id_foreign",
-          "columnNames": [
-            "department_id"
-          ],
-          "localTableName": "public.questionnaire_submission",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.department",
-          "updateRule": "cascade"
-        },
-        "questionnaire_submission_program_id_foreign": {
-          "constraintName": "questionnaire_submission_program_id_foreign",
-          "columnNames": [
-            "program_id"
-          ],
-          "localTableName": "public.questionnaire_submission",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.program",
-          "updateRule": "cascade"
-        },
-        "questionnaire_submission_campus_id_foreign": {
-          "constraintName": "questionnaire_submission_campus_id_foreign",
-          "columnNames": [
-            "campus_id"
-          ],
-          "localTableName": "public.questionnaire_submission",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.campus",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "submission_id": {
-          "name": "submission_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "embedding": {
-          "name": "embedding",
-          "type": "vector",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 768,
-          "mappedType": "unknown"
-        },
-        "model_name": {
-          "name": "model_name",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        }
-      },
-      "name": "submission_embedding",
-      "schema": "public",
-      "indexes": [
-        {
-          "keyName": "submission_embedding_submission_id_index",
-          "columnNames": [
-            "submission_id"
-          ],
-          "composite": false,
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "submission_embedding_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "submission_embedding_submission_id_foreign": {
-          "constraintName": "submission_embedding_submission_id_foreign",
-          "columnNames": [
-            "submission_id"
-          ],
-          "localTableName": "public.submission_embedding",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.questionnaire_submission",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "submission_id": {
-          "name": "submission_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "question_id": {
-          "name": "question_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "section_id": {
-          "name": "section_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "dimension_code": {
-          "name": "dimension_code",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "numeric_value": {
-          "name": "numeric_value",
-          "type": "numeric(10,2)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "precision": 10,
-          "scale": 2,
-          "mappedType": "decimal"
-        }
-      },
-      "name": "questionnaire_answer",
-      "schema": "public",
-      "indexes": [
-        {
-          "keyName": "questionnaire_answer_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "questionnaire_answer_submission_id_foreign": {
-          "constraintName": "questionnaire_answer_submission_id_foreign",
-          "columnNames": [
-            "submission_id"
-          ],
-          "localTableName": "public.questionnaire_answer",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.questionnaire_submission",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "respondent_id": {
-          "name": "respondent_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "questionnaire_version_id": {
-          "name": "questionnaire_version_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "faculty_id": {
-          "name": "faculty_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "semester_id": {
-          "name": "semester_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "course_id": {
-          "name": "course_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "answers": {
-          "name": "answers",
-          "type": "jsonb",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "json"
-        },
-        "qualitative_comment": {
-          "name": "qualitative_comment",
-          "type": "text",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "mappedType": "text"
-        }
-      },
-      "name": "questionnaire_draft",
-      "schema": "public",
-      "indexes": [
-        {
-          "keyName": "questionnaire_draft_unique_active_without_course",
-          "columnNames": [
-            "respondent_id",
-            "questionnaire_version_id",
-            "faculty_id",
-            "semester_id"
-          ],
-          "composite": true,
-          "constraint": false,
-          "primary": false,
           "unique": false,
-          "options": {
-            "where": "deleted_at IS NULL AND course_id IS NULL"
-          }
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
         },
-        {
-          "keyName": "questionnaire_draft_unique_active_with_course",
-          "columnNames": [
-            "respondent_id",
-            "questionnaire_version_id",
-            "faculty_id",
-            "semester_id",
-            "course_id"
-          ],
-          "composite": true,
-          "constraint": false,
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
           "primary": false,
+          "nullable": false,
           "unique": false,
-          "options": {
-            "where": "deleted_at IS NULL AND course_id IS NOT NULL"
-          }
-        },
-        {
-          "keyName": "questionnaire_draft_respondent_id_updated_at_index",
-          "columnNames": [
-            "respondent_id",
-            "updated_at"
-          ],
-          "composite": true,
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "questionnaire_draft_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "questionnaire_draft_respondent_id_foreign": {
-          "constraintName": "questionnaire_draft_respondent_id_foreign",
-          "columnNames": [
-            "respondent_id"
-          ],
-          "localTableName": "public.questionnaire_draft",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.user",
-          "updateRule": "cascade"
-        },
-        "questionnaire_draft_questionnaire_version_id_foreign": {
-          "constraintName": "questionnaire_draft_questionnaire_version_id_foreign",
-          "columnNames": [
-            "questionnaire_version_id"
-          ],
-          "localTableName": "public.questionnaire_draft",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.questionnaire_version",
-          "updateRule": "cascade"
-        },
-        "questionnaire_draft_faculty_id_foreign": {
-          "constraintName": "questionnaire_draft_faculty_id_foreign",
-          "columnNames": [
-            "faculty_id"
-          ],
-          "localTableName": "public.questionnaire_draft",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.user",
-          "updateRule": "cascade"
-        },
-        "questionnaire_draft_semester_id_foreign": {
-          "constraintName": "questionnaire_draft_semester_id_foreign",
-          "columnNames": [
-            "semester_id"
-          ],
-          "localTableName": "public.questionnaire_draft",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.semester",
-          "updateRule": "cascade"
-        },
-        "questionnaire_draft_course_id_foreign": {
-          "constraintName": "questionnaire_draft_course_id_foreign",
-          "columnNames": [
-            "course_id"
-          ],
-          "localTableName": "public.questionnaire_draft",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.course",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "deleted_at": {
@@ -3414,557 +61,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 255,
-          "mappedType": "string"
-        },
-        "token": {
-          "name": "token",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "moodle_user_id": {
-          "name": "moodle_user_id",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "integer"
-        },
-        "last_validated_at": {
-          "name": "last_validated_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "invalidated_at": {
-          "name": "invalidated_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "is_valid": {
-          "name": "is_valid",
-          "type": "boolean",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "default": "true",
-          "mappedType": "boolean"
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        }
-      },
-      "name": "moodle_token",
-      "schema": "public",
-      "indexes": [
-        {
-          "columnNames": [
-            "moodle_user_id"
-          ],
-          "composite": false,
-          "keyName": "moodle_token_moodle_user_id_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "moodle_token_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "moodle_token_user_id_foreign": {
-          "constraintName": "moodle_token_user_id_foreign",
-          "columnNames": [
-            "user_id"
-          ],
-          "localTableName": "public.moodle_token",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.user",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "course_id": {
-          "name": "course_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "role": {
-          "name": "role",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "section_id": {
-          "name": "section_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "is_active": {
-          "name": "is_active",
-          "type": "boolean",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "default": "true",
-          "mappedType": "boolean"
-        },
-        "time_modified": {
-          "name": "time_modified",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        }
-      },
-      "name": "enrollment",
-      "schema": "public",
-      "indexes": [
-        {
-          "columnNames": [
-            "user_id"
-          ],
-          "composite": false,
-          "keyName": "enrollment_user_id_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "columnNames": [
-            "course_id"
-          ],
-          "composite": false,
-          "keyName": "enrollment_course_id_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "columnNames": [
-            "section_id"
-          ],
-          "composite": false,
-          "keyName": "enrollment_section_id_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "enrollment_user_id_course_id_unique",
-          "columnNames": [
-            "user_id",
-            "course_id"
-          ],
-          "composite": true,
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "enrollment_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "enrollment_user_id_foreign": {
-          "constraintName": "enrollment_user_id_foreign",
-          "columnNames": [
-            "user_id"
-          ],
-          "localTableName": "public.enrollment",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.user",
-          "updateRule": "cascade"
-        },
-        "enrollment_course_id_foreign": {
-          "constraintName": "enrollment_course_id_foreign",
-          "columnNames": [
-            "course_id"
-          ],
-          "localTableName": "public.enrollment",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.course",
-          "updateRule": "cascade"
-        },
-        "enrollment_section_id_foreign": {
-          "constraintName": "enrollment_section_id_foreign",
-          "columnNames": [
-            "section_id"
-          ],
-          "localTableName": "public.enrollment",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.section",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "title": {
-          "name": "title",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "status": {
-          "name": "status",
-          "type": "jsonb",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "json"
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "json"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        }
-      },
-      "name": "chatkit_thread",
-      "schema": "public",
-      "indexes": [
-        {
-          "keyName": "chatkit_thread_user_id_created_at_index",
-          "columnNames": [
-            "user_id",
-            "created_at"
-          ],
-          "composite": true,
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "chatkit_thread_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "chatkit_thread_user_id_foreign": {
-          "constraintName": "chatkit_thread_user_id_foreign",
-          "columnNames": [
-            "user_id"
-          ],
-          "localTableName": "public.chatkit_thread",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.user",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "thread_id": {
-          "name": "thread_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "type": {
-          "name": "type",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "payload": {
-          "name": "payload",
-          "type": "jsonb",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "json"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        }
-      },
-      "name": "chatkit_thread_item",
-      "schema": "public",
-      "indexes": [
-        {
-          "keyName": "chatkit_thread_item_thread_id_created_at_index",
-          "columnNames": [
-            "thread_id",
-            "created_at"
-          ],
-          "composite": true,
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "chatkit_thread_item_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "chatkit_thread_item_thread_id_foreign": {
-          "constraintName": "chatkit_thread_item_thread_id_foreign",
-          "columnNames": [
-            "thread_id"
-          ],
-          "localTableName": "public.chatkit_thread_item",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.chatkit_thread",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "semester_id": {
@@ -3974,7 +77,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "faculty_id": {
@@ -3984,7 +93,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "questionnaire_version_id": {
@@ -3994,7 +109,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "department_id": {
@@ -4004,7 +125,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "program_id": {
@@ -4014,7 +141,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "campus_id": {
@@ -4024,7 +157,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "course_id": {
@@ -4034,7 +173,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "triggered_by_id": {
@@ -4044,34 +189,61 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "total_enrolled": {
           "name": "total_enrolled",
-          "type": "int",
+          "type": "int4",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "integer"
         },
         "submission_count": {
           "name": "submission_count",
-          "type": "int",
+          "type": "int4",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "integer"
         },
         "comment_count": {
           "name": "comment_count",
-          "type": "int",
+          "type": "int4",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "integer"
         },
         "response_rate": {
@@ -4081,8 +253,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
           "precision": 10,
           "scale": 4,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "decimal"
         },
         "warnings": {
@@ -4092,24 +269,45 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "array"
         },
         "sentiment_gate_included": {
           "name": "sentiment_gate_included",
-          "type": "int",
+          "type": "int4",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "integer"
         },
         "sentiment_gate_excluded": {
           "name": "sentiment_gate_excluded",
-          "type": "int",
+          "type": "int4",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "integer"
         },
         "status": {
@@ -4119,7 +317,12 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
           "default": "'AWAITING_CONFIRMATION'",
+          "comment": null,
           "enumItems": [
             "AWAITING_CONFIRMATION",
             "EMBEDDING_CHECK",
@@ -4140,26 +343,45 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "text"
         },
         "confirmed_at": {
           "name": "confirmed_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "completed_at": {
           "name": "completed_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         }
       },
@@ -4167,133 +389,145 @@
       "schema": "public",
       "indexes": [
         {
-          "keyName": "analysis_pipeline_semester_id_status_index",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "analysis_pipeline_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
           "columnNames": [
             "semester_id",
             "status"
           ],
           "composite": true,
           "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "analysis_pipeline_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "keyName": "analysis_pipeline_semester_id_status_index",
+          "unique": false,
+          "primary": false
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "analysis_pipeline_semester_id_foreign": {
-          "constraintName": "analysis_pipeline_semester_id_foreign",
-          "columnNames": [
-            "semester_id"
-          ],
-          "localTableName": "public.analysis_pipeline",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.semester",
-          "updateRule": "cascade"
-        },
-        "analysis_pipeline_faculty_id_foreign": {
-          "constraintName": "analysis_pipeline_faculty_id_foreign",
-          "columnNames": [
-            "faculty_id"
-          ],
-          "localTableName": "public.analysis_pipeline",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.user",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
-        },
-        "analysis_pipeline_questionnaire_version_id_foreign": {
-          "constraintName": "analysis_pipeline_questionnaire_version_id_foreign",
-          "columnNames": [
-            "questionnaire_version_id"
-          ],
-          "localTableName": "public.analysis_pipeline",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.questionnaire_version",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
-        },
-        "analysis_pipeline_department_id_foreign": {
-          "constraintName": "analysis_pipeline_department_id_foreign",
-          "columnNames": [
-            "department_id"
-          ],
-          "localTableName": "public.analysis_pipeline",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.department",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
-        },
-        "analysis_pipeline_program_id_foreign": {
-          "constraintName": "analysis_pipeline_program_id_foreign",
-          "columnNames": [
-            "program_id"
-          ],
-          "localTableName": "public.analysis_pipeline",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.program",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
-        },
         "analysis_pipeline_campus_id_foreign": {
-          "constraintName": "analysis_pipeline_campus_id_foreign",
           "columnNames": [
             "campus_id"
           ],
+          "constraintName": "analysis_pipeline_campus_id_foreign",
           "localTableName": "public.analysis_pipeline",
+          "referencedTableName": "public.campus",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.campus",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "set null"
         },
         "analysis_pipeline_course_id_foreign": {
-          "constraintName": "analysis_pipeline_course_id_foreign",
           "columnNames": [
             "course_id"
           ],
+          "constraintName": "analysis_pipeline_course_id_foreign",
           "localTableName": "public.analysis_pipeline",
+          "referencedTableName": "public.course",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.course",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        },
+        "analysis_pipeline_department_id_foreign": {
+          "columnNames": [
+            "department_id"
+          ],
+          "constraintName": "analysis_pipeline_department_id_foreign",
+          "localTableName": "public.analysis_pipeline",
+          "referencedTableName": "public.department",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        },
+        "analysis_pipeline_faculty_id_foreign": {
+          "columnNames": [
+            "faculty_id"
+          ],
+          "constraintName": "analysis_pipeline_faculty_id_foreign",
+          "localTableName": "public.analysis_pipeline",
+          "referencedTableName": "public.user",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        },
+        "analysis_pipeline_program_id_foreign": {
+          "columnNames": [
+            "program_id"
+          ],
+          "constraintName": "analysis_pipeline_program_id_foreign",
+          "localTableName": "public.analysis_pipeline",
+          "referencedTableName": "public.program",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        },
+        "analysis_pipeline_questionnaire_version_id_foreign": {
+          "columnNames": [
+            "questionnaire_version_id"
+          ],
+          "constraintName": "analysis_pipeline_questionnaire_version_id_foreign",
+          "localTableName": "public.analysis_pipeline",
+          "referencedTableName": "public.questionnaire_version",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        },
+        "analysis_pipeline_semester_id_foreign": {
+          "columnNames": [
+            "semester_id"
+          ],
+          "constraintName": "analysis_pipeline_semester_id_foreign",
+          "localTableName": "public.analysis_pipeline",
+          "referencedTableName": "public.semester",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
         },
         "analysis_pipeline_triggered_by_id_foreign": {
-          "constraintName": "analysis_pipeline_triggered_by_id_foreign",
           "columnNames": [
             "triggered_by_id"
           ],
+          "constraintName": "analysis_pipeline_triggered_by_id_foreign",
           "localTableName": "public.analysis_pipeline",
-          "referencedColumnNames": [
-            "id"
-          ],
           "referencedTableName": "public.user",
-          "updateRule": "cascade"
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
         }
       },
-      "nativeEnums": {}
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
     },
     {
       "columns": {
@@ -4302,29 +536,284 @@
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "actor_username": {
+          "name": "actor_username",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "json"
+        },
+        "browser_name": {
+          "name": "browser_name",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "os": {
+          "name": "os",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": "now()",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        }
+      },
+      "name": "audit_log",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "action"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "audit_log_action_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "actor_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "audit_log_actor_id_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "occurred_at"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "audit_log_occurred_at_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "audit_log_pkey",
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {},
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "deleted_at": {
@@ -4334,153 +823,279 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
-        "pipeline_id": {
-          "name": "pipeline_id",
+        "moodle_category_id": {
+          "name": "moodle_category_id",
+          "type": "int4",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "code": {
+          "name": "code",
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
-        "submission_count": {
-          "name": "submission_count",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "integer"
-        },
-        "topic_count": {
-          "name": "topic_count",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "default": "0",
-          "mappedType": "integer"
-        },
-        "outlier_count": {
-          "name": "outlier_count",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "default": "0",
-          "mappedType": "integer"
-        },
-        "model_params": {
-          "name": "model_params",
-          "type": "jsonb",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "mappedType": "json"
-        },
-        "metrics": {
-          "name": "metrics",
-          "type": "jsonb",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "mappedType": "json"
-        },
-        "worker_version": {
-          "name": "worker_version",
+        "name": {
+          "name": "name",
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        }
+      },
+      "name": "campus",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "moodle_category_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "campus_moodle_category_id_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "moodle_category_id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "campus_moodle_category_id_unique",
+          "unique": true,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "campus_pkey",
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {},
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
-        "job_id": {
-          "name": "job_id",
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "title": {
+          "name": "title",
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "status": {
           "name": "status",
-          "type": "text",
+          "type": "jsonb",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "default": "'PENDING'",
-          "enumItems": [
-            "PENDING",
-            "PROCESSING",
-            "COMPLETED",
-            "FAILED"
-          ],
-          "mappedType": "enum"
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "json"
         },
-        "completed_at": {
-          "name": "completed_at",
-          "type": "timestamptz",
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
-          "nullable": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         }
       },
-      "name": "topic_model_run",
+      "name": "chatkit_thread",
       "schema": "public",
       "indexes": [
         {
-          "keyName": "topic_model_run_pipeline_id_index",
-          "columnNames": [
-            "pipeline_id"
-          ],
-          "composite": false,
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "topic_model_run_pkey",
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "chatkit_thread_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
+          "columnNames": [
+            "user_id",
+            "created_at"
+          ],
+          "composite": true,
+          "constraint": false,
+          "keyName": "chatkit_thread_user_id_created_at_index",
+          "unique": false,
+          "primary": false
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "topic_model_run_pipeline_id_foreign": {
-          "constraintName": "topic_model_run_pipeline_id_foreign",
+        "chatkit_thread_user_id_foreign": {
           "columnNames": [
-            "pipeline_id"
+            "user_id"
           ],
-          "localTableName": "public.topic_model_run",
+          "constraintName": "chatkit_thread_user_id_foreign",
+          "localTableName": "public.chatkit_thread",
+          "referencedTableName": "public.user",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.analysis_pipeline",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "no action"
         }
       },
-      "nativeEnums": {}
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
     },
     {
       "columns": {
@@ -4489,29 +1104,183 @@
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        }
+      },
+      "name": "chatkit_thread_item",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "chatkit_thread_item_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
+          "columnNames": [
+            "thread_id",
+            "created_at"
+          ],
+          "composite": true,
+          "constraint": false,
+          "keyName": "chatkit_thread_item_thread_id_created_at_index",
+          "unique": false,
+          "primary": false
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "chatkit_thread_item_thread_id_foreign": {
+          "columnNames": [
+            "thread_id"
+          ],
+          "constraintName": "chatkit_thread_item_thread_id_foreign",
+          "localTableName": "public.chatkit_thread_item",
+          "referencedTableName": "public.chatkit_thread",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        }
+      },
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "deleted_at": {
@@ -4521,253 +1290,237 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
-        "run_id": {
-          "name": "run_id",
-          "type": "varchar(255)",
+        "moodle_course_id": {
+          "name": "moodle_course_id",
+          "type": "int4",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "topic_index": {
-          "name": "topic_index",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
+          "unique": true,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "integer"
         },
-        "raw_label": {
-          "name": "raw_label",
+        "shortname": {
+          "name": "shortname",
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
-        "label": {
-          "name": "label",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "keywords": {
-          "name": "keywords",
-          "type": "text[]",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "array"
-        },
-        "doc_count": {
-          "name": "doc_count",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "integer"
-        }
-      },
-      "name": "topic",
-      "schema": "public",
-      "indexes": [
-        {
-          "keyName": "topic_run_id_index",
-          "columnNames": [
-            "run_id"
-          ],
-          "composite": false,
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "topic_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "topic_run_id_foreign": {
-          "constraintName": "topic_run_id_foreign",
-          "columnNames": [
-            "run_id"
-          ],
-          "localTableName": "public.topic",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.topic_model_run",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
+        "fullname": {
+          "name": "fullname",
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz",
+        "program_id": {
+          "name": "program_id",
+          "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamptz",
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "topic_id": {
-          "name": "topic_id",
-          "type": "varchar(255)",
+        "is_visible": {
+          "name": "is_visible",
+          "type": "bool",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "submission_id": {
-          "name": "submission_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "probability": {
-          "name": "probability",
-          "type": "numeric(10,4)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "precision": 10,
-          "scale": 4,
-          "mappedType": "decimal"
-        },
-        "is_dominant": {
-          "name": "is_dominant",
-          "type": "boolean",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "boolean"
+        },
+        "time_modified": {
+          "name": "time_modified",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "bool",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "true",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
+        },
+        "course_image": {
+          "name": "course_image",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
         }
       },
-      "name": "topic_assignment",
+      "name": "course",
       "schema": "public",
       "indexes": [
         {
-          "keyName": "topic_assignment_submission_id_index",
           "columnNames": [
-            "submission_id"
+            "moodle_course_id"
           ],
           "composite": false,
           "constraint": false,
-          "primary": false,
-          "unique": false
+          "keyName": "course_moodle_course_id_index",
+          "unique": false,
+          "primary": false
         },
         {
-          "keyName": "topic_assignment_topic_id_index",
           "columnNames": [
-            "topic_id"
+            "moodle_course_id"
           ],
           "composite": false,
-          "constraint": false,
-          "primary": false,
-          "unique": false
+          "constraint": true,
+          "keyName": "course_moodle_course_id_unique",
+          "unique": true,
+          "primary": false
         },
         {
-          "keyName": "topic_assignment_pkey",
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "course_pkey",
+          "unique": true,
+          "primary": true
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "topic_assignment_topic_id_foreign": {
-          "constraintName": "topic_assignment_topic_id_foreign",
+        "course_program_id_foreign": {
           "columnNames": [
-            "topic_id"
+            "program_id"
           ],
-          "localTableName": "public.topic_assignment",
+          "constraintName": "course_program_id_foreign",
+          "localTableName": "public.course",
+          "referencedTableName": "public.program",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.topic",
-          "updateRule": "cascade"
-        },
-        "topic_assignment_submission_id_foreign": {
-          "constraintName": "topic_assignment_submission_id_foreign",
-          "columnNames": [
-            "submission_id"
-          ],
-          "localTableName": "public.topic_assignment",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.questionnaire_submission",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "no action"
         }
       },
-      "nativeEnums": {}
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
     },
     {
       "columns": {
@@ -4776,29 +1529,47 @@
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
-          "primary": false,
+          "primary": true,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "deleted_at": {
@@ -4808,46 +1579,1434 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
-        "pipeline_id": {
-          "name": "pipeline_id",
-          "type": "varchar(255)",
+        "moodle_category_id": {
+          "name": "moodle_category_id",
+          "type": "int4",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "length": 255,
-          "mappedType": "string"
-        },
-        "submission_count": {
-          "name": "submission_count",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
+          "unique": true,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "integer"
         },
-        "worker_version": {
-          "name": "worker_version",
+        "code": {
+          "name": "code",
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
-          "nullable": true,
+          "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
-        "job_id": {
-          "name": "job_id",
+        "name": {
+          "name": "name",
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "semester_id": {
+          "name": "semester_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        }
+      },
+      "name": "department",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "moodle_category_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "department_moodle_category_id_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "moodle_category_id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "department_moodle_category_id_unique",
+          "unique": true,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "department_pkey",
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "department_semester_id_foreign": {
+          "columnNames": [
+            "semester_id"
+          ],
+          "constraintName": "department_semester_id_foreign",
+          "localTableName": "public.department",
+          "referencedTableName": "public.semester",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        }
+      },
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "active": {
+          "name": "active",
+          "type": "bool",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "true",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
+        },
+        "questionnaire_type_id": {
+          "name": "questionnaire_type_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        }
+      },
+      "name": "dimension",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "code"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "dimension_code_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "code",
+            "questionnaire_type_id"
+          ],
+          "composite": true,
+          "constraint": true,
+          "keyName": "dimension_code_questionnaire_type_id_unique",
+          "unique": true,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "dimension_pkey",
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "dimension_questionnaire_type_id_foreign": {
+          "columnNames": [
+            "questionnaire_type_id"
+          ],
+          "constraintName": "dimension_questionnaire_type_id_foreign",
+          "localTableName": "public.dimension",
+          "referencedTableName": "public.questionnaire_type",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        }
+      },
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "bool",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "true",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
+        },
+        "time_modified": {
+          "name": "time_modified",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        }
+      },
+      "name": "enrollment",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "course_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "enrollment_course_id_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "enrollment_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
+          "columnNames": [
+            "section_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "enrollment_section_id_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "user_id",
+            "course_id"
+          ],
+          "composite": true,
+          "constraint": true,
+          "keyName": "enrollment_user_id_course_id_unique",
+          "unique": true,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "user_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "enrollment_user_id_index",
+          "unique": false,
+          "primary": false
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "enrollment_course_id_foreign": {
+          "columnNames": [
+            "course_id"
+          ],
+          "constraintName": "enrollment_course_id_foreign",
+          "localTableName": "public.enrollment",
+          "referencedTableName": "public.course",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        },
+        "enrollment_section_id_foreign": {
+          "columnNames": [
+            "section_id"
+          ],
+          "constraintName": "enrollment_section_id_foreign",
+          "localTableName": "public.enrollment",
+          "referencedTableName": "public.section",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        },
+        "enrollment_user_id_foreign": {
+          "columnNames": [
+            "user_id"
+          ],
+          "constraintName": "enrollment_user_id_foreign",
+          "localTableName": "public.enrollment",
+          "referencedTableName": "public.user",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        }
+      },
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "moodle_category_id": {
+          "name": "moodle_category_id",
+          "type": "int4",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "parent_moodle_category_id": {
+          "name": "parent_moodle_category_id",
+          "type": "int4",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "depth": {
+          "name": "depth",
+          "type": "int4",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "int4",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "is_visible": {
+          "name": "is_visible",
+          "type": "bool",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
+        },
+        "time_modified": {
+          "name": "time_modified",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        }
+      },
+      "name": "moodle_category",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "moodle_category_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "moodle_category_moodle_category_id_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "moodle_category_id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "moodle_category_moodle_category_id_unique",
+          "unique": true,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "moodle_category_pkey",
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {},
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "moodle_user_id": {
+          "name": "moodle_user_id",
+          "type": "int4",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "invalidated_at": {
+          "name": "invalidated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "is_valid": {
+          "name": "is_valid",
+          "type": "bool",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "true",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        }
+      },
+      "name": "moodle_token",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "moodle_user_id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "moodle_token_moodle_user_id_unique",
+          "unique": true,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "moodle_token_pkey",
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "moodle_token_user_id_foreign": {
+          "columnNames": [
+            "user_id"
+          ],
+          "constraintName": "moodle_token_user_id_foreign",
+          "localTableName": "public.moodle_token",
+          "referencedTableName": "public.user",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        }
+      },
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int4",
+          "unsigned": true,
+          "autoincrement": true,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "value": {
+          "name": "value",
+          "type": "float4",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": 24,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "float"
+        }
+      },
+      "name": "playing_with_neon",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "playing_with_neon_pkey",
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {},
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "moodle_category_id": {
+          "name": "moodle_category_id",
+          "type": "int4",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "department_id": {
+          "name": "department_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        }
+      },
+      "name": "program",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "moodle_category_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "program_moodle_category_id_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "moodle_category_id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "program_moodle_category_id_unique",
+          "unique": true,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "program_pkey",
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "program_department_id_foreign": {
+          "columnNames": [
+            "department_id"
+          ],
+          "constraintName": "program_department_id_foreign",
+          "localTableName": "public.program",
+          "referencedTableName": "public.department",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        }
+      },
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "status": {
@@ -4857,66 +3016,88 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "default": "'PENDING'",
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "'DRAFT'",
+          "comment": null,
           "enumItems": [
-            "PENDING",
-            "PROCESSING",
-            "COMPLETED",
-            "FAILED"
+            "DRAFT",
+            "ACTIVE",
+            "DEPRECATED",
+            "ARCHIVED"
           ],
           "mappedType": "enum"
         },
-        "completed_at": {
-          "name": "completed_at",
-          "type": "timestamptz",
+        "type_id": {
+          "name": "type_id",
+          "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
-          "nullable": true,
-          "length": 6,
-          "mappedType": "datetime"
+          "nullable": false,
+          "unique": true,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
         }
       },
-      "name": "sentiment_run",
+      "name": "questionnaire",
       "schema": "public",
       "indexes": [
         {
-          "keyName": "sentiment_run_pipeline_id_index",
-          "columnNames": [
-            "pipeline_id"
-          ],
-          "composite": false,
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "sentiment_run_pkey",
           "columnNames": [
             "id"
           ],
           "composite": false,
+          "constraint": false,
+          "keyName": "questionnaire_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
+          "columnNames": [
+            "type_id"
+          ],
+          "composite": false,
           "constraint": true,
-          "primary": true,
-          "unique": true
+          "keyName": "questionnaire_type_id_unique",
+          "unique": true,
+          "primary": false
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "sentiment_run_pipeline_id_foreign": {
-          "constraintName": "sentiment_run_pipeline_id_foreign",
+        "questionnaire_type_id_foreign": {
           "columnNames": [
-            "pipeline_id"
+            "type_id"
           ],
-          "localTableName": "public.sentiment_run",
+          "constraintName": "questionnaire_type_id_foreign",
+          "localTableName": "public.questionnaire",
+          "referencedTableName": "public.questionnaire_type",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.analysis_pipeline",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "no action"
         }
       },
-      "nativeEnums": {}
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
     },
     {
       "columns": {
@@ -4925,29 +3106,47 @@
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
-          "primary": false,
+          "primary": true,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "deleted_at": {
@@ -4957,17 +3156,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 255,
-          "mappedType": "string"
-        },
-        "run_id": {
-          "name": "run_id",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "submission_id": {
@@ -4977,144 +3172,1315 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
-        "positive_score": {
-          "name": "positive_score",
-          "type": "numeric(10,4)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "precision": 10,
-          "scale": 4,
-          "mappedType": "decimal"
-        },
-        "neutral_score": {
-          "name": "neutral_score",
-          "type": "numeric(10,4)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "precision": 10,
-          "scale": 4,
-          "mappedType": "decimal"
-        },
-        "negative_score": {
-          "name": "negative_score",
-          "type": "numeric(10,4)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "precision": 10,
-          "scale": 4,
-          "mappedType": "decimal"
-        },
-        "label": {
-          "name": "label",
+        "question_id": {
+          "name": "question_id",
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
-        "raw_result": {
-          "name": "raw_result",
+        "section_id": {
+          "name": "section_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "dimension_code": {
+          "name": "dimension_code",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "numeric_value": {
+          "name": "numeric_value",
+          "type": "numeric(10,2)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 10,
+          "scale": 2,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "decimal"
+        }
+      },
+      "name": "questionnaire_answer",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "questionnaire_answer_pkey",
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "questionnaire_answer_submission_id_foreign": {
+          "columnNames": [
+            "submission_id"
+          ],
+          "constraintName": "questionnaire_answer_submission_id_foreign",
+          "localTableName": "public.questionnaire_answer",
+          "referencedTableName": "public.questionnaire_submission",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        }
+      },
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "respondent_id": {
+          "name": "respondent_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "questionnaire_version_id": {
+          "name": "questionnaire_version_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "faculty_id": {
+          "name": "faculty_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "semester_id": {
+          "name": "semester_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "answers": {
+          "name": "answers",
           "type": "jsonb",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "json"
         },
-        "passed_topic_gate": {
-          "name": "passed_topic_gate",
-          "type": "boolean",
+        "qualitative_comment": {
+          "name": "qualitative_comment",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        }
+      },
+      "name": "questionnaire_draft",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "questionnaire_draft_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
+          "columnNames": [
+            "respondent_id",
+            "updated_at"
+          ],
+          "composite": true,
+          "constraint": false,
+          "keyName": "questionnaire_draft_respondent_id_updated_at_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "respondent_id",
+            "questionnaire_version_id",
+            "faculty_id",
+            "semester_id",
+            "course_id"
+          ],
+          "composite": true,
+          "constraint": false,
+          "keyName": "questionnaire_draft_unique_active_with_course",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "respondent_id",
+            "questionnaire_version_id",
+            "faculty_id",
+            "semester_id"
+          ],
+          "composite": true,
+          "constraint": false,
+          "keyName": "questionnaire_draft_unique_active_without_course",
+          "unique": false,
+          "primary": false
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "questionnaire_draft_course_id_foreign": {
+          "columnNames": [
+            "course_id"
+          ],
+          "constraintName": "questionnaire_draft_course_id_foreign",
+          "localTableName": "public.questionnaire_draft",
+          "referencedTableName": "public.course",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        },
+        "questionnaire_draft_faculty_id_foreign": {
+          "columnNames": [
+            "faculty_id"
+          ],
+          "constraintName": "questionnaire_draft_faculty_id_foreign",
+          "localTableName": "public.questionnaire_draft",
+          "referencedTableName": "public.user",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        },
+        "questionnaire_draft_questionnaire_version_id_foreign": {
+          "columnNames": [
+            "questionnaire_version_id"
+          ],
+          "constraintName": "questionnaire_draft_questionnaire_version_id_foreign",
+          "localTableName": "public.questionnaire_draft",
+          "referencedTableName": "public.questionnaire_version",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        },
+        "questionnaire_draft_respondent_id_foreign": {
+          "columnNames": [
+            "respondent_id"
+          ],
+          "constraintName": "questionnaire_draft_respondent_id_foreign",
+          "localTableName": "public.questionnaire_draft",
+          "referencedTableName": "public.user",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        },
+        "questionnaire_draft_semester_id_foreign": {
+          "columnNames": [
+            "semester_id"
+          ],
+          "constraintName": "questionnaire_draft_semester_id_foreign",
+          "localTableName": "public.questionnaire_draft",
+          "referencedTableName": "public.semester",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        }
+      },
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "questionnaire_version_id": {
+          "name": "questionnaire_version_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "respondent_id": {
+          "name": "respondent_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "faculty_id": {
+          "name": "faculty_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "respondent_role": {
+          "name": "respondent_role",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [
+            "STUDENT",
+            "DEAN"
+          ],
+          "mappedType": "enum"
+        },
+        "semester_id": {
+          "name": "semester_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "department_id": {
+          "name": "department_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "campus_id": {
+          "name": "campus_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "numeric(10,2)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 10,
+          "scale": 2,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "decimal"
+        },
+        "normalized_score": {
+          "name": "normalized_score",
+          "type": "numeric(10,2)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 10,
+          "scale": 2,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "decimal"
+        },
+        "qualitative_comment": {
+          "name": "qualitative_comment",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": "now()",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "faculty_name_snapshot": {
+          "name": "faculty_name_snapshot",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "faculty_employee_number_snapshot": {
+          "name": "faculty_employee_number_snapshot",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "department_code_snapshot": {
+          "name": "department_code_snapshot",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "department_name_snapshot": {
+          "name": "department_name_snapshot",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "program_code_snapshot": {
+          "name": "program_code_snapshot",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "program_name_snapshot": {
+          "name": "program_name_snapshot",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "campus_code_snapshot": {
+          "name": "campus_code_snapshot",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "campus_name_snapshot": {
+          "name": "campus_name_snapshot",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "course_code_snapshot": {
+          "name": "course_code_snapshot",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "course_title_snapshot": {
+          "name": "course_title_snapshot",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "semester_code_snapshot": {
+          "name": "semester_code_snapshot",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "semester_label_snapshot": {
+          "name": "semester_label_snapshot",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "academic_year_snapshot": {
+          "name": "academic_year_snapshot",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "cleaned_comment": {
+          "name": "cleaned_comment",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        }
+      },
+      "name": "questionnaire_submission",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "campus_id",
+            "semester_id"
+          ],
+          "composite": true,
+          "constraint": false,
+          "keyName": "questionnaire_submission_campus_id_semester_id_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "department_id",
+            "semester_id"
+          ],
+          "composite": true,
+          "constraint": false,
+          "keyName": "questionnaire_submission_department_id_semester_id_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "faculty_id",
+            "semester_id"
+          ],
+          "composite": true,
+          "constraint": false,
+          "keyName": "questionnaire_submission_faculty_id_semester_id_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "questionnaire_submission_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
+          "columnNames": [
+            "program_id",
+            "semester_id"
+          ],
+          "composite": true,
+          "constraint": false,
+          "keyName": "questionnaire_submission_program_id_semester_id_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "questionnaire_version_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "questionnaire_submission_questionnaire_version_id_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "respondent_id",
+            "faculty_id",
+            "questionnaire_version_id",
+            "semester_id",
+            "course_id"
+          ],
+          "composite": true,
+          "constraint": true,
+          "keyName": "questionnaire_submission_respondent_id_faculty_id_46f83_unique",
+          "unique": true,
+          "primary": false
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "questionnaire_submission_campus_id_foreign": {
+          "columnNames": [
+            "campus_id"
+          ],
+          "constraintName": "questionnaire_submission_campus_id_foreign",
+          "localTableName": "public.questionnaire_submission",
+          "referencedTableName": "public.campus",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        },
+        "questionnaire_submission_course_id_foreign": {
+          "columnNames": [
+            "course_id"
+          ],
+          "constraintName": "questionnaire_submission_course_id_foreign",
+          "localTableName": "public.questionnaire_submission",
+          "referencedTableName": "public.course",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        },
+        "questionnaire_submission_department_id_foreign": {
+          "columnNames": [
+            "department_id"
+          ],
+          "constraintName": "questionnaire_submission_department_id_foreign",
+          "localTableName": "public.questionnaire_submission",
+          "referencedTableName": "public.department",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        },
+        "questionnaire_submission_faculty_id_foreign": {
+          "columnNames": [
+            "faculty_id"
+          ],
+          "constraintName": "questionnaire_submission_faculty_id_foreign",
+          "localTableName": "public.questionnaire_submission",
+          "referencedTableName": "public.user",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        },
+        "questionnaire_submission_program_id_foreign": {
+          "columnNames": [
+            "program_id"
+          ],
+          "constraintName": "questionnaire_submission_program_id_foreign",
+          "localTableName": "public.questionnaire_submission",
+          "referencedTableName": "public.program",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        },
+        "questionnaire_submission_questionnaire_version_id_foreign": {
+          "columnNames": [
+            "questionnaire_version_id"
+          ],
+          "constraintName": "questionnaire_submission_questionnaire_version_id_foreign",
+          "localTableName": "public.questionnaire_submission",
+          "referencedTableName": "public.questionnaire_version",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        },
+        "questionnaire_submission_respondent_id_foreign": {
+          "columnNames": [
+            "respondent_id"
+          ],
+          "constraintName": "questionnaire_submission_respondent_id_foreign",
+          "localTableName": "public.questionnaire_submission",
+          "referencedTableName": "public.user",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        },
+        "questionnaire_submission_semester_id_foreign": {
+          "columnNames": [
+            "semester_id"
+          ],
+          "constraintName": "questionnaire_submission_semester_id_foreign",
+          "localTableName": "public.questionnaire_submission",
+          "referencedTableName": "public.semester",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        }
+      },
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "bool",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
           "default": "false",
+          "comment": null,
+          "enumItems": [],
           "mappedType": "boolean"
-        },
-        "processed_at": {
-          "name": "processed_at",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "length": 6,
-          "mappedType": "datetime"
         }
       },
-      "name": "sentiment_result",
+      "name": "questionnaire_type",
       "schema": "public",
       "indexes": [
         {
-          "keyName": "sentiment_result_submission_id_index",
           "columnNames": [
-            "submission_id"
+            "code"
           ],
           "composite": false,
           "constraint": false,
-          "primary": false,
-          "unique": false
+          "keyName": "questionnaire_type_code_index",
+          "unique": false,
+          "primary": false
         },
         {
-          "keyName": "sentiment_result_run_id_index",
           "columnNames": [
-            "run_id"
+            "code"
           ],
           "composite": false,
           "constraint": false,
+          "keyName": "questionnaire_type_code_unique",
+          "unique": true,
           "primary": false,
-          "unique": false
+          "expression": "CREATE UNIQUE INDEX questionnaire_type_code_unique ON public.questionnaire_type USING btree (code) WHERE (deleted_at IS NULL)"
         },
         {
-          "keyName": "sentiment_result_pkey",
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "questionnaire_type_pkey",
+          "unique": true,
+          "primary": true
         }
       ],
       "checks": [],
-      "foreignKeys": {
-        "sentiment_result_run_id_foreign": {
-          "constraintName": "sentiment_result_run_id_foreign",
-          "columnNames": [
-            "run_id"
-          ],
-          "localTableName": "public.sentiment_result",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.sentiment_run",
-          "updateRule": "cascade"
-        },
-        "sentiment_result_submission_id_foreign": {
-          "constraintName": "sentiment_result_submission_id_foreign",
-          "columnNames": [
-            "submission_id"
-          ],
-          "localTableName": "public.sentiment_result",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.questionnaire_submission",
-          "updateRule": "cascade"
+      "foreignKeys": {},
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
         }
       },
-      "nativeEnums": {}
+      "comment": null
     },
     {
       "columns": {
@@ -5123,29 +4489,47 @@
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
-          "primary": false,
+          "primary": true,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "deleted_at": {
@@ -5155,7 +4539,233 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "questionnaire_id": {
+          "name": "questionnaire_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "int4",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "schema_snapshot": {
+          "name": "schema_snapshot",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "json"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "bool",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "false",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "'DRAFT'",
+          "comment": null,
+          "enumItems": [
+            "DRAFT",
+            "ACTIVE",
+            "DEPRECATED"
+          ],
+          "mappedType": "enum"
+        }
+      },
+      "name": "questionnaire_version",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "questionnaire_version_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
+          "columnNames": [
+            "questionnaire_id",
+            "version_number"
+          ],
+          "composite": true,
+          "constraint": true,
+          "keyName": "questionnaire_version_questionnaire_id_version_number_unique",
+          "unique": true,
+          "primary": false
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "questionnaire_version_questionnaire_id_foreign": {
+          "columnNames": [
+            "questionnaire_id"
+          ],
+          "constraintName": "questionnaire_version_questionnaire_id_foreign",
+          "localTableName": "public.questionnaire_version",
+          "referencedTableName": "public.questionnaire",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        }
+      },
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "pipeline_id": {
@@ -5165,36 +4775,61 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "submission_count": {
           "name": "submission_count",
-          "type": "int",
+          "type": "int4",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "integer"
         },
         "sentiment_coverage": {
           "name": "sentiment_coverage",
-          "type": "int",
+          "type": "int4",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
           "default": "0",
+          "comment": null,
+          "enumItems": [],
           "mappedType": "integer"
         },
         "topic_coverage": {
           "name": "topic_coverage",
-          "type": "int",
+          "type": "int4",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
           "default": "0",
+          "comment": null,
+          "enumItems": [],
           "mappedType": "integer"
         },
         "worker_version": {
@@ -5204,7 +4839,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "job_id": {
@@ -5214,7 +4855,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "status": {
@@ -5224,7 +4871,12 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
           "default": "'PENDING'",
+          "comment": null,
           "enumItems": [
             "PENDING",
             "PROCESSING",
@@ -5235,12 +4887,18 @@
         },
         "completed_at": {
           "name": "completed_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         }
       },
@@ -5248,42 +4906,53 @@
       "schema": "public",
       "indexes": [
         {
-          "keyName": "recommendation_run_pipeline_id_index",
           "columnNames": [
             "pipeline_id"
           ],
           "composite": false,
           "constraint": false,
-          "primary": false,
-          "unique": false
+          "keyName": "recommendation_run_pipeline_id_index",
+          "unique": false,
+          "primary": false
         },
         {
-          "keyName": "recommendation_run_pkey",
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "recommendation_run_pkey",
+          "unique": true,
+          "primary": true
         }
       ],
       "checks": [],
       "foreignKeys": {
         "recommendation_run_pipeline_id_foreign": {
-          "constraintName": "recommendation_run_pipeline_id_foreign",
           "columnNames": [
             "pipeline_id"
           ],
+          "constraintName": "recommendation_run_pipeline_id_foreign",
           "localTableName": "public.recommendation_run",
+          "referencedTableName": "public.analysis_pipeline",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.analysis_pipeline",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "no action"
         }
       },
-      "nativeEnums": {}
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
     },
     {
       "columns": {
@@ -5292,29 +4961,47 @@
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
-          "primary": false,
+          "primary": true,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "deleted_at": {
@@ -5324,7 +5011,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "run_id": {
@@ -5334,21 +5027,34 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "category": {
           "name": "category",
-          "type": "text",
+          "type": "action_category",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
           "enumItems": [
             "STRENGTH",
             "IMPROVEMENT"
           ],
-          "mappedType": "enum"
+          "mappedType": "unknown",
+          "nativeEnumName": "action_category"
         },
         "headline": {
           "name": "headline",
@@ -5357,24 +5063,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "mappedType": "text"
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "text"
-        },
-        "action_plan": {
-          "name": "action_plan",
-          "type": "text",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "text"
         },
         "priority": {
@@ -5384,6 +5079,12 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
           "enumItems": [
             "HIGH",
             "MEDIUM",
@@ -5398,49 +5099,99 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "json"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "''",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "action_plan": {
+          "name": "action_plan",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "''",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
         }
       },
       "name": "recommended_action",
       "schema": "public",
       "indexes": [
         {
-          "keyName": "recommended_action_run_id_index",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "recommended_action_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
           "columnNames": [
             "run_id"
           ],
           "composite": false,
           "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "recommended_action_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "keyName": "recommended_action_run_id_index",
+          "unique": false,
+          "primary": false
         }
       ],
       "checks": [],
       "foreignKeys": {
         "recommended_action_run_id_foreign": {
-          "constraintName": "recommended_action_run_id_foreign",
           "columnNames": [
             "run_id"
           ],
+          "constraintName": "recommended_action_run_id_foreign",
           "localTableName": "public.recommended_action",
+          "referencedTableName": "public.recommendation_run",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.recommendation_run",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "no action"
         }
       },
-      "nativeEnums": {}
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
     },
     {
       "columns": {
@@ -5449,29 +5200,47 @@
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
-          "primary": false,
+          "primary": true,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "deleted_at": {
@@ -5481,7 +5250,29 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "user_id": {
@@ -5491,7 +5282,3209 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "replaced_by_token_id": {
+          "name": "replaced_by_token_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "bool",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
+        },
+        "browser_name": {
+          "name": "browser_name",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "os": {
+          "name": "os",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        }
+      },
+      "name": "refresh_token",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "refresh_token_pkey",
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {},
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "report_type": {
+          "name": "report_type",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": "'waiting'",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "requested_by_id": {
+          "name": "requested_by_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "faculty_id": {
+          "name": "faculty_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "faculty_name": {
+          "name": "faculty_name",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "semester_id": {
+          "name": "semester_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "questionnaire_type_code": {
+          "name": "questionnaire_type_code",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        }
+      },
+      "name": "report_job",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "batch_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "report_job_batch_id_index",
+          "unique": false,
+          "primary": false,
+          "expression": "CREATE INDEX report_job_batch_id_index ON public.report_job USING btree (batch_id) WHERE (batch_id IS NOT NULL)"
+        },
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "report_job_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
+          "columnNames": [
+            "requested_by_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "report_job_requested_by_id_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "status",
+            "completed_at"
+          ],
+          "composite": true,
+          "constraint": false,
+          "keyName": "report_job_status_completed_at_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "status"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "report_job_status_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "faculty_id",
+            "semester_id",
+            "questionnaire_type_code",
+            "report_type"
+          ],
+          "composite": true,
+          "constraint": false,
+          "keyName": "uq_report_job_pending",
+          "unique": true,
+          "primary": false,
+          "expression": "CREATE UNIQUE INDEX uq_report_job_pending ON public.report_job USING btree (faculty_id, semester_id, questionnaire_type_code, report_type) WHERE (((status)::text = ANY ((ARRAY['waiting'::character varying, 'active'::character varying])::text[])) AND (deleted_at IS NULL))"
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "report_job_requested_by_id_foreign": {
+          "columnNames": [
+            "requested_by_id"
+          ],
+          "constraintName": "report_job_requested_by_id_foreign",
+          "localTableName": "public.report_job",
+          "referencedTableName": "public.user",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        }
+      },
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "moodle_group_id": {
+          "name": "moodle_group_id",
+          "type": "int4",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        }
+      },
+      "name": "section",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "course_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "section_course_id_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "moodle_group_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "section_moodle_group_id_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "moodle_group_id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "section_moodle_group_id_unique",
+          "unique": true,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "section_pkey",
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "section_course_id_foreign": {
+          "columnNames": [
+            "course_id"
+          ],
+          "constraintName": "section_course_id_foreign",
+          "localTableName": "public.section",
+          "referencedTableName": "public.course",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        }
+      },
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "moodle_category_id": {
+          "name": "moodle_category_id",
+          "type": "int4",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "campus_id": {
+          "name": "campus_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        }
+      },
+      "name": "semester",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "moodle_category_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "semester_moodle_category_id_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "moodle_category_id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "semester_moodle_category_id_unique",
+          "unique": true,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "semester_pkey",
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "semester_campus_id_foreign": {
+          "columnNames": [
+            "campus_id"
+          ],
+          "constraintName": "semester_campus_id_foreign",
+          "localTableName": "public.semester",
+          "referencedTableName": "public.campus",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        }
+      },
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "positive_score": {
+          "name": "positive_score",
+          "type": "numeric(10,4)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 10,
+          "scale": 4,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "decimal"
+        },
+        "neutral_score": {
+          "name": "neutral_score",
+          "type": "numeric(10,4)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 10,
+          "scale": 4,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "decimal"
+        },
+        "negative_score": {
+          "name": "negative_score",
+          "type": "numeric(10,4)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 10,
+          "scale": 4,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "decimal"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "raw_result": {
+          "name": "raw_result",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "json"
+        },
+        "passed_topic_gate": {
+          "name": "passed_topic_gate",
+          "type": "bool",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "false",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        }
+      },
+      "name": "sentiment_result",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "submission_id",
+            "processed_at"
+          ],
+          "composite": true,
+          "constraint": false,
+          "keyName": "idx_sr_submission_processed",
+          "unique": false,
+          "primary": false,
+          "expression": "CREATE INDEX idx_sr_submission_processed ON public.sentiment_result USING btree (submission_id, processed_at DESC) WHERE (deleted_at IS NULL)"
+        },
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "sentiment_result_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
+          "columnNames": [
+            "run_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "sentiment_result_run_id_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "run_id",
+            "submission_id"
+          ],
+          "composite": true,
+          "constraint": false,
+          "keyName": "sentiment_result_run_id_submission_id_unique",
+          "unique": true,
+          "primary": false,
+          "expression": "CREATE UNIQUE INDEX sentiment_result_run_id_submission_id_unique ON public.sentiment_result USING btree (run_id, submission_id) WHERE (deleted_at IS NULL)"
+        },
+        {
+          "columnNames": [
+            "submission_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "sentiment_result_submission_id_index",
+          "unique": false,
+          "primary": false
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "sentiment_result_run_id_foreign": {
+          "columnNames": [
+            "run_id"
+          ],
+          "constraintName": "sentiment_result_run_id_foreign",
+          "localTableName": "public.sentiment_result",
+          "referencedTableName": "public.sentiment_run",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        },
+        "sentiment_result_submission_id_foreign": {
+          "columnNames": [
+            "submission_id"
+          ],
+          "constraintName": "sentiment_result_submission_id_foreign",
+          "localTableName": "public.sentiment_result",
+          "referencedTableName": "public.questionnaire_submission",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        }
+      },
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "pipeline_id": {
+          "name": "pipeline_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "submission_count": {
+          "name": "submission_count",
+          "type": "int4",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "worker_version": {
+          "name": "worker_version",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "'PENDING'",
+          "comment": null,
+          "enumItems": [
+            "PENDING",
+            "PROCESSING",
+            "COMPLETED",
+            "FAILED"
+          ],
+          "mappedType": "enum"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        }
+      },
+      "name": "sentiment_run",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "pipeline_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "sentiment_run_pipeline_id_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "sentiment_run_pkey",
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "sentiment_run_pipeline_id_foreign": {
+          "columnNames": [
+            "pipeline_id"
+          ],
+          "constraintName": "sentiment_run_pipeline_id_foreign",
+          "localTableName": "public.sentiment_run",
+          "referencedTableName": "public.analysis_pipeline",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        }
+      },
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 768,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "unknown"
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        }
+      },
+      "name": "submission_embedding",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "submission_embedding_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
+          "columnNames": [
+            "submission_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "submission_embedding_submission_id_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "submission_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "submission_embedding_submission_id_unique",
+          "unique": true,
+          "primary": false,
+          "expression": "CREATE UNIQUE INDEX submission_embedding_submission_id_unique ON public.submission_embedding USING btree (submission_id) WHERE (deleted_at IS NULL)"
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "submission_embedding_submission_id_foreign": {
+          "columnNames": [
+            "submission_id"
+          ],
+          "constraintName": "submission_embedding_submission_id_foreign",
+          "localTableName": "public.submission_embedding",
+          "referencedTableName": "public.questionnaire_submission",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        }
+      },
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "triggered_by_id": {
+          "name": "triggered_by_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": "'running'",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "int4",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "json"
+        },
+        "courses": {
+          "name": "courses",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "json"
+        },
+        "enrollments": {
+          "name": "enrollments",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "json"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        }
+      },
+      "name": "sync_log",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "sync_log_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
+          "columnNames": [
+            "started_at"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "sync_log_started_at_index",
+          "unique": false,
+          "primary": false
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "sync_log_triggered_by_id_foreign": {
+          "columnNames": [
+            "triggered_by_id"
+          ],
+          "constraintName": "sync_log_triggered_by_id_foreign",
+          "localTableName": "public.sync_log",
+          "referencedTableName": "public.user",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        }
+      },
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        }
+      },
+      "name": "system_config",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "key"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "system_config_key_unique",
+          "unique": true,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "system_config_pkey",
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {},
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "topic_index": {
+          "name": "topic_index",
+          "type": "int4",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "raw_label": {
+          "name": "raw_label",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "array"
+        },
+        "doc_count": {
+          "name": "doc_count",
+          "type": "int4",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        }
+      },
+      "name": "topic",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "topic_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
+          "columnNames": [
+            "run_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "topic_run_id_index",
+          "unique": false,
+          "primary": false
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "topic_run_id_foreign": {
+          "columnNames": [
+            "run_id"
+          ],
+          "constraintName": "topic_run_id_foreign",
+          "localTableName": "public.topic",
+          "referencedTableName": "public.topic_model_run",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        }
+      },
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "probability": {
+          "name": "probability",
+          "type": "numeric(10,4)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 10,
+          "scale": 4,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "decimal"
+        },
+        "is_dominant": {
+          "name": "is_dominant",
+          "type": "bool",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
+        }
+      },
+      "name": "topic_assignment",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "topic_assignment_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
+          "columnNames": [
+            "submission_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "topic_assignment_submission_id_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "topic_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "topic_assignment_topic_id_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "topic_id",
+            "submission_id"
+          ],
+          "composite": true,
+          "constraint": false,
+          "keyName": "topic_assignment_topic_id_submission_id_unique",
+          "unique": true,
+          "primary": false,
+          "expression": "CREATE UNIQUE INDEX topic_assignment_topic_id_submission_id_unique ON public.topic_assignment USING btree (topic_id, submission_id) WHERE (deleted_at IS NULL)"
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "topic_assignment_submission_id_foreign": {
+          "columnNames": [
+            "submission_id"
+          ],
+          "constraintName": "topic_assignment_submission_id_foreign",
+          "localTableName": "public.topic_assignment",
+          "referencedTableName": "public.questionnaire_submission",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        },
+        "topic_assignment_topic_id_foreign": {
+          "columnNames": [
+            "topic_id"
+          ],
+          "constraintName": "topic_assignment_topic_id_foreign",
+          "localTableName": "public.topic_assignment",
+          "referencedTableName": "public.topic",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        }
+      },
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "pipeline_id": {
+          "name": "pipeline_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "submission_count": {
+          "name": "submission_count",
+          "type": "int4",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "topic_count": {
+          "name": "topic_count",
+          "type": "int4",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": "0",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "outlier_count": {
+          "name": "outlier_count",
+          "type": "int4",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": "0",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "model_params": {
+          "name": "model_params",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "json"
+        },
+        "metrics": {
+          "name": "metrics",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "json"
+        },
+        "worker_version": {
+          "name": "worker_version",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "'PENDING'",
+          "comment": null,
+          "enumItems": [
+            "PENDING",
+            "PROCESSING",
+            "COMPLETED",
+            "FAILED"
+          ],
+          "mappedType": "enum"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        }
+      },
+      "name": "topic_model_run",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "pipeline_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "topic_model_run_pipeline_id_index",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "topic_model_run_pkey",
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "topic_model_run_pipeline_id_foreign": {
+          "columnNames": [
+            "pipeline_id"
+          ],
+          "constraintName": "topic_model_run_pipeline_id_foreign",
+          "localTableName": "public.topic_model_run",
+          "referencedTableName": "public.analysis_pipeline",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        }
+      },
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "moodle_user_id": {
+          "name": "moodle_user_id",
+          "type": "int4",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": true,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "user_profile_picture": {
+          "name": "user_profile_picture",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "bool",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
+        },
+        "roles": {
+          "name": "roles",
+          "type": "text[]",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "'{}'",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "array"
+        },
+        "campus_id": {
+          "name": "campus_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "department_id": {
+          "name": "department_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        }
+      },
+      "name": "user",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "moodle_user_id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "user_moodle_user_id_unique",
+          "unique": true,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "user_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
+          "columnNames": [
+            "user_name"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "user_user_name_unique",
+          "unique": true,
+          "primary": false
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "user_campus_id_foreign": {
+          "columnNames": [
+            "campus_id"
+          ],
+          "constraintName": "user_campus_id_foreign",
+          "localTableName": "public.user",
+          "referencedTableName": "public.campus",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        },
+        "user_department_id_foreign": {
+          "columnNames": [
+            "department_id"
+          ],
+          "constraintName": "user_department_id_foreign",
+          "localTableName": "public.user",
+          "referencedTableName": "public.department",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        },
+        "user_program_id_foreign": {
+          "columnNames": [
+            "program_id"
+          ],
+          "constraintName": "user_program_id_foreign",
+          "localTableName": "public.user",
+          "referencedTableName": "public.program",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        }
+      },
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "role": {
@@ -5501,7 +8494,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "moodle_category_id": {
@@ -5511,7 +8510,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         },
         "source": {
@@ -5521,8 +8526,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 255,
+          "precision": null,
+          "scale": null,
           "default": "'auto'",
+          "comment": null,
+          "enumItems": [],
           "mappedType": "string"
         }
       },
@@ -5530,7 +8540,16 @@
       "schema": "public",
       "indexes": [
         {
-          "keyName": "user_institutional_role_user_id_moodle_category_id_role_unique",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "user_institutional_role_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
           "columnNames": [
             "user_id",
             "moodle_category_id",
@@ -5538,49 +8557,61 @@
           ],
           "composite": true,
           "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "user_institutional_role_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "keyName": "user_institutional_role_user_id_moodle_category_id_role_unique",
+          "unique": true,
+          "primary": false
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "user_institutional_role_user_id_foreign": {
-          "constraintName": "user_institutional_role_user_id_foreign",
-          "columnNames": [
-            "user_id"
-          ],
-          "localTableName": "public.user_institutional_role",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.user",
-          "updateRule": "cascade"
-        },
         "user_institutional_role_moodle_category_id_foreign": {
-          "constraintName": "user_institutional_role_moodle_category_id_foreign",
           "columnNames": [
             "moodle_category_id"
           ],
+          "constraintName": "user_institutional_role_moodle_category_id_foreign",
           "localTableName": "public.user_institutional_role",
+          "referencedTableName": "public.moodle_category",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.moodle_category",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "no action"
+        },
+        "user_institutional_role_user_id_foreign": {
+          "columnNames": [
+            "user_id"
+          ],
+          "constraintName": "user_institutional_role_user_id_foreign",
+          "localTableName": "public.user_institutional_role",
+          "referencedTableName": "public.user",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "no action"
         }
       },
-      "nativeEnums": {}
+      "nativeEnums": {
+        "action_category": {
+          "name": "action_category",
+          "schema": "public",
+          "items": [
+            "STRENGTH",
+            "IMPROVEMENT"
+          ]
+        }
+      },
+      "comment": null
     }
   ],
-  "nativeEnums": {}
+  "nativeEnums": {
+    "action_category": {
+      "name": "action_category",
+      "schema": "public",
+      "items": [
+        "STRENGTH",
+        "IMPROVEMENT"
+      ]
+    }
+  }
 }

--- a/src/migrations/Migration20260401120000_report-job.ts
+++ b/src/migrations/Migration20260401120000_report-job.ts
@@ -1,0 +1,22 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260401120000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table "report_job" ("id" varchar(255) not null, "created_at" timestamptz not null, "updated_at" timestamptz not null, "deleted_at" timestamptz null, "report_type" varchar(255) not null, "status" varchar(255) not null default 'waiting', "requested_by_id" varchar(255) not null, "faculty_id" varchar(255) not null, "faculty_name" varchar(255) not null, "semester_id" varchar(255) not null, "questionnaire_type_code" varchar(255) not null, "batch_id" varchar(255) null, "storage_key" varchar(255) null, "error" text null, "completed_at" timestamptz null, constraint "report_job_pkey" primary key ("id"));`);
+
+    this.addSql(`create index "report_job_status_index" on "report_job" ("status");`);
+    this.addSql(`create index "report_job_requested_by_id_index" on "report_job" ("requested_by_id");`);
+    this.addSql(`create index "report_job_batch_id_index" on "report_job" ("batch_id") where batch_id is not null;`);
+    this.addSql(`create index "report_job_status_completed_at_index" on "report_job" ("status", "completed_at");`);
+
+    this.addSql(`create unique index "uq_report_job_pending" on "report_job" ("faculty_id", "semester_id", "questionnaire_type_code", "report_type") where status in ('waiting', 'active') and deleted_at is null;`);
+
+    this.addSql(`alter table "report_job" add constraint "report_job_requested_by_id_foreign" foreign key ("requested_by_id") references "user" ("id") on update cascade;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "report_job" cascade;`);
+  }
+
+}

--- a/src/modules/analytics/analytics.module.ts
+++ b/src/modules/analytics/analytics.module.ts
@@ -18,5 +18,6 @@ import { AnalyticsRefreshProcessor } from './processors/analytics-refresh.proces
   ],
   controllers: [AnalyticsController],
   providers: [AnalyticsService, AnalyticsRefreshProcessor],
+  exports: [AnalyticsService],
 })
 export class AnalyticsModule {}

--- a/src/modules/analytics/analytics.service.spec.ts
+++ b/src/modules/analytics/analytics.service.spec.ts
@@ -461,10 +461,20 @@ describe('AnalyticsService', () => {
       countResult: number,
     ) {
       // Super admin: scope returns null (no validateFacultyScope execute call)
-      // 1. faculty metadata query + semester metadata query (parallel)
-      // 2. resolveVersionIds: phase 1 (type check), phase 2 (versions)
+      // 1. resolveVersionIds: phase 1 (type check), phase 2 (versions)
+      // 2. BuildFacultyReportData: faculty metadata + semester metadata (parallel)
       // 3. aggregation + submission count (parallel)
       mockExecute
+        // phase 1: type check
+        .mockResolvedValueOnce([{ id: 'type-1', name: 'Student Evaluation' }])
+        // phase 2: versions
+        .mockResolvedValueOnce([
+          {
+            id: 'v-1',
+            version_number: 1,
+            schema_snapshot: schema,
+          },
+        ])
         // faculty metadata
         .mockResolvedValueOnce([{ first_name: 'John', last_name: 'Doe' }])
         // semester metadata
@@ -474,16 +484,6 @@ describe('AnalyticsService', () => {
             code: '1S2526',
             label: '1st Semester',
             academic_year: '2025-2026',
-          },
-        ])
-        // phase 1: type check
-        .mockResolvedValueOnce([{ id: 'type-1', name: 'Student Evaluation' }])
-        // phase 2: versions
-        .mockResolvedValueOnce([
-          {
-            id: 'v-1',
-            version_number: 1,
-            schema_snapshot: schema,
           },
         ])
         // aggregation query
@@ -549,7 +549,13 @@ describe('AnalyticsService', () => {
 
     it('should return empty report when no submissions found', async () => {
       // Super admin — no scope execute call
+      // 1. resolveVersionIds: type check, no versions
+      // 2. BuildFacultyReportData: faculty + semester (still fetched for metadata)
       mockExecute
+        // phase 1: type check
+        .mockResolvedValueOnce([{ id: 'type-1', name: 'Student Evaluation' }])
+        // phase 2: no versions found
+        .mockResolvedValueOnce([])
         // faculty metadata
         .mockResolvedValueOnce([{ first_name: 'John', last_name: 'Doe' }])
         // semester metadata
@@ -560,11 +566,7 @@ describe('AnalyticsService', () => {
             label: '1st Semester',
             academic_year: '2025-2026',
           },
-        ])
-        // phase 1: type check
-        .mockResolvedValueOnce([{ id: 'type-1', name: 'Student Evaluation' }])
-        // phase 2: no versions found
-        .mockResolvedValueOnce([]);
+        ]);
 
       const result = await service.GetFacultyReport(facultyId, baseQuery);
 
@@ -576,18 +578,8 @@ describe('AnalyticsService', () => {
     });
 
     it('should throw NotFoundException for invalid questionnaireTypeCode', async () => {
+      // resolveVersionIds: type not found (throws before BuildFacultyReportData)
       mockExecute
-        // faculty metadata
-        .mockResolvedValueOnce([{ first_name: 'John', last_name: 'Doe' }])
-        // semester metadata
-        .mockResolvedValueOnce([
-          {
-            id: semesterId,
-            code: '1S2526',
-            label: '1st Semester',
-            academic_year: '2025-2026',
-          },
-        ])
         // phase 1: type not found
         .mockResolvedValueOnce([]);
 
@@ -597,8 +589,25 @@ describe('AnalyticsService', () => {
     });
 
     it('should throw NotFoundException when faculty does not exist', async () => {
-      // faculty metadata returns empty
-      mockExecute.mockResolvedValueOnce([]);
+      // resolveVersionIds succeeds, BuildFacultyReportData: faculty returns empty
+      mockExecute
+        // phase 1: type check
+        .mockResolvedValueOnce([{ id: 'type-1', name: 'Student Evaluation' }])
+        // phase 2: versions
+        .mockResolvedValueOnce([
+          { id: 'v-1', version_number: 1, schema_snapshot: sampleSchema },
+        ])
+        // faculty metadata returns empty
+        .mockResolvedValueOnce([])
+        // semester metadata
+        .mockResolvedValueOnce([
+          {
+            id: semesterId,
+            code: '1S2526',
+            label: '1st Semester',
+            academic_year: '2025-2026',
+          },
+        ]);
 
       await expect(
         service.GetFacultyReport(facultyId, baseQuery),
@@ -606,8 +615,15 @@ describe('AnalyticsService', () => {
     });
 
     it('should throw NotFoundException when semester does not exist', async () => {
-      // faculty metadata exists
+      // resolveVersionIds succeeds, BuildFacultyReportData: semester returns empty
       mockExecute
+        // phase 1: type check
+        .mockResolvedValueOnce([{ id: 'type-1', name: 'Student Evaluation' }])
+        // phase 2: versions
+        .mockResolvedValueOnce([
+          { id: 'v-1', version_number: 1, schema_snapshot: sampleSchema },
+        ])
+        // faculty metadata
         .mockResolvedValueOnce([{ first_name: 'John', last_name: 'Doe' }])
         // semester metadata returns empty
         .mockResolvedValueOnce([]);
@@ -640,8 +656,11 @@ describe('AnalyticsService', () => {
       mockScopeResolver.ResolveDepartmentIds.mockResolvedValue([
         'dept-allowed',
       ]);
-      // validateFacultyScope returns user data — no separate faculty query needed
+      // 1. validateFacultyScope: user query
+      // 2. resolveVersionIds: type check, no versions
+      // 3. BuildFacultyReportData: faculty metadata, semester metadata
       mockExecute
+        // validateFacultyScope: user query
         .mockResolvedValueOnce([
           {
             id: facultyId,
@@ -650,6 +669,12 @@ describe('AnalyticsService', () => {
             last_name: 'Smith',
           },
         ])
+        // phase 1: type check
+        .mockResolvedValueOnce([{ id: 'type-1', name: 'Student Evaluation' }])
+        // phase 2: no versions
+        .mockResolvedValueOnce([])
+        // faculty metadata (BuildFacultyReportData fetches independently)
+        .mockResolvedValueOnce([{ first_name: 'Jane', last_name: 'Smith' }])
         // semester metadata
         .mockResolvedValueOnce([
           {
@@ -658,11 +683,7 @@ describe('AnalyticsService', () => {
             label: '1st Semester',
             academic_year: '2025-2026',
           },
-        ])
-        // phase 1: type check
-        .mockResolvedValueOnce([{ id: 'type-1', name: 'Student Evaluation' }])
-        // phase 2: no versions
-        .mockResolvedValueOnce([]);
+        ]);
 
       const result = await service.GetFacultyReport(facultyId, baseQuery);
 

--- a/src/modules/analytics/analytics.service.spec.ts
+++ b/src/modules/analytics/analytics.service.spec.ts
@@ -14,6 +14,7 @@ describe('AnalyticsService', () => {
     mockExecute = jest.fn().mockResolvedValue([]);
 
     const mockEm = {
+      execute: mockExecute,
       getConnection: jest.fn().mockReturnValue({ execute: mockExecute }),
     };
 

--- a/src/modules/analytics/analytics.service.ts
+++ b/src/modules/analytics/analytics.service.ts
@@ -15,7 +15,9 @@ import {
   FacultyTrendsQueryDto,
   FacultyReportQueryDto,
   FacultyReportCommentsQueryDto,
+  BaseFacultyReportQueryDto,
 } from './dto/analytics-query.dto';
+import { ReportCommentDto } from './dto/responses/faculty-report-comments.response.dto';
 import {
   DepartmentOverviewResponseDto,
   FacultySemesterStatsDto,
@@ -459,26 +461,165 @@ export class AnalyticsService {
     facultyId: string,
     query: FacultyReportQueryDto,
   ): Promise<FacultyReportResponseDto> {
-    const scopeUser = await this.validateFacultyScope(
+    await this.validateFacultyScope(facultyId, query.semesterId);
+
+    const { versionIds, canonicalSchema, questionnaireTypeName } =
+      await this.resolveVersionIds(
+        facultyId,
+        query.semesterId,
+        query.questionnaireTypeCode,
+      );
+
+    return this.BuildFacultyReportData(
+      facultyId,
+      versionIds,
+      canonicalSchema,
+      questionnaireTypeName,
+      query,
+    );
+  }
+
+  /** @internal Called by report processor only — scope validation was performed at enqueue time. Do NOT expose via HTTP. */
+  async GetFacultyReportUnscoped(
+    facultyId: string,
+    query: FacultyReportQueryDto,
+  ): Promise<FacultyReportResponseDto> {
+    const { versionIds, canonicalSchema, questionnaireTypeName } =
+      await this.resolveVersionIds(
+        facultyId,
+        query.semesterId,
+        query.questionnaireTypeCode,
+      );
+
+    return this.BuildFacultyReportData(
+      facultyId,
+      versionIds,
+      canonicalSchema,
+      questionnaireTypeName,
+      query,
+    );
+  }
+
+  /** @internal Called by report processor only — scope validation was performed at enqueue time. Do NOT expose via HTTP. */
+  async GetAllFacultyReportComments(
+    facultyId: string,
+    query: BaseFacultyReportQueryDto,
+  ): Promise<ReportCommentDto[]> {
+    const { versionIds } = await this.resolveVersionIds(
       facultyId,
       query.semesterId,
+      query.questionnaireTypeCode,
     );
 
-    // If scope check returned user data, reuse it; otherwise fetch separately
+    if (versionIds.length === 0) {
+      return [];
+    }
+
+    return this.queryComments(facultyId, versionIds, query);
+  }
+
+  async GetFacultyReportComments(
+    facultyId: string,
+    query: FacultyReportCommentsQueryDto,
+  ): Promise<FacultyReportCommentsResponseDto> {
+    await this.validateFacultyScope(facultyId, query.semesterId);
+
+    const { versionIds } = await this.resolveVersionIds(
+      facultyId,
+      query.semesterId,
+      query.questionnaireTypeCode,
+    );
+
+    if (versionIds.length === 0) {
+      return {
+        items: [],
+        meta: {
+          totalItems: 0,
+          itemCount: 0,
+          itemsPerPage: query.limit!,
+          totalPages: 0,
+          currentPage: query.page!,
+        } as PaginationMeta,
+      };
+    }
+
+    const baseParams: unknown[] = [facultyId, query.semesterId, versionIds];
+    let baseParamIdx = 4;
+    let courseFilter = '';
+    if (query.courseId) {
+      courseFilter = ` AND qs.course_id = $${baseParamIdx}`;
+      baseParams.push(query.courseId);
+      baseParamIdx++;
+    }
+
+    const whereClause = `
+      WHERE qs.faculty_id = $1
+        AND qs.semester_id = $2
+        AND qs.questionnaire_version_id = ANY($3)
+        AND qs.qualitative_comment IS NOT NULL
+        AND TRIM(qs.qualitative_comment) != ''
+        AND qs.deleted_at IS NULL${courseFilter}
+    `;
+
+    const countSql = `SELECT COUNT(*) AS total FROM questionnaire_submission qs ${whereClause}`;
+
+    const page = query.page!;
+    const limit = query.limit!;
+    const offset = (page - 1) * limit;
+
+    const paginatedParams = [...baseParams, limit, offset];
+    const paginatedSql = `
+      SELECT qs.qualitative_comment AS text, qs.submitted_at
+      FROM questionnaire_submission qs
+      ${whereClause}
+      ORDER BY qs.submitted_at DESC
+      LIMIT $${baseParamIdx} OFFSET $${baseParamIdx + 1}
+    `;
+
+    const [countRows, commentRows] = await Promise.all([
+      this.em.getConnection().execute(countSql, baseParams),
+      this.em.getConnection().execute(paginatedSql, paginatedParams),
+    ]);
+
+    const totalItems = Number(countRows[0]?.total ?? 0);
+    const items = commentRows.map((r) => ({
+      text: r.text as string,
+      submittedAt: new Date(r.submitted_at as string).toISOString(),
+    }));
+
+    const totalPages = Math.ceil(totalItems / limit) || 0;
+
+    return {
+      items,
+      meta: {
+        totalItems,
+        itemCount: items.length,
+        itemsPerPage: limit,
+        totalPages,
+        currentPage: page,
+      } as PaginationMeta,
+    };
+  }
+
+  private async BuildFacultyReportData(
+    facultyId: string,
+    versionIds: string[],
+    canonicalSchema: QuestionnaireSchemaSnapshot | null,
+    questionnaireTypeName: string,
+    query: FacultyReportQueryDto,
+  ): Promise<FacultyReportResponseDto> {
     const [facultyRow, semesterRow] = await Promise.all([
-      scopeUser
-        ? Promise.resolve(scopeUser)
-        : this.em
-            .getConnection()
-            .execute(
-              'SELECT u.first_name, u.last_name FROM "user" u WHERE u.id = $1 AND u.deleted_at IS NULL',
-              [facultyId],
-            )
-            .then((rows: { first_name: string; last_name: string }[]) => {
-              if (rows.length === 0)
-                throw new NotFoundException('Faculty not found');
-              return rows[0];
-            }),
+      this.em
+        .getConnection()
+        .execute(
+          'SELECT u.first_name, u.last_name FROM "user" u WHERE u.id = $1 AND u.deleted_at IS NULL',
+          [facultyId],
+        )
+        .then((rows: { first_name: string; last_name: string }[]) => {
+          if (rows.length === 0)
+            throw new NotFoundException('Faculty not found');
+          return rows[0];
+        }),
       this.em
         .getConnection()
         .execute(
@@ -500,13 +641,6 @@ export class AnalyticsService {
           },
         ),
     ]);
-
-    const { versionIds, canonicalSchema, questionnaireTypeName } =
-      await this.resolveVersionIds(
-        facultyId,
-        query.semesterId,
-        query.questionnaireTypeCode,
-      );
 
     const facultyDto = {
       id: facultyId,
@@ -691,87 +825,38 @@ export class AnalyticsService {
     };
   }
 
-  async GetFacultyReportComments(
+  private async queryComments(
     facultyId: string,
-    query: FacultyReportCommentsQueryDto,
-  ): Promise<FacultyReportCommentsResponseDto> {
-    await this.validateFacultyScope(facultyId, query.semesterId);
-
-    const { versionIds } = await this.resolveVersionIds(
-      facultyId,
-      query.semesterId,
-      query.questionnaireTypeCode,
-    );
-
-    if (versionIds.length === 0) {
-      return {
-        items: [],
-        meta: {
-          totalItems: 0,
-          itemCount: 0,
-          itemsPerPage: query.limit!,
-          totalPages: 0,
-          currentPage: query.page!,
-        } as PaginationMeta,
-      };
-    }
-
-    const baseParams: unknown[] = [facultyId, query.semesterId, versionIds];
-    let baseParamIdx = 4;
+    versionIds: string[],
+    query: BaseFacultyReportQueryDto,
+  ): Promise<ReportCommentDto[]> {
+    const params: unknown[] = [facultyId, query.semesterId, versionIds];
+    let paramIdx = 4;
     let courseFilter = '';
     if (query.courseId) {
-      courseFilter = ` AND qs.course_id = $${baseParamIdx}`;
-      baseParams.push(query.courseId);
-      baseParamIdx++;
+      courseFilter = ` AND qs.course_id = $${paramIdx}`;
+      params.push(query.courseId);
+      paramIdx++;
     }
 
-    const whereClause = `
+    const sql = `
+      SELECT qs.qualitative_comment AS text, qs.submitted_at
+      FROM questionnaire_submission qs
       WHERE qs.faculty_id = $1
         AND qs.semester_id = $2
         AND qs.questionnaire_version_id = ANY($3)
         AND qs.qualitative_comment IS NOT NULL
         AND TRIM(qs.qualitative_comment) != ''
         AND qs.deleted_at IS NULL${courseFilter}
-    `;
-
-    const countSql = `SELECT COUNT(*) AS total FROM questionnaire_submission qs ${whereClause}`;
-
-    const page = query.page!;
-    const limit = query.limit!;
-    const offset = (page - 1) * limit;
-
-    const paginatedParams = [...baseParams, limit, offset];
-    const paginatedSql = `
-      SELECT qs.qualitative_comment AS text, qs.submitted_at
-      FROM questionnaire_submission qs
-      ${whereClause}
       ORDER BY qs.submitted_at DESC
-      LIMIT $${baseParamIdx} OFFSET $${baseParamIdx + 1}
     `;
 
-    const [countRows, commentRows] = await Promise.all([
-      this.em.getConnection().execute(countSql, baseParams),
-      this.em.getConnection().execute(paginatedSql, paginatedParams),
-    ]);
+    const rows = await this.em.getConnection().execute(sql, params);
 
-    const totalItems = Number(countRows[0]?.total ?? 0);
-    const items = commentRows.map((r) => ({
+    return rows.map((r) => ({
       text: r.text as string,
       submittedAt: new Date(r.submitted_at as string).toISOString(),
     }));
-
-    const totalPages = Math.ceil(totalItems / limit) || 0;
-
-    return {
-      items,
-      meta: {
-        totalItems,
-        itemCount: items.length,
-        itemsPerPage: limit,
-        totalPages,
-        currentPage: page,
-      } as PaginationMeta,
-    };
   }
 
   private async validateFacultyScope(

--- a/src/modules/analytics/analytics.service.ts
+++ b/src/modules/analytics/analytics.service.ts
@@ -51,6 +51,11 @@ interface SectionMeta {
   weight: number;
 }
 
+/** Convert a JS array to a PG array literal for use with em.execute() + ? bindings */
+function pgArray(arr: string[]): string {
+  return `{${arr.join(',')}}`;
+}
+
 const ATTENTION_THRESHOLDS = {
   MIN_ANALYZED_FOR_GAP: 10,
   QUANT_QUAL_DIVERGENCE: 0.2,
@@ -71,32 +76,28 @@ export class AnalyticsService {
   ): Promise<DepartmentOverviewResponseDto> {
     const deptCodes = await this.ResolveDepartmentCodes(semesterId);
 
-    // F5 fix: pre-compute previous semester ID (same for all rows since semester_id is constant)
-    const prevSemRows: { id: string }[] = await this.em.getConnection().execute(
+    const prevSemRows: { id: string }[] = await this.em.execute(
       `SELECT s2.id FROM semester s2
-         WHERE s2.campus_id = (SELECT s1.campus_id FROM semester s1 WHERE s1.id = $1)
-           AND s2.created_at < (SELECT s1.created_at FROM semester s1 WHERE s1.id = $1)
+         WHERE s2.campus_id = (SELECT s1.campus_id FROM semester s1 WHERE s1.id = ?)
+           AND s2.created_at < (SELECT s1.created_at FROM semester s1 WHERE s1.id = ?)
            AND s2.deleted_at IS NULL
          ORDER BY s2.created_at DESC LIMIT 1`,
-      [semesterId],
+      [semesterId, semesterId],
     );
     const prevSemesterId = prevSemRows[0]?.id ?? null;
 
     const params: unknown[] = [semesterId, prevSemesterId];
-    let paramIdx = 3;
 
     let deptFilter = '';
     if (deptCodes !== null) {
-      deptFilter = ` AND curr.department_code_snapshot = ANY($${paramIdx})`;
-      params.push(deptCodes);
-      paramIdx++;
+      deptFilter = ` AND curr.department_code_snapshot = ANY(?)`;
+      params.push(pgArray(deptCodes));
     }
 
     let programFilter = '';
     if (query.programCode) {
-      programFilter = ` AND curr.program_code_snapshot = $${paramIdx}`;
+      programFilter = ` AND curr.program_code_snapshot = ?`;
       params.push(query.programCode);
-      paramIdx++;
     }
 
     const sql = `
@@ -127,12 +128,14 @@ export class AnalyticsService {
       LEFT JOIN mv_faculty_semester_stats prev
         ON prev.faculty_id = curr.faculty_id
         AND prev.department_code_snapshot = curr.department_code_snapshot
-        AND prev.semester_id = $2
-      WHERE curr.semester_id = $1${deptFilter}${programFilter}
+        AND prev.semester_id = ?
+      WHERE curr.semester_id = ?${deptFilter}${programFilter}
       ORDER BY curr.department_code_snapshot, curr.avg_normalized_score DESC
     `;
 
-    const rows = await this.em.getConnection().execute(sql, params);
+    // prev.semester_id and curr.semester_id use positional ? — reorder params
+    const reorderedParams = [prevSemesterId, semesterId, ...params.slice(2)];
+    const rows = await this.em.execute(sql, reorderedParams);
 
     const faculty: FacultySemesterStatsDto[] = rows.map((r) => ({
       facultyId: r.faculty_id as string,
@@ -207,13 +210,11 @@ export class AnalyticsService {
         ATTENTION_THRESHOLDS.MIN_SEMESTERS_FOR_TREND,
         ATTENTION_THRESHOLDS.MIN_R2_FOR_TREND,
       ];
-      let paramIdx = 3;
 
       let deptFilter = '';
       if (deptCodes !== null) {
-        deptFilter = ` AND department_code_snapshot = ANY($${paramIdx})`;
-        params.push(deptCodes);
-        paramIdx++;
+        deptFilter = ` AND department_code_snapshot = ANY(?)`;
+        params.push(pgArray(deptCodes));
       }
 
       const sql = `
@@ -221,14 +222,16 @@ export class AnalyticsService {
                department_code_snapshot AS department_code,
                score_slope, score_r2, sentiment_slope, sentiment_r2
         FROM mv_faculty_trends
-        WHERE semester_count >= $1
+        WHERE semester_count >= ?
           AND (
-            (score_slope < 0 AND score_r2 >= $2)
-            OR (sentiment_slope < 0 AND sentiment_r2 >= $2)
+            (score_slope < 0 AND score_r2 >= ?)
+            OR (sentiment_slope < 0 AND sentiment_r2 >= ?)
           )${deptFilter}
       `;
 
-      const rows = await this.em.getConnection().execute(sql, params);
+      // The R2 threshold is used twice in the SQL
+      const sqlParams = [params[0], params[1], params[1], ...params.slice(2)];
+      const rows = await this.em.execute(sql, sqlParams);
 
       for (const r of rows) {
         const scoreSlope = Number(r.score_slope);
@@ -277,13 +280,11 @@ export class AnalyticsService {
         ATTENTION_THRESHOLDS.MIN_ANALYZED_FOR_GAP,
         ATTENTION_THRESHOLDS.QUANT_QUAL_DIVERGENCE,
       ];
-      let paramIdx = 4;
 
       let deptFilter = '';
       if (deptCodes !== null) {
-        deptFilter = ` AND department_code_snapshot = ANY($${paramIdx})`;
-        params.push(deptCodes);
-        paramIdx++;
+        deptFilter = ` AND department_code_snapshot = ANY(?)`;
+        params.push(pgArray(deptCodes));
       }
 
       const sql = `
@@ -292,12 +293,12 @@ export class AnalyticsService {
                avg_normalized_score, positive_count, analyzed_count,
                (avg_normalized_score / 100.0) - (positive_count::float / analyzed_count) AS divergence
         FROM mv_faculty_semester_stats
-        WHERE semester_id = $1
-          AND analyzed_count >= $2
-          AND ABS((avg_normalized_score / 100.0) - (positive_count::float / analyzed_count)) > $3${deptFilter}
+        WHERE semester_id = ?
+          AND analyzed_count >= ?
+          AND ABS((avg_normalized_score / 100.0) - (positive_count::float / analyzed_count)) > ?${deptFilter}
       `;
 
-      const rows = await this.em.getConnection().execute(sql, params);
+      const rows = await this.em.execute(sql, params);
 
       for (const r of rows) {
         const normalizedScore = Number(r.avg_normalized_score);
@@ -325,13 +326,11 @@ export class AnalyticsService {
     // 3. Low coverage
     {
       const params: unknown[] = [semesterId];
-      let paramIdx = 2;
 
       let deptFilter = '';
       if (deptCodes !== null) {
-        deptFilter = ` AND department_code_snapshot = ANY($${paramIdx})`;
-        params.push(deptCodes);
-        paramIdx++;
+        deptFilter = ` AND department_code_snapshot = ANY(?)`;
+        params.push(pgArray(deptCodes));
       }
 
       const sql = `
@@ -339,12 +338,12 @@ export class AnalyticsService {
                department_code_snapshot AS department_code,
                analyzed_count, submission_count
         FROM mv_faculty_semester_stats
-        WHERE semester_id = $1
+        WHERE semester_id = ?
           AND submission_count > 0
           AND (analyzed_count::float / submission_count) < 0.5${deptFilter}
       `;
 
-      const rows = await this.em.getConnection().execute(sql, params);
+      const rows = await this.em.execute(sql, params);
 
       for (const r of rows) {
         const analyzedCount = Number(r.analyzed_count);
@@ -379,11 +378,9 @@ export class AnalyticsService {
     // Resolve scope — use provided semesterId or fall back to latest semester
     let scopeSemesterId = query.semesterId;
     if (!scopeSemesterId) {
-      const rows: { id: string }[] = await this.em
-        .getConnection()
-        .execute(
-          'SELECT id FROM semester WHERE deleted_at IS NULL ORDER BY created_at DESC LIMIT 1',
-        );
+      const rows: { id: string }[] = await this.em.execute(
+        'SELECT id FROM semester WHERE deleted_at IS NULL ORDER BY created_at DESC LIMIT 1',
+      );
       scopeSemesterId = rows[0]?.id;
     }
 
@@ -393,13 +390,11 @@ export class AnalyticsService {
     }
 
     const params: unknown[] = [minSemesters, minR2];
-    let paramIdx = 3;
 
     let deptFilter = '';
     if (deptCodes !== null) {
-      deptFilter = ` AND department_code_snapshot = ANY($${paramIdx})`;
-      params.push(deptCodes);
-      paramIdx++;
+      deptFilter = ` AND department_code_snapshot = ANY(?)`;
+      params.push(pgArray(deptCodes));
     }
 
     const sql = `
@@ -409,12 +404,12 @@ export class AnalyticsService {
              score_slope, score_r2,
              sentiment_slope, sentiment_r2
       FROM mv_faculty_trends
-      WHERE semester_count >= $1
-        AND COALESCE(score_r2, 0) >= $2${deptFilter}
+      WHERE semester_count >= ?
+        AND COALESCE(score_r2, 0) >= ?${deptFilter}
       ORDER BY score_slope ASC
     `;
 
-    const rows = await this.em.getConnection().execute(sql, params);
+    const rows = await this.em.execute(sql, params);
 
     const items: FacultyTrendDto[] = rows.map((r) => {
       const scoreSlope = r.score_slope != null ? Number(r.score_slope) : null;
@@ -543,19 +538,21 @@ export class AnalyticsService {
       };
     }
 
-    const baseParams: unknown[] = [facultyId, query.semesterId, versionIds];
-    let baseParamIdx = 4;
+    const baseParams: unknown[] = [
+      facultyId,
+      query.semesterId,
+      pgArray(versionIds),
+    ];
     let courseFilter = '';
     if (query.courseId) {
-      courseFilter = ` AND qs.course_id = $${baseParamIdx}`;
+      courseFilter = ` AND qs.course_id = ?`;
       baseParams.push(query.courseId);
-      baseParamIdx++;
     }
 
     const whereClause = `
-      WHERE qs.faculty_id = $1
-        AND qs.semester_id = $2
-        AND qs.questionnaire_version_id = ANY($3)
+      WHERE qs.faculty_id = ?
+        AND qs.semester_id = ?
+        AND qs.questionnaire_version_id = ANY(?)
         AND qs.qualitative_comment IS NOT NULL
         AND TRIM(qs.qualitative_comment) != ''
         AND qs.deleted_at IS NULL${courseFilter}
@@ -573,12 +570,12 @@ export class AnalyticsService {
       FROM questionnaire_submission qs
       ${whereClause}
       ORDER BY qs.submitted_at DESC
-      LIMIT $${baseParamIdx} OFFSET $${baseParamIdx + 1}
+      LIMIT ? OFFSET ?
     `;
 
     const [countRows, commentRows] = await Promise.all([
-      this.em.getConnection().execute(countSql, baseParams),
-      this.em.getConnection().execute(paginatedSql, paginatedParams),
+      this.em.execute(countSql, baseParams),
+      this.em.execute(paginatedSql, paginatedParams),
     ]);
 
     const totalItems = Number(countRows[0]?.total ?? 0);
@@ -610,9 +607,8 @@ export class AnalyticsService {
   ): Promise<FacultyReportResponseDto> {
     const [facultyRow, semesterRow] = await Promise.all([
       this.em
-        .getConnection()
         .execute(
-          'SELECT u.first_name, u.last_name FROM "user" u WHERE u.id = $1 AND u.deleted_at IS NULL',
+          'SELECT u.first_name, u.last_name FROM "user" u WHERE u.id = ? AND u.deleted_at IS NULL',
           [facultyId],
         )
         .then((rows: { first_name: string; last_name: string }[]) => {
@@ -621,9 +617,8 @@ export class AnalyticsService {
           return rows[0];
         }),
       this.em
-        .getConnection()
         .execute(
-          'SELECT s.id, s.code, s.label, s.academic_year FROM semester s WHERE s.id = $1 AND s.deleted_at IS NULL',
+          'SELECT s.id, s.code, s.label, s.academic_year FROM semester s WHERE s.id = ? AND s.deleted_at IS NULL',
           [query.semesterId],
         )
         .then(
@@ -675,13 +670,15 @@ export class AnalyticsService {
     );
 
     // Aggregate scores
-    const aggParams: unknown[] = [facultyId, query.semesterId, versionIds];
-    let aggParamIdx = 4;
+    const aggParams: unknown[] = [
+      facultyId,
+      query.semesterId,
+      pgArray(versionIds),
+    ];
     let courseFilter = '';
     if (query.courseId) {
-      courseFilter = ` AND qs.course_id = $${aggParamIdx}`;
+      courseFilter = ` AND qs.course_id = ?`;
       aggParams.push(query.courseId);
-      aggParamIdx++;
     }
 
     const aggSql = `
@@ -690,9 +687,9 @@ export class AnalyticsService {
              COUNT(*) AS response_count
       FROM questionnaire_answer qa
       JOIN questionnaire_submission qs ON qs.id = qa.submission_id
-      WHERE qs.faculty_id = $1
-        AND qs.semester_id = $2
-        AND qs.questionnaire_version_id = ANY($3)
+      WHERE qs.faculty_id = ?
+        AND qs.semester_id = ?
+        AND qs.questionnaire_version_id = ANY(?)
         AND qs.deleted_at IS NULL
         AND qa.deleted_at IS NULL${courseFilter}
       GROUP BY qa.question_id, qa.section_id
@@ -701,15 +698,15 @@ export class AnalyticsService {
     const countSql = `
       SELECT COUNT(DISTINCT qs.id) AS count
       FROM questionnaire_submission qs
-      WHERE qs.faculty_id = $1
-        AND qs.semester_id = $2
-        AND qs.questionnaire_version_id = ANY($3)
+      WHERE qs.faculty_id = ?
+        AND qs.semester_id = ?
+        AND qs.questionnaire_version_id = ANY(?)
         AND qs.deleted_at IS NULL${courseFilter}
     `;
 
     const [aggRows, countRows] = await Promise.all([
-      this.em.getConnection().execute(aggSql, aggParams),
-      this.em.getConnection().execute(countSql, aggParams),
+      this.em.execute(aggSql, aggParams),
+      this.em.execute(countSql, aggParams),
     ]);
 
     const submissionCount = Number(countRows[0]?.count ?? 0);
@@ -792,16 +789,16 @@ export class AnalyticsService {
     // Course filter metadata
     let courseFilterDto: FacultyReportResponseDto['courseFilter'] = null;
     if (query.courseId) {
-      const courseRows = await this.em.getConnection().execute(
+      const courseRows = await this.em.execute(
         `SELECT qs.course_code_snapshot, qs.course_title_snapshot
            FROM questionnaire_submission qs
-           WHERE qs.faculty_id = $1
-             AND qs.semester_id = $2
-             AND qs.questionnaire_version_id = ANY($3)
-             AND qs.course_id = $4
+           WHERE qs.faculty_id = ?
+             AND qs.semester_id = ?
+             AND qs.questionnaire_version_id = ANY(?)
+             AND qs.course_id = ?
              AND qs.deleted_at IS NULL
            LIMIT 1`,
-        [facultyId, query.semesterId, versionIds, query.courseId],
+        [facultyId, query.semesterId, pgArray(versionIds), query.courseId],
       );
       const courseRow = courseRows[0];
       if (courseRow) {
@@ -830,28 +827,30 @@ export class AnalyticsService {
     versionIds: string[],
     query: BaseFacultyReportQueryDto,
   ): Promise<ReportCommentDto[]> {
-    const params: unknown[] = [facultyId, query.semesterId, versionIds];
-    let paramIdx = 4;
+    const params: unknown[] = [
+      facultyId,
+      query.semesterId,
+      pgArray(versionIds),
+    ];
     let courseFilter = '';
     if (query.courseId) {
-      courseFilter = ` AND qs.course_id = $${paramIdx}`;
+      courseFilter = ` AND qs.course_id = ?`;
       params.push(query.courseId);
-      paramIdx++;
     }
 
     const sql = `
       SELECT qs.qualitative_comment AS text, qs.submitted_at
       FROM questionnaire_submission qs
-      WHERE qs.faculty_id = $1
-        AND qs.semester_id = $2
-        AND qs.questionnaire_version_id = ANY($3)
+      WHERE qs.faculty_id = ?
+        AND qs.semester_id = ?
+        AND qs.questionnaire_version_id = ANY(?)
         AND qs.qualitative_comment IS NOT NULL
         AND TRIM(qs.qualitative_comment) != ''
         AND qs.deleted_at IS NULL${courseFilter}
       ORDER BY qs.submitted_at DESC
     `;
 
-    const rows = await this.em.getConnection().execute(sql, params);
+    const rows = await this.em.execute(sql, params);
 
     return rows.map((r) => ({
       text: r.text as string,
@@ -874,12 +873,10 @@ export class AnalyticsService {
       department_id: string;
       first_name: string;
       last_name: string;
-    }[] = await this.em
-      .getConnection()
-      .execute(
-        'SELECT u.id, u.department_id, u.first_name, u.last_name FROM "user" u WHERE u.id = $1 AND u.deleted_at IS NULL',
-        [facultyId],
-      );
+    }[] = await this.em.execute(
+      'SELECT u.id, u.department_id, u.first_name, u.last_name FROM "user" u WHERE u.id = ? AND u.deleted_at IS NULL',
+      [facultyId],
+    );
 
     if (userRows.length === 0) {
       throw new NotFoundException('Faculty not found');
@@ -907,12 +904,10 @@ export class AnalyticsService {
     questionnaireTypeName: string;
   }> {
     // Phase 1: Verify type exists
-    const typeRows: { id: string; name: string }[] = await this.em
-      .getConnection()
-      .execute(
-        'SELECT qt.id, qt.name FROM questionnaire_type qt WHERE qt.code = $1 AND qt.deleted_at IS NULL',
-        [questionnaireTypeCode],
-      );
+    const typeRows: { id: string; name: string }[] = await this.em.execute(
+      'SELECT qt.id, qt.name FROM questionnaire_type qt WHERE qt.code = ? AND qt.deleted_at IS NULL',
+      [questionnaireTypeCode],
+    );
 
     if (typeRows.length === 0) {
       throw new NotFoundException('Questionnaire type not found');
@@ -926,14 +921,14 @@ export class AnalyticsService {
       id: string;
       version_number: number;
       schema_snapshot: QuestionnaireSchemaSnapshot;
-    }[] = await this.em.getConnection().execute(
+    }[] = await this.em.execute(
       `SELECT DISTINCT qv.id, qv.version_number, qv.schema_snapshot
        FROM questionnaire_version qv
        JOIN questionnaire q ON q.id = qv.questionnaire_id
        JOIN questionnaire_submission qs ON qs.questionnaire_version_id = qv.id
-       WHERE q.type_id = $1
-         AND qs.faculty_id = $2
-         AND qs.semester_id = $3
+       WHERE q.type_id = ?
+         AND qs.faculty_id = ?
+         AND qs.semester_id = ?
          AND qv.status IN ('ACTIVE', 'DEPRECATED')
          AND qv.deleted_at IS NULL
          AND q.deleted_at IS NULL
@@ -996,11 +991,9 @@ export class AnalyticsService {
   }
 
   private async GetLastRefreshedAt(): Promise<string | null> {
-    const rows: { value: string }[] = await this.em
-      .getConnection()
-      .execute(
-        "SELECT value FROM system_config WHERE key = 'analytics_last_refreshed_at' AND deleted_at IS NULL",
-      );
+    const rows: { value: string }[] = await this.em.execute(
+      "SELECT value FROM system_config WHERE key = 'analytics_last_refreshed_at' AND deleted_at IS NULL",
+    );
 
     return rows[0]?.value ?? null;
   }
@@ -1018,12 +1011,10 @@ export class AnalyticsService {
       return [];
     }
 
-    const rows: { code: string }[] = await this.em
-      .getConnection()
-      .execute(
-        'SELECT DISTINCT code FROM department WHERE id = ANY($1) AND deleted_at IS NULL',
-        [deptIds],
-      );
+    const rows: { code: string }[] = await this.em.execute(
+      'SELECT DISTINCT code FROM department WHERE id = ANY(?) AND deleted_at IS NULL',
+      [pgArray(deptIds)],
+    );
 
     return rows.map((r) => r.code);
   }

--- a/src/modules/index.module.ts
+++ b/src/modules/index.module.ts
@@ -23,6 +23,7 @@ import { CurriculumModule } from './curriculum/curriculum.module';
 import { AdminModule } from './admin/admin.module';
 import { AuditModule } from './audit/audit.module';
 import { SemestersModule } from './semesters/semesters.module';
+import { ReportsModule } from './reports/reports.module';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { ThrottlerStorageRedisService } from '@nest-lab/throttler-storage-redis';
 import { LoggerModule } from 'nestjs-pino';
@@ -47,6 +48,7 @@ export const ApplicationModules = [
   AdminModule,
   AuditModule,
   SemestersModule,
+  ReportsModule,
 ];
 
 export const InfrastructureModules = [

--- a/src/modules/reports/dto/batch-status.response.dto.ts
+++ b/src/modules/reports/dto/batch-status.response.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PaginationMeta } from 'src/modules/common/dto/pagination.dto';
+import { ReportStatusResponseDto } from './report-status.response.dto';
+
+export class BatchStatusResponseDto {
+  @ApiProperty()
+  batchId: string;
+
+  @ApiProperty()
+  total: number;
+
+  @ApiProperty()
+  completed: number;
+
+  @ApiProperty()
+  failed: number;
+
+  @ApiProperty()
+  skipped: number;
+
+  @ApiProperty()
+  active: number;
+
+  @ApiProperty()
+  waiting: number;
+
+  @ApiProperty({ type: [ReportStatusResponseDto] })
+  jobs: ReportStatusResponseDto[];
+
+  @ApiProperty({ type: PaginationMeta })
+  meta: PaginationMeta;
+}

--- a/src/modules/reports/dto/generate-batch-report.dto.ts
+++ b/src/modules/reports/dto/generate-batch-report.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
+
+export class GenerateBatchReportDto {
+  @ApiProperty({ description: 'UUID of the semester' })
+  @IsUUID()
+  semesterId: string;
+
+  @ApiProperty({ description: 'Questionnaire type code' })
+  @IsString()
+  @IsNotEmpty()
+  questionnaireTypeCode: string;
+
+  @ApiPropertyOptional({ description: 'Optional department UUID to filter by' })
+  @IsUUID()
+  @IsOptional()
+  departmentId?: string;
+
+  @ApiPropertyOptional({ description: 'Optional program UUID to filter by' })
+  @IsUUID()
+  @IsOptional()
+  programId?: string;
+}

--- a/src/modules/reports/dto/generate-report.dto.ts
+++ b/src/modules/reports/dto/generate-report.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, IsUUID } from 'class-validator';
+
+export class GenerateReportDto {
+  @ApiProperty({ description: 'UUID of the faculty member' })
+  @IsUUID()
+  facultyId: string;
+
+  @ApiProperty({ description: 'UUID of the semester' })
+  @IsUUID()
+  semesterId: string;
+
+  @ApiProperty({ description: 'Questionnaire type code' })
+  @IsString()
+  @IsNotEmpty()
+  questionnaireTypeCode: string;
+}

--- a/src/modules/reports/dto/report-status.response.dto.ts
+++ b/src/modules/reports/dto/report-status.response.dto.ts
@@ -1,0 +1,34 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ReportStatusResponseDto {
+  @ApiProperty()
+  jobId: string;
+
+  @ApiProperty({
+    enum: ['waiting', 'active', 'completed', 'failed', 'skipped'],
+  })
+  status: string;
+
+  @ApiProperty()
+  facultyName: string;
+
+  @ApiPropertyOptional({
+    description: 'Presigned download URL, present when completed',
+  })
+  downloadUrl?: string;
+
+  @ApiPropertyOptional({ description: 'ISO timestamp of URL expiry' })
+  expiresAt?: string;
+
+  @ApiPropertyOptional({ description: 'Error message, present when failed' })
+  error?: string;
+
+  @ApiPropertyOptional({ description: 'Info message, present when skipped' })
+  message?: string;
+
+  @ApiProperty()
+  createdAt: string;
+
+  @ApiPropertyOptional()
+  completedAt?: string;
+}

--- a/src/modules/reports/interfaces/storage-provider.interface.ts
+++ b/src/modules/reports/interfaces/storage-provider.interface.ts
@@ -1,0 +1,15 @@
+export abstract class StorageProvider {
+  abstract Upload(
+    key: string,
+    buffer: Buffer,
+    contentType: string,
+  ): Promise<void>;
+  abstract GetPresignedUrl(
+    key: string,
+    expiresInSeconds: number,
+  ): Promise<string>;
+  abstract Delete(key: string): Promise<void>;
+  abstract DeleteByPrefix(prefix: string): Promise<void>;
+}
+
+export const STORAGE_PROVIDER = 'STORAGE_PROVIDER';

--- a/src/modules/reports/jobs/report-cleanup.job.spec.ts
+++ b/src/modules/reports/jobs/report-cleanup.job.spec.ts
@@ -1,0 +1,255 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { EntityManager } from '@mikro-orm/postgresql';
+import { ReportCleanupJob } from './report-cleanup.job';
+import { ReportJobRepository } from 'src/repositories/report-job.repository';
+import { ReportJob } from 'src/entities/report-job.entity';
+import {
+  StorageProvider,
+  STORAGE_PROVIDER,
+} from '../interfaces/storage-provider.interface';
+
+jest.mock('src/configurations/index.config', () => ({
+  env: { REPORT_RETENTION_DAYS: 7 },
+}));
+
+describe('ReportCleanupJob', () => {
+  let job: ReportCleanupJob;
+  let reportJobRepository: jest.Mocked<
+    Pick<ReportJobRepository, 'FindExpiredCompleted'>
+  >;
+  let storageProvider: jest.Mocked<
+    Pick<StorageProvider, 'Delete' | 'DeleteByPrefix'>
+  >;
+  let em: jest.Mocked<Pick<EntityManager, 'nativeDelete'>>;
+
+  beforeEach(async () => {
+    reportJobRepository = {
+      FindExpiredCompleted: jest.fn(),
+    };
+
+    storageProvider = {
+      Delete: jest.fn(),
+      DeleteByPrefix: jest.fn(),
+    };
+
+    em = {
+      nativeDelete: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReportCleanupJob,
+        {
+          provide: ReportJobRepository,
+          useValue: reportJobRepository,
+        },
+        {
+          provide: STORAGE_PROVIDER,
+          useValue: storageProvider,
+        },
+        {
+          provide: EntityManager,
+          useValue: em,
+        },
+        {
+          provide: SchedulerRegistry,
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    job = module.get<ReportCleanupJob>(ReportCleanupJob);
+  });
+
+  it('should be defined', () => {
+    expect(job).toBeDefined();
+  });
+
+  describe('runStartupTask', () => {
+    it('should return skipped status', async () => {
+      const result = await job['runStartupTask']();
+      expect(result).toEqual({
+        status: 'skipped',
+        details: 'Cleanup runs on schedule only',
+      });
+    });
+  });
+
+  describe('handleCleanup', () => {
+    it('should delete R2 objects by prefix and hard-delete expired completed jobs', async () => {
+      jest.useFakeTimers();
+      const now = new Date('2026-04-01T03:00:00Z').getTime();
+      jest.setSystemTime(now);
+
+      const expiredJobs = [
+        { id: 'job-1', storageKey: 'reports/batch-a/job-1.pdf' },
+        { id: 'job-2', storageKey: 'reports/batch-a/job-2.pdf' },
+      ] as ReportJob[];
+
+      reportJobRepository.FindExpiredCompleted.mockResolvedValue(expiredJobs);
+      storageProvider.DeleteByPrefix.mockResolvedValue(undefined);
+      em.nativeDelete.mockResolvedValue(2);
+
+      await job.handleCleanup();
+
+      const expectedCutoff = new Date(now - 7 * 24 * 60 * 60 * 1000);
+      expect(reportJobRepository.FindExpiredCompleted).toHaveBeenCalledWith(
+        expectedCutoff,
+      );
+
+      // Same prefix — only one DeleteByPrefix call
+      expect(storageProvider.DeleteByPrefix).toHaveBeenCalledTimes(1);
+      expect(storageProvider.DeleteByPrefix).toHaveBeenCalledWith(
+        'reports/batch-a/',
+      );
+
+      expect(em.nativeDelete).toHaveBeenCalledWith(ReportJob, {
+        id: { $in: ['job-1', 'job-2'] },
+      });
+
+      jest.useRealTimers();
+    });
+
+    it('should skip R2 deletion for jobs without storageKey', async () => {
+      const expiredJobs = [
+        { id: 'job-1', storageKey: undefined },
+        { id: 'job-2', storageKey: 'reports/batch-b/job-2.pdf' },
+      ] as ReportJob[];
+
+      reportJobRepository.FindExpiredCompleted.mockResolvedValue(expiredJobs);
+      storageProvider.DeleteByPrefix.mockResolvedValue(undefined);
+      em.nativeDelete.mockResolvedValue(2);
+
+      await job.handleCleanup();
+
+      expect(storageProvider.DeleteByPrefix).toHaveBeenCalledTimes(1);
+      expect(storageProvider.DeleteByPrefix).toHaveBeenCalledWith(
+        'reports/batch-b/',
+      );
+    });
+
+    it('should continue cleanup when R2 deletion fails', async () => {
+      const expiredJobs = [
+        { id: 'job-1', storageKey: 'reports/batch-c/job-1.pdf' },
+        { id: 'job-2', storageKey: 'reports/batch-d/job-2.pdf' },
+      ] as ReportJob[];
+
+      reportJobRepository.FindExpiredCompleted.mockResolvedValue(expiredJobs);
+      storageProvider.DeleteByPrefix.mockRejectedValueOnce(
+        new Error('R2 unavailable'),
+      ).mockResolvedValueOnce(undefined);
+      em.nativeDelete.mockResolvedValue(2);
+
+      const warnSpy = jest.spyOn(job['logger'], 'warn');
+
+      await job.handleCleanup();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to delete R2 prefix reports/batch-c/'),
+      );
+      // Both prefixes attempted
+      expect(storageProvider.DeleteByPrefix).toHaveBeenCalledTimes(2);
+      expect(em.nativeDelete).toHaveBeenCalledWith(ReportJob, {
+        id: { $in: ['job-1', 'job-2'] },
+      });
+    });
+
+    it('should not call nativeDelete when no expired jobs found', async () => {
+      reportJobRepository.FindExpiredCompleted.mockResolvedValue([]);
+      em.nativeDelete.mockResolvedValue(0);
+
+      await job.handleCleanup();
+
+      // First nativeDelete call should be for orphaned jobs only
+      expect(em.nativeDelete).toHaveBeenCalledTimes(1);
+      expect(em.nativeDelete).toHaveBeenCalledWith(ReportJob, {
+        status: 'waiting',
+        createdAt: { $lt: expect.any(Date) as Date },
+      });
+    });
+
+    it('should hard-delete orphaned waiting jobs older than 1 hour', async () => {
+      jest.useFakeTimers();
+      const now = new Date('2026-04-01T03:00:00Z').getTime();
+      jest.setSystemTime(now);
+
+      reportJobRepository.FindExpiredCompleted.mockResolvedValue([]);
+      em.nativeDelete.mockResolvedValue(3);
+
+      await job.handleCleanup();
+
+      const orphanCutoff = new Date(now - 60 * 60 * 1000);
+      expect(em.nativeDelete).toHaveBeenCalledWith(ReportJob, {
+        status: 'waiting',
+        createdAt: { $lt: orphanCutoff },
+      });
+
+      jest.useRealTimers();
+    });
+
+    it('should log the cleanup summary', async () => {
+      reportJobRepository.FindExpiredCompleted.mockResolvedValue([
+        { id: 'job-1', storageKey: 'key' },
+      ] as ReportJob[]);
+      storageProvider.Delete.mockResolvedValue(undefined);
+      em.nativeDelete
+        .mockResolvedValueOnce(1) // expired jobs delete
+        .mockResolvedValueOnce(2); // orphaned jobs delete
+
+      const logSpy = jest.spyOn(job['logger'], 'log');
+
+      await job.handleCleanup();
+
+      expect(logSpy).toHaveBeenCalledWith(
+        'Cleaned up 1 expired + 2 orphaned report jobs',
+      );
+    });
+
+    it('should skip execution when already running', async () => {
+      job['isRunning'] = true;
+      const logSpy = jest.spyOn(job['logger'], 'log');
+
+      await job.handleCleanup();
+
+      expect(reportJobRepository.FindExpiredCompleted).not.toHaveBeenCalled();
+      expect(em.nativeDelete).not.toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledWith(
+        'ReportCleanupJob is already running',
+      );
+    });
+
+    it('should reset isRunning after successful execution', async () => {
+      reportJobRepository.FindExpiredCompleted.mockResolvedValue([]);
+      em.nativeDelete.mockResolvedValue(0);
+
+      await job.handleCleanup();
+
+      expect(job['isRunning']).toBe(false);
+    });
+
+    it('should reset isRunning after failed execution', async () => {
+      reportJobRepository.FindExpiredCompleted.mockRejectedValue(
+        new Error('DB error'),
+      );
+
+      await job.handleCleanup();
+
+      expect(job['isRunning']).toBe(false);
+    });
+
+    it('should return failed status and log error when an exception occurs', async () => {
+      reportJobRepository.FindExpiredCompleted.mockRejectedValue(
+        new Error('DB connection lost'),
+      );
+      const errorSpy = jest.spyOn(job['logger'], 'error');
+
+      await job.handleCleanup();
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Error during report cleanup:',
+        'DB connection lost',
+      );
+    });
+  });
+});

--- a/src/modules/reports/jobs/report-cleanup.job.ts
+++ b/src/modules/reports/jobs/report-cleanup.job.ts
@@ -1,0 +1,104 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { Cron, SchedulerRegistry } from '@nestjs/schedule';
+import { EntityManager } from '@mikro-orm/postgresql';
+import { BaseJob } from 'src/crons/base.job';
+import { JobRecordType } from 'src/crons/startup-job-registry';
+import { env } from 'src/configurations/index.config';
+import { ReportJob } from 'src/entities/report-job.entity';
+import { ReportJobRepository } from 'src/repositories/report-job.repository';
+import {
+  StorageProvider,
+  STORAGE_PROVIDER,
+} from '../interfaces/storage-provider.interface';
+
+@Injectable()
+export class ReportCleanupJob extends BaseJob {
+  private isRunning = false;
+
+  constructor(
+    private readonly reportJobRepository: ReportJobRepository,
+    @Inject(STORAGE_PROVIDER)
+    private readonly storageProvider: StorageProvider,
+    private readonly em: EntityManager,
+    schedulerRegistry: SchedulerRegistry,
+  ) {
+    super(schedulerRegistry, ReportCleanupJob.name);
+  }
+
+  protected runStartupTask(): Promise<JobRecordType> {
+    return Promise.resolve({
+      status: 'skipped',
+      details: 'Cleanup runs on schedule only',
+    });
+  }
+
+  @Cron('0 3 * * *', { name: 'ReportCleanupJob' })
+  async handleCleanup(): Promise<void> {
+    await this.safeRun();
+  }
+
+  private async safeRun(): Promise<JobRecordType> {
+    if (this.isRunning) {
+      this.logger.log('ReportCleanupJob is already running');
+      return { status: 'skipped', details: 'Job is already running' };
+    }
+
+    this.isRunning = true;
+
+    try {
+      const cutoffDate = new Date(
+        Date.now() - env.REPORT_RETENTION_DAYS * 24 * 60 * 60 * 1000,
+      );
+
+      // 1. Clean up expired completed/skipped jobs
+      const expiredJobs =
+        await this.reportJobRepository.FindExpiredCompleted(cutoffDate);
+      const storageKeys = expiredJobs
+        .map((j) => j.storageKey)
+        .filter((k): k is string => !!k);
+
+      // Batch delete R2 objects — group by prefix for efficiency
+      const prefixes = new Set(
+        storageKeys.map((k) => k.substring(0, k.lastIndexOf('/') + 1)),
+      );
+      for (const prefix of prefixes) {
+        try {
+          await this.storageProvider.DeleteByPrefix(prefix);
+        } catch (error) {
+          this.logger.warn(
+            `Failed to delete R2 prefix ${prefix}: ${(error as Error).message}`,
+          );
+        }
+      }
+
+      let expiredCount = 0;
+      if (expiredJobs.length > 0) {
+        expiredCount = await this.em.nativeDelete(ReportJob, {
+          id: { $in: expiredJobs.map((j) => j.id) },
+        });
+      }
+
+      // 2. Clean up orphaned waiting jobs (>1hr old)
+      const orphanCutoff = new Date(Date.now() - 60 * 60 * 1000);
+      const orphanedCount = await this.em.nativeDelete(ReportJob, {
+        status: 'waiting',
+        createdAt: { $lt: orphanCutoff },
+      });
+
+      this.logger.log(
+        `Cleaned up ${expiredCount} expired + ${orphanedCount} orphaned report jobs`,
+      );
+
+      return {
+        status: 'executed',
+        details: `Deleted ${expiredCount} expired + ${orphanedCount} orphaned jobs`,
+      };
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error('Error during report cleanup:', message);
+      return { status: 'failed', details: message };
+    } finally {
+      this.isRunning = false;
+    }
+  }
+}

--- a/src/modules/reports/processors/report-generation.processor.spec.ts
+++ b/src/modules/reports/processors/report-generation.processor.spec.ts
@@ -1,0 +1,260 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EntityManager } from '@mikro-orm/postgresql';
+import type { Job } from 'bullmq';
+import { ReportJob } from 'src/entities/report-job.entity';
+import { AnalyticsService } from 'src/modules/analytics/analytics.service';
+import { PdfService } from '../services/pdf.service';
+import { STORAGE_PROVIDER } from '../interfaces/storage-provider.interface';
+import {
+  ReportGenerationProcessor,
+  ReportJobMessage,
+} from './report-generation.processor';
+
+describe('ReportGenerationProcessor', () => {
+  let processor: ReportGenerationProcessor;
+  let mockFork: {
+    findOneOrFail: jest.Mock;
+    findOne: jest.Mock;
+    flush: jest.Mock;
+  };
+  let mockEm: { fork: jest.Mock };
+  let mockAnalyticsService: {
+    GetFacultyReportUnscoped: jest.Mock;
+    GetAllFacultyReportComments: jest.Mock;
+  };
+  let mockPdfService: { GenerateFacultyEvaluationPdf: jest.Mock };
+  let mockStorageProvider: { Upload: jest.Mock };
+
+  const jobData: ReportJobMessage = {
+    reportJobId: 'rj-1',
+    facultyId: 'faculty-1',
+    semesterId: 'sem-1',
+    questionnaireTypeCode: 'EVAL',
+  };
+
+  const mockReportJob: Partial<ReportJob> = {
+    id: 'rj-1',
+    status: 'waiting',
+    batchId: 'batch-1',
+  };
+
+  beforeEach(async () => {
+    mockFork = {
+      findOneOrFail: jest.fn().mockResolvedValue({ ...mockReportJob }),
+      findOne: jest.fn(),
+      flush: jest.fn().mockResolvedValue(undefined),
+    };
+    mockEm = { fork: jest.fn().mockReturnValue(mockFork) };
+
+    mockAnalyticsService = {
+      GetFacultyReportUnscoped: jest.fn(),
+      GetAllFacultyReportComments: jest.fn(),
+    };
+
+    mockPdfService = {
+      GenerateFacultyEvaluationPdf: jest.fn(),
+    };
+
+    mockStorageProvider = {
+      Upload: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReportGenerationProcessor,
+        { provide: EntityManager, useValue: mockEm },
+        { provide: AnalyticsService, useValue: mockAnalyticsService },
+        { provide: PdfService, useValue: mockPdfService },
+        { provide: STORAGE_PROVIDER, useValue: mockStorageProvider },
+      ],
+    }).compile();
+
+    processor = module.get<ReportGenerationProcessor>(
+      ReportGenerationProcessor,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(processor).toBeDefined();
+  });
+
+  describe('process — happy path', () => {
+    it('should fetch data, generate PDF, upload, and set status to completed', async () => {
+      const reportData = { submissionCount: 10 };
+      const comments = [{ text: 'Great course' }];
+      const pdfBuffer = Buffer.from('pdf-content');
+
+      mockAnalyticsService.GetFacultyReportUnscoped.mockResolvedValue(
+        reportData,
+      );
+      mockAnalyticsService.GetAllFacultyReportComments.mockResolvedValue(
+        comments,
+      );
+      mockPdfService.GenerateFacultyEvaluationPdf.mockResolvedValue(pdfBuffer);
+
+      const reportJobEntity = { ...mockReportJob };
+      mockFork.findOneOrFail.mockResolvedValue(reportJobEntity);
+
+      const mockJob = { data: jobData } as Job<ReportJobMessage>;
+      await processor.process(mockJob);
+
+      // Forks the EntityManager
+      expect(mockEm.fork).toHaveBeenCalled();
+
+      // Loads the ReportJob entity and sets status to active
+      expect(mockFork.findOneOrFail).toHaveBeenCalledWith(ReportJob, 'rj-1');
+      expect(reportJobEntity.status).toBe('completed');
+
+      // Fetches report data
+      expect(
+        mockAnalyticsService.GetFacultyReportUnscoped,
+      ).toHaveBeenCalledWith('faculty-1', {
+        semesterId: 'sem-1',
+        questionnaireTypeCode: 'EVAL',
+      });
+
+      // Fetches comments
+      expect(
+        mockAnalyticsService.GetAllFacultyReportComments,
+      ).toHaveBeenCalledWith('faculty-1', {
+        semesterId: 'sem-1',
+        questionnaireTypeCode: 'EVAL',
+      });
+
+      // Generates PDF
+      expect(mockPdfService.GenerateFacultyEvaluationPdf).toHaveBeenCalledWith(
+        reportData,
+        comments,
+      );
+
+      // Uploads to storage
+      const expectedKey =
+        'reports/faculty_evaluation/sem-1/batch-1/faculty-1.pdf';
+      expect(mockStorageProvider.Upload).toHaveBeenCalledWith(
+        expectedKey,
+        pdfBuffer,
+        'application/pdf',
+      );
+
+      // Updates entity with completed status and storage key
+      expect(reportJobEntity.storageKey).toBe(expectedKey);
+      expect(reportJobEntity.completedAt).toBeInstanceOf(Date);
+
+      // Flushes changes (initial active + final completed)
+      expect(mockFork.flush).toHaveBeenCalledTimes(2);
+    });
+
+    it('should use reportJob.id as storage key segment when batchId is absent', async () => {
+      const reportJobEntity = { ...mockReportJob, batchId: undefined };
+      mockFork.findOneOrFail.mockResolvedValue(reportJobEntity);
+      mockAnalyticsService.GetFacultyReportUnscoped.mockResolvedValue({
+        submissionCount: 5,
+      });
+      mockAnalyticsService.GetAllFacultyReportComments.mockResolvedValue([]);
+      mockPdfService.GenerateFacultyEvaluationPdf.mockResolvedValue(
+        Buffer.from('pdf'),
+      );
+
+      await processor.process({ data: jobData } as Job<ReportJobMessage>);
+
+      const expectedKey = 'reports/faculty_evaluation/sem-1/rj-1/faculty-1.pdf';
+      expect(mockStorageProvider.Upload).toHaveBeenCalledWith(
+        expectedKey,
+        expect.any(Buffer),
+        'application/pdf',
+      );
+    });
+  });
+
+  describe('process — skipped (no submissions)', () => {
+    it('should set status to skipped when submissionCount is 0', async () => {
+      const reportJobEntity = { ...mockReportJob };
+      mockFork.findOneOrFail.mockResolvedValue(reportJobEntity);
+      mockAnalyticsService.GetFacultyReportUnscoped.mockResolvedValue({
+        submissionCount: 0,
+      });
+
+      await processor.process({ data: jobData } as Job<ReportJobMessage>);
+
+      expect(reportJobEntity.status).toBe('skipped');
+      expect(reportJobEntity.completedAt).toBeInstanceOf(Date);
+
+      // Should NOT generate PDF, fetch comments, or upload
+      expect(
+        mockAnalyticsService.GetAllFacultyReportComments,
+      ).not.toHaveBeenCalled();
+      expect(
+        mockPdfService.GenerateFacultyEvaluationPdf,
+      ).not.toHaveBeenCalled();
+      expect(mockStorageProvider.Upload).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onFailed', () => {
+    it('should update report job status to failed on final attempt', async () => {
+      const reportJobEntity = { status: 'active' as const, error: undefined };
+      mockFork.findOne.mockResolvedValue(reportJobEntity);
+
+      const mockJob = {
+        id: 'bull-job-1',
+        data: jobData,
+        attemptsMade: 3,
+        opts: { attempts: 3 },
+      } as Job<ReportJobMessage>;
+
+      await processor.onFailed(mockJob, new Error('Worker crashed'));
+
+      expect(mockEm.fork).toHaveBeenCalled();
+      expect(mockFork.findOne).toHaveBeenCalledWith(ReportJob, 'rj-1');
+      expect(reportJobEntity.status).toBe('failed');
+      expect(reportJobEntity.error).toBe('Worker crashed');
+      expect(mockFork.flush).toHaveBeenCalled();
+    });
+
+    it('should skip DB update on non-final attempt', async () => {
+      const mockJob = {
+        id: 'bull-job-4',
+        data: jobData,
+        attemptsMade: 1,
+        opts: { attempts: 3 },
+      } as Job<ReportJobMessage>;
+
+      await processor.onFailed(mockJob, new Error('transient error'));
+
+      expect(mockEm.fork).not.toHaveBeenCalled();
+      expect(mockFork.flush).not.toHaveBeenCalled();
+    });
+
+    it('should not throw if the report job entity is not found', async () => {
+      mockFork.findOne.mockResolvedValue(null);
+
+      const mockJob = {
+        id: 'bull-job-2',
+        data: jobData,
+        attemptsMade: 3,
+        opts: { attempts: 3 },
+      } as Job<ReportJobMessage>;
+
+      await expect(
+        processor.onFailed(mockJob, new Error('some error')),
+      ).resolves.toBeUndefined();
+
+      expect(mockFork.flush).not.toHaveBeenCalled();
+    });
+
+    it('should not throw if the DB update itself fails', async () => {
+      mockFork.findOne.mockRejectedValue(new Error('DB connection lost'));
+
+      const mockJob = {
+        id: 'bull-job-3',
+        data: jobData,
+        attemptsMade: 3,
+        opts: { attempts: 3 },
+      } as Job<ReportJobMessage>;
+
+      await expect(
+        processor.onFailed(mockJob, new Error('original error')),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/modules/reports/processors/report-generation.processor.ts
+++ b/src/modules/reports/processors/report-generation.processor.ts
@@ -1,0 +1,120 @@
+import { Logger, Inject } from '@nestjs/common';
+import { Processor, WorkerHost, OnWorkerEvent } from '@nestjs/bullmq';
+import { Job } from 'bullmq';
+import { EntityManager } from '@mikro-orm/postgresql';
+import { QueueName } from 'src/configurations/common/queue-names';
+import { env } from 'src/configurations/index.config';
+import { ReportJob } from 'src/entities/report-job.entity';
+import { AnalyticsService } from 'src/modules/analytics/analytics.service';
+import { PdfService } from '../services/pdf.service';
+import {
+  StorageProvider,
+  STORAGE_PROVIDER,
+} from '../interfaces/storage-provider.interface';
+
+export interface ReportJobMessage {
+  reportJobId: string;
+  facultyId: string;
+  semesterId: string;
+  questionnaireTypeCode: string;
+}
+
+@Processor(QueueName.REPORT_GENERATION, {
+  concurrency: env.REPORT_GENERATION_CONCURRENCY,
+})
+export class ReportGenerationProcessor extends WorkerHost {
+  private readonly logger = new Logger(ReportGenerationProcessor.name);
+
+  constructor(
+    private readonly em: EntityManager,
+    private readonly analyticsService: AnalyticsService,
+    private readonly pdfService: PdfService,
+    @Inject(STORAGE_PROVIDER)
+    private readonly storageProvider: StorageProvider,
+  ) {
+    super();
+  }
+
+  async process(job: Job<ReportJobMessage>): Promise<void> {
+    const { reportJobId, facultyId, semesterId, questionnaireTypeCode } =
+      job.data;
+
+    const fork = this.em.fork();
+    const reportJob = await fork.findOneOrFail(ReportJob, reportJobId);
+    reportJob.status = 'active';
+    await fork.flush();
+
+    // Fetch report data (unscoped — authorization was performed at enqueue time)
+    const reportData = await this.analyticsService.GetFacultyReportUnscoped(
+      facultyId,
+      { semesterId, questionnaireTypeCode },
+    );
+
+    // Skip PDF generation if no submissions
+    if (reportData.submissionCount === 0) {
+      reportJob.status = 'skipped';
+      reportJob.completedAt = new Date();
+      await fork.flush();
+      this.logger.log(
+        `Report job ${reportJobId} skipped — no submissions for faculty ${facultyId}`,
+      );
+      return;
+    }
+
+    // Fetch all comments
+    const comments = await this.analyticsService.GetAllFacultyReportComments(
+      facultyId,
+      { semesterId, questionnaireTypeCode },
+    );
+
+    // Generate PDF
+    const pdfBuffer = await this.pdfService.GenerateFacultyEvaluationPdf(
+      reportData,
+      comments,
+    );
+
+    // Build storage key
+    const storageKey = `reports/faculty_evaluation/${semesterId}/${reportJob.batchId ?? reportJob.id}/${facultyId}.pdf`;
+
+    // Upload to R2
+    await this.storageProvider.Upload(storageKey, pdfBuffer, 'application/pdf');
+
+    // Update job status
+    reportJob.status = 'completed';
+    reportJob.storageKey = storageKey;
+    reportJob.completedAt = new Date();
+    await fork.flush();
+
+    this.logger.log(
+      `Report job ${reportJobId} completed — faculty ${facultyId}`,
+    );
+  }
+
+  @OnWorkerEvent('failed')
+  async onFailed(job: Job<ReportJobMessage>, error: Error): Promise<void> {
+    const maxAttempts = job.opts.attempts ?? env.BULLMQ_DEFAULT_ATTEMPTS;
+    const isFinalAttempt = job.attemptsMade >= maxAttempts;
+
+    this.logger.error(
+      `Report job ${job.id} failed (attempt ${job.attemptsMade}/${maxAttempts}): ` +
+        `reportJobId=${job.data.reportJobId}, facultyId=${job.data.facultyId} — ${error.message}`,
+    );
+
+    // Only mark as permanently failed on the final attempt — BullMQ will retry otherwise
+    if (!isFinalAttempt) return;
+
+    try {
+      const fork = this.em.fork();
+      const reportJob = await fork.findOne(ReportJob, job.data.reportJobId);
+      if (reportJob) {
+        reportJob.status = 'failed';
+        reportJob.error = error.message;
+        await fork.flush();
+      }
+    } catch (dbError) {
+      this.logger.error(
+        `Failed to update report job status: ${(dbError as Error).message}`,
+      );
+    }
+  }
+}

--- a/src/modules/reports/reports.controller.ts
+++ b/src/modules/reports/reports.controller.ts
@@ -1,0 +1,84 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Query,
+  Req,
+  UseInterceptors,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { UseJwtGuard } from 'src/security/decorators';
+import { UserRole } from 'src/modules/auth/roles.enum';
+import { CurrentUserInterceptor } from 'src/modules/common/interceptors/current-user.interceptor';
+import type { AuthenticatedRequest } from 'src/modules/common/interceptors/http/authenticated-request';
+import { ReportsService } from './reports.service';
+import { GenerateReportDto } from './dto/generate-report.dto';
+import { GenerateBatchReportDto } from './dto/generate-batch-report.dto';
+import { ReportStatusResponseDto } from './dto/report-status.response.dto';
+import { BatchStatusResponseDto } from './dto/batch-status.response.dto';
+
+@ApiTags('Reports')
+@Controller('reports')
+@UseJwtGuard(UserRole.SUPER_ADMIN, UserRole.DEAN, UserRole.CHAIRPERSON)
+@UseInterceptors(CurrentUserInterceptor)
+export class ReportsController {
+  constructor(private readonly reportsService: ReportsService) {}
+
+  @Post('generate')
+  @HttpCode(HttpStatus.ACCEPTED)
+  @ApiOperation({ summary: 'Generate a single faculty evaluation PDF report' })
+  @ApiResponse({ status: 202, description: 'Report generation queued' })
+  async GenerateReport(
+    @Body() dto: GenerateReportDto,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<{ jobId: string }> {
+    return this.reportsService.GenerateSingle(dto, req.user!.userId);
+  }
+
+  @Post('generate/batch')
+  @HttpCode(HttpStatus.ACCEPTED)
+  @Throttle({ default: { limit: 3, ttl: 60000 } })
+  @ApiOperation({ summary: 'Generate batch faculty evaluation PDF reports' })
+  @ApiResponse({ status: 202, description: 'Batch report generation queued' })
+  async GenerateBatchReport(
+    @Body() dto: GenerateBatchReportDto,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<{ batchId: string; jobCount: number; skippedCount: number }> {
+    return this.reportsService.GenerateBatch(dto, req.user!.userId);
+  }
+
+  @Get('status/:jobId')
+  @ApiOperation({ summary: 'Get status of a single report job' })
+  @ApiResponse({ status: 200, type: ReportStatusResponseDto })
+  async GetReportStatus(
+    @Param('jobId', ParseUUIDPipe) jobId: string,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<ReportStatusResponseDto> {
+    return this.reportsService.GetJobStatus(jobId, req.user!.userId);
+  }
+
+  @Get('batch/:batchId')
+  @ApiOperation({ summary: 'Get status of a batch report generation' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiResponse({ status: 200, type: BatchStatusResponseDto })
+  async GetBatchStatus(
+    @Param('batchId', ParseUUIDPipe) batchId: string,
+    @Query('page') page: string,
+    @Query('limit') limit: string,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<BatchStatusResponseDto> {
+    return this.reportsService.GetBatchStatus(
+      batchId,
+      req.user!.userId,
+      page ? parseInt(page, 10) : undefined,
+      limit ? parseInt(limit, 10) : undefined,
+    );
+  }
+}

--- a/src/modules/reports/reports.module.ts
+++ b/src/modules/reports/reports.module.ts
@@ -3,6 +3,7 @@ import { BullModule } from '@nestjs/bullmq';
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { QueueName } from 'src/configurations/common/queue-names';
 import { ReportJob } from 'src/entities/report-job.entity';
+import { User } from 'src/entities/user.entity';
 import { CommonModule } from '../common/common.module';
 import { AnalyticsModule } from '../analytics/analytics.module';
 import DataLoaderModule from '../common/data-loaders/index.module';
@@ -17,7 +18,7 @@ import { ReportCleanupJob } from './jobs/report-cleanup.job';
 @Module({
   imports: [
     BullModule.registerQueue({ name: QueueName.REPORT_GENERATION }),
-    MikroOrmModule.forFeature([ReportJob]),
+    MikroOrmModule.forFeature([ReportJob, User]),
     CommonModule,
     AnalyticsModule,
     DataLoaderModule,

--- a/src/modules/reports/reports.module.ts
+++ b/src/modules/reports/reports.module.ts
@@ -1,0 +1,35 @@
+import { Module } from '@nestjs/common';
+import { BullModule } from '@nestjs/bullmq';
+import { MikroOrmModule } from '@mikro-orm/nestjs';
+import { QueueName } from 'src/configurations/common/queue-names';
+import { ReportJob } from 'src/entities/report-job.entity';
+import { CommonModule } from '../common/common.module';
+import { AnalyticsModule } from '../analytics/analytics.module';
+import DataLoaderModule from '../common/data-loaders/index.module';
+import { ReportsService } from './reports.service';
+import { ReportsController } from './reports.controller';
+import { ReportGenerationProcessor } from './processors/report-generation.processor';
+import { PdfService } from './services/pdf.service';
+import { R2StorageService } from './services/r2-storage.service';
+import { STORAGE_PROVIDER } from './interfaces/storage-provider.interface';
+import { ReportCleanupJob } from './jobs/report-cleanup.job';
+
+@Module({
+  imports: [
+    BullModule.registerQueue({ name: QueueName.REPORT_GENERATION }),
+    MikroOrmModule.forFeature([ReportJob]),
+    CommonModule,
+    AnalyticsModule,
+    DataLoaderModule,
+  ],
+  controllers: [ReportsController],
+  providers: [
+    ReportsService,
+    ReportGenerationProcessor,
+    PdfService,
+    { provide: STORAGE_PROVIDER, useClass: R2StorageService },
+    ReportCleanupJob,
+  ],
+  exports: [ReportsService],
+})
+export class ReportsModule {}

--- a/src/modules/reports/reports.service.spec.ts
+++ b/src/modules/reports/reports.service.spec.ts
@@ -26,6 +26,7 @@ describe('ReportsService', () => {
   let mockEntityManager: {
     fork: jest.Mock;
     nativeDelete: jest.Mock;
+    execute: jest.Mock;
     getConnection: jest.Mock;
   };
   let mockStorageProvider: {
@@ -78,6 +79,7 @@ describe('ReportsService', () => {
     mockEntityManager = {
       fork: jest.fn().mockReturnValue(mockForkEm),
       nativeDelete: jest.fn().mockResolvedValue(0),
+      execute: mockConnection.execute,
       getConnection: jest.fn().mockReturnValue(mockConnection),
     };
     mockStorageProvider = {

--- a/src/modules/reports/reports.service.spec.ts
+++ b/src/modules/reports/reports.service.spec.ts
@@ -1,0 +1,582 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { getQueueToken } from '@nestjs/bullmq';
+import { QueueName } from 'src/configurations/common/queue-names';
+import { ReportsService } from './reports.service';
+import { ReportJobRepository } from 'src/repositories/report-job.repository';
+import { ScopeResolverService } from 'src/modules/common/services/scope-resolver.service';
+import { STORAGE_PROVIDER } from './interfaces/storage-provider.interface';
+import { EntityManager } from '@mikro-orm/postgresql';
+import { CurrentUserService } from 'src/modules/common/cls/current-user.service';
+import { UserRole } from 'src/modules/auth/roles.enum';
+import type { ReportJobStatus } from 'src/entities/report-job.entity';
+
+describe('ReportsService', () => {
+  let service: ReportsService;
+  let mockQueue: { add: jest.Mock; addBulk: jest.Mock };
+  let mockReportJobRepository: {
+    findOne: jest.Mock;
+    find: jest.Mock;
+  };
+  let mockScopeResolver: { ResolveDepartmentIds: jest.Mock };
+  let mockEntityManager: {
+    fork: jest.Mock;
+    nativeDelete: jest.Mock;
+    getConnection: jest.Mock;
+  };
+  let mockStorageProvider: {
+    GetPresignedUrl: jest.Mock;
+    Upload: jest.Mock;
+    Delete: jest.Mock;
+    DeleteByPrefix: jest.Mock;
+  };
+  let mockCurrentUserService: { getOrFail: jest.Mock };
+
+  // Shared test data
+  const userId = 'user-001';
+  const facultyId = 'faculty-001';
+  const semesterId = 'semester-001';
+  const questionnaireTypeCode = 'STUDENT_EVAL';
+
+  const mockForkEm = {
+    getReference: jest.fn().mockReturnValue({ id: userId }),
+    create: jest.fn(),
+    flush: jest.fn(),
+  };
+
+  const mockConnection = {
+    execute: jest.fn(),
+  };
+
+  const baseDeanUser = {
+    id: userId,
+    roles: [UserRole.DEAN],
+  };
+
+  const baseSuperAdminUser = {
+    id: userId,
+    roles: [UserRole.SUPER_ADMIN],
+  };
+
+  beforeEach(async () => {
+    mockQueue = {
+      add: jest.fn().mockResolvedValue({ id: 'bull-job-1' }),
+      addBulk: jest.fn().mockResolvedValue([]),
+    };
+    mockReportJobRepository = {
+      findOne: jest.fn().mockResolvedValue(null),
+      find: jest.fn().mockResolvedValue([]),
+    };
+    mockScopeResolver = {
+      ResolveDepartmentIds: jest.fn().mockResolvedValue(null),
+    };
+    mockConnection.execute = jest.fn().mockResolvedValue([]);
+    mockEntityManager = {
+      fork: jest.fn().mockReturnValue(mockForkEm),
+      nativeDelete: jest.fn().mockResolvedValue(0),
+      getConnection: jest.fn().mockReturnValue(mockConnection),
+    };
+    mockStorageProvider = {
+      GetPresignedUrl: jest
+        .fn()
+        .mockResolvedValue('https://storage.example.com/presigned'),
+      Upload: jest.fn().mockResolvedValue(undefined),
+      Delete: jest.fn().mockResolvedValue(undefined),
+      DeleteByPrefix: jest.fn().mockResolvedValue(undefined),
+    };
+    mockCurrentUserService = {
+      getOrFail: jest.fn().mockReturnValue(baseDeanUser),
+    };
+
+    // Reset fork em mocks
+    mockForkEm.getReference = jest.fn().mockReturnValue({ id: userId });
+    mockForkEm.create = jest
+      .fn()
+      .mockImplementation(
+        (_entity: unknown, data: Record<string, unknown>) => ({
+          id: 'report-job-001',
+          ...data,
+        }),
+      );
+    mockForkEm.flush = jest.fn().mockResolvedValue(undefined);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReportsService,
+        {
+          provide: getQueueToken(QueueName.REPORT_GENERATION),
+          useValue: mockQueue,
+        },
+        { provide: ReportJobRepository, useValue: mockReportJobRepository },
+        { provide: EntityManager, useValue: mockEntityManager },
+        { provide: ScopeResolverService, useValue: mockScopeResolver },
+        { provide: CurrentUserService, useValue: mockCurrentUserService },
+        { provide: STORAGE_PROVIDER, useValue: mockStorageProvider },
+      ],
+    }).compile();
+
+    service = module.get<ReportsService>(ReportsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('GenerateSingle', () => {
+    const dto = { facultyId, semesterId, questionnaireTypeCode };
+
+    beforeEach(() => {
+      // Semester validation passes
+      mockConnection.execute.mockImplementation((sql: string) => {
+        if (sql.includes('FROM semester')) {
+          return [{ id: semesterId }];
+        }
+        if (sql.includes('FROM "user"')) {
+          return [
+            { department_id: 'dept-001', first_name: 'John', last_name: 'Doe' },
+          ];
+        }
+        return [];
+      });
+      // Scope: dean with access
+      mockScopeResolver.ResolveDepartmentIds.mockResolvedValue(['dept-001']);
+    });
+
+    it('should create entity, enqueue job, and return jobId', async () => {
+      const result = await service.GenerateSingle(dto, userId);
+
+      expect(result).toEqual({ jobId: 'report-job-001' });
+
+      // Semester was validated
+      expect(mockConnection.execute).toHaveBeenCalledWith(
+        expect.stringContaining('FROM semester'),
+        [semesterId],
+      );
+
+      // Scope was validated
+      expect(mockScopeResolver.ResolveDepartmentIds).toHaveBeenCalledWith(
+        semesterId,
+      );
+
+      // Entity was created via fork
+      expect(mockEntityManager.fork).toHaveBeenCalled();
+      expect(mockForkEm.create).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          reportType: 'faculty_evaluation',
+          status: 'waiting',
+          facultyId,
+          semesterId,
+          questionnaireTypeCode,
+        }),
+      );
+      expect(mockForkEm.flush).toHaveBeenCalled();
+
+      // Job was enqueued
+      expect(mockQueue.add).toHaveBeenCalledTimes(1);
+      const [name, message, opts] = mockQueue.add.mock.calls[0] as [
+        string,
+        Record<string, unknown>,
+        Record<string, unknown>,
+      ];
+      expect(name).toBe('report');
+      expect(message).toMatchObject({
+        reportJobId: 'report-job-001',
+        facultyId,
+        semesterId,
+        questionnaireTypeCode,
+      });
+      expect(opts.removeOnComplete).toBe(true);
+      expect(opts.removeOnFail).toBe(100);
+    });
+
+    it('should throw ForbiddenException when faculty is out of scope', async () => {
+      // Faculty belongs to dept-002 but dean only has access to dept-001
+      mockScopeResolver.ResolveDepartmentIds.mockResolvedValue(['dept-001']);
+      mockConnection.execute.mockImplementation((sql: string) => {
+        if (sql.includes('FROM semester')) {
+          return [{ id: semesterId }];
+        }
+        if (sql.includes('FROM "user"')) {
+          return [
+            {
+              department_id: 'dept-002',
+              first_name: 'Jane',
+              last_name: 'Smith',
+            },
+          ];
+        }
+        return [];
+      });
+
+      await expect(service.GenerateSingle(dto, userId)).rejects.toThrow(
+        ForbiddenException,
+      );
+      // Should never reach entity creation or enqueue
+      expect(mockForkEm.create).not.toHaveBeenCalled();
+      expect(mockQueue.add).not.toHaveBeenCalled();
+    });
+
+    it('should return existing jobId when duplicate pending job exists (dedup)', async () => {
+      const existingJob = { id: 'existing-job-id' };
+      mockReportJobRepository.findOne.mockResolvedValueOnce(existingJob);
+
+      const result = await service.GenerateSingle(dto, userId);
+
+      expect(result).toEqual({ jobId: 'existing-job-id' });
+      // Should not create a new entity or enqueue
+      expect(mockForkEm.create).not.toHaveBeenCalled();
+      expect(mockQueue.add).not.toHaveBeenCalled();
+    });
+
+    it('should delete entity on BullMQ enqueue failure (orphan protection)', async () => {
+      mockQueue.add.mockRejectedValue(new Error('Redis ECONNREFUSED'));
+
+      await expect(service.GenerateSingle(dto, userId)).rejects.toThrow(
+        'Redis ECONNREFUSED',
+      );
+
+      // Entity was created
+      expect(mockForkEm.create).toHaveBeenCalled();
+      expect(mockForkEm.flush).toHaveBeenCalled();
+
+      // Orphaned entity was cleaned up
+      expect(mockEntityManager.nativeDelete).toHaveBeenCalledWith(
+        expect.anything(),
+        { id: 'report-job-001' },
+      );
+    });
+
+    it('should throw NotFoundException when semester does not exist', async () => {
+      mockConnection.execute.mockImplementation((sql: string) => {
+        if (sql.includes('FROM semester')) {
+          return [];
+        }
+        return [];
+      });
+
+      await expect(service.GenerateSingle(dto, userId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('GenerateBatch', () => {
+    const batchDto = { semesterId, questionnaireTypeCode };
+
+    beforeEach(() => {
+      mockConnection.execute.mockImplementation((sql: string) => {
+        if (sql.includes('FROM semester')) {
+          return [{ id: semesterId }];
+        }
+        if (sql.includes('questionnaire_submission')) {
+          return [
+            { faculty_id: 'fac-1', first_name: 'Alice', last_name: 'A' },
+            { faculty_id: 'fac-2', first_name: 'Bob', last_name: 'B' },
+          ];
+        }
+        return [];
+      });
+      // Super admin scope (unrestricted)
+      mockScopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
+    });
+
+    it('should enforce batch size cap and throw BadRequestException', async () => {
+      // Create an array exceeding REPORT_BATCH_MAX_SIZE (default 100)
+      const largeFacultyList = Array.from({ length: 101 }, (_, i) => ({
+        faculty_id: `fac-${i}`,
+        first_name: `Name${i}`,
+        last_name: `Last${i}`,
+      }));
+      mockConnection.execute.mockImplementation((sql: string) => {
+        if (sql.includes('FROM semester')) {
+          return [{ id: semesterId }];
+        }
+        if (sql.includes('questionnaire_submission')) {
+          return largeFacultyList;
+        }
+        return [];
+      });
+
+      await expect(service.GenerateBatch(batchDto, userId)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should skip already-queued faculty and return correct skippedCount', async () => {
+      // Bulk dedup: fac-1 already has a pending job
+      mockReportJobRepository.find.mockResolvedValueOnce([
+        { id: 'existing-job', facultyId: 'fac-1' },
+      ]);
+
+      const result = await service.GenerateBatch(batchDto, userId);
+
+      expect(result.skippedCount).toBe(1);
+      expect(result.jobCount).toBe(1);
+      // addBulk called with 1 job (fac-2 only)
+      expect(mockQueue.addBulk).toHaveBeenCalledTimes(1);
+      expect(mockQueue.addBulk).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ name: 'report' })]),
+      );
+    });
+
+    it('should return jobCount 0 and correct skippedCount when all faculty are already queued', async () => {
+      // Bulk dedup: both faculty already have pending jobs
+      mockReportJobRepository.find.mockResolvedValueOnce([
+        { id: 'existing-job-1', facultyId: 'fac-1' },
+        { id: 'existing-job-2', facultyId: 'fac-2' },
+      ]);
+
+      const result = await service.GenerateBatch(batchDto, userId);
+
+      expect(result.jobCount).toBe(0);
+      expect(result.skippedCount).toBe(2);
+      expect(mockQueue.addBulk).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GetJobStatus', () => {
+    it('should generate fresh presigned URL for completed jobs', async () => {
+      const completedJob = {
+        id: 'job-001',
+        status: 'completed' as ReportJobStatus,
+        facultyName: 'John Doe',
+        storageKey: 'reports/job-001.pdf',
+        createdAt: new Date('2026-01-15T10:00:00Z'),
+        completedAt: new Date('2026-01-15T10:05:00Z'),
+        requestedBy: { id: userId },
+      };
+      mockReportJobRepository.findOne.mockResolvedValue(completedJob);
+      mockCurrentUserService.getOrFail.mockReturnValue(baseDeanUser);
+
+      const result = await service.GetJobStatus('job-001', userId);
+
+      expect(result.jobId).toBe('job-001');
+      expect(result.status).toBe('completed');
+      expect(result.downloadUrl).toBe('https://storage.example.com/presigned');
+      expect(result.expiresAt).toBeDefined();
+      expect(result.completedAt).toBe('2026-01-15T10:05:00.000Z');
+      expect(mockStorageProvider.GetPresignedUrl).toHaveBeenCalledWith(
+        'reports/job-001.pdf',
+        expect.any(Number),
+      );
+    });
+
+    it('should return 404 for jobs not owned by requesting user', async () => {
+      const otherUsersJob = {
+        id: 'job-002',
+        status: 'waiting' as ReportJobStatus,
+        facultyName: 'Jane Smith',
+        createdAt: new Date('2026-01-15T10:00:00Z'),
+        requestedBy: { id: 'other-user-id' },
+      };
+      mockReportJobRepository.findOne.mockResolvedValue(otherUsersJob);
+      // Non-admin user requesting someone else's job
+      mockCurrentUserService.getOrFail.mockReturnValue({
+        id: userId,
+        roles: [UserRole.DEAN],
+      });
+
+      await expect(service.GetJobStatus('job-002', userId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should allow super admin to access any job', async () => {
+      const otherUsersJob = {
+        id: 'job-003',
+        status: 'waiting' as ReportJobStatus,
+        facultyName: 'Jane Smith',
+        createdAt: new Date('2026-01-15T10:00:00Z'),
+        requestedBy: { id: 'other-user-id' },
+      };
+      mockReportJobRepository.findOne.mockResolvedValue(otherUsersJob);
+      mockCurrentUserService.getOrFail.mockReturnValue(baseSuperAdminUser);
+
+      const result = await service.GetJobStatus('job-003', userId);
+
+      expect(result.jobId).toBe('job-003');
+      expect(result.status).toBe('waiting');
+    });
+
+    it('should throw NotFoundException when job does not exist', async () => {
+      mockReportJobRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.GetJobStatus('nonexistent-id', userId),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should include error field for failed jobs', async () => {
+      const failedJob = {
+        id: 'job-fail',
+        status: 'failed' as ReportJobStatus,
+        facultyName: 'Jane Smith',
+        error: 'Worker timeout',
+        createdAt: new Date('2026-01-15T10:00:00Z'),
+        requestedBy: { id: userId },
+      };
+      mockReportJobRepository.findOne.mockResolvedValue(failedJob);
+
+      const result = await service.GetJobStatus('job-fail', userId);
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toBe('Worker timeout');
+      expect(result.downloadUrl).toBeUndefined();
+    });
+  });
+
+  describe('GetBatchStatus', () => {
+    const setupBatchMocks = (
+      batchId: string,
+      ownerId: string,
+      countRows: { status: string; count: string }[],
+      pageJobs: Record<string, unknown>[],
+    ) => {
+      // findOne for ownership check
+      mockReportJobRepository.findOne.mockResolvedValue({
+        id: 'j1',
+        requestedBy: { id: ownerId },
+        batchId,
+      });
+      // SQL count aggregation
+      mockConnection.execute.mockResolvedValue(countRows);
+      // find for paginated jobs
+      mockReportJobRepository.find.mockResolvedValue(pageJobs);
+    };
+
+    it('should aggregate counts correctly', async () => {
+      const batchId = 'batch-001';
+      const pageJobs = [
+        {
+          id: 'j1',
+          status: 'completed' as ReportJobStatus,
+          facultyName: 'Alice A',
+          storageKey: 'reports/j1.pdf',
+          createdAt: new Date('2026-01-15T10:00:00Z'),
+          completedAt: new Date('2026-01-15T10:05:00Z'),
+          requestedBy: { id: userId },
+        },
+        {
+          id: 'j2',
+          status: 'completed' as ReportJobStatus,
+          facultyName: 'Bob B',
+          storageKey: 'reports/j2.pdf',
+          createdAt: new Date('2026-01-15T10:00:00Z'),
+          completedAt: new Date('2026-01-15T10:06:00Z'),
+          requestedBy: { id: userId },
+        },
+        {
+          id: 'j3',
+          status: 'failed' as ReportJobStatus,
+          facultyName: 'Carol C',
+          error: 'Worker error',
+          createdAt: new Date('2026-01-15T10:00:00Z'),
+          requestedBy: { id: userId },
+        },
+        {
+          id: 'j4',
+          status: 'waiting' as ReportJobStatus,
+          facultyName: 'Dave D',
+          createdAt: new Date('2026-01-15T10:00:00Z'),
+          requestedBy: { id: userId },
+        },
+        {
+          id: 'j5',
+          status: 'active' as ReportJobStatus,
+          facultyName: 'Eve E',
+          createdAt: new Date('2026-01-15T10:00:00Z'),
+          requestedBy: { id: userId },
+        },
+      ];
+      setupBatchMocks(
+        batchId,
+        userId,
+        [
+          { status: 'completed', count: '2' },
+          { status: 'failed', count: '1' },
+          { status: 'waiting', count: '1' },
+          { status: 'active', count: '1' },
+        ],
+        pageJobs,
+      );
+      mockCurrentUserService.getOrFail.mockReturnValue(baseDeanUser);
+
+      const result = await service.GetBatchStatus(batchId, userId);
+
+      expect(result.batchId).toBe(batchId);
+      expect(result.total).toBe(5);
+      expect(result.completed).toBe(2);
+      expect(result.failed).toBe(1);
+      expect(result.waiting).toBe(1);
+      expect(result.active).toBe(1);
+      expect(result.skipped).toBe(0);
+      expect(result.jobs).toHaveLength(5);
+
+      // Pagination meta
+      expect(result.meta.totalItems).toBe(5);
+      expect(result.meta.currentPage).toBe(1);
+      expect(result.meta.itemCount).toBe(5);
+    });
+
+    it('should throw NotFoundException for non-existent batch', async () => {
+      mockReportJobRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.GetBatchStatus('nonexistent-batch', userId),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw NotFoundException when user does not own the batch', async () => {
+      mockReportJobRepository.findOne.mockResolvedValue({
+        id: 'j1',
+        requestedBy: { id: 'other-user-id' },
+        batchId: 'batch-002',
+      });
+      mockCurrentUserService.getOrFail.mockReturnValue({
+        id: userId,
+        roles: [UserRole.DEAN],
+      });
+
+      await expect(service.GetBatchStatus('batch-002', userId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should paginate results correctly', async () => {
+      const batchId = 'batch-paginate';
+      const pageJobs = Array.from({ length: 2 }, (_, i) => ({
+        id: `j${i + 2}`,
+        status: 'waiting' as ReportJobStatus,
+        facultyName: `Faculty ${i + 2}`,
+        createdAt: new Date('2026-01-15T10:00:00Z'),
+        requestedBy: { id: userId },
+      }));
+      setupBatchMocks(
+        batchId,
+        userId,
+        [{ status: 'waiting', count: '5' }],
+        pageJobs,
+      );
+      mockCurrentUserService.getOrFail.mockReturnValue(baseDeanUser);
+
+      const result = await service.GetBatchStatus(batchId, userId, 2, 2);
+
+      expect(result.meta.currentPage).toBe(2);
+      expect(result.meta.itemsPerPage).toBe(2);
+      expect(result.meta.totalPages).toBe(3);
+      expect(result.meta.totalItems).toBe(5);
+      expect(result.meta.itemCount).toBe(2);
+      expect(result.jobs).toHaveLength(2);
+      // Verify DB-level pagination was used
+      expect(mockReportJobRepository.find).toHaveBeenCalledWith(
+        { batchId },
+        expect.objectContaining({ limit: 2, offset: 2 }),
+      );
+    });
+  });
+});

--- a/src/modules/reports/reports.service.ts
+++ b/src/modules/reports/reports.service.ts
@@ -31,6 +31,10 @@ import { CurrentUserService } from 'src/modules/common/cls/current-user.service'
 
 const REPORT_TYPE = 'faculty_evaluation';
 
+function pgArray(arr: string[]): string {
+  return `{${arr.join(',')}}`;
+}
+
 @Injectable()
 export class ReportsService {
   private readonly logger = new Logger(ReportsService.name);
@@ -139,23 +143,19 @@ export class ReportsService {
       if (deptIds.length === 0) {
         return { batchId: v4(), jobCount: 0, skippedCount: 0 };
       }
-      const codeRows: { code: string }[] = await this.em
-        .getConnection()
-        .execute(
-          'SELECT DISTINCT code FROM department WHERE id = ANY($1) AND deleted_at IS NULL',
-          [deptIds],
-        );
+      const codeRows: { code: string }[] = await this.em.execute(
+        'SELECT DISTINCT code FROM department WHERE id = ANY(?) AND deleted_at IS NULL',
+        [pgArray(deptIds)],
+      );
       departmentCodes = codeRows.map((r) => r.code);
     }
 
     // Apply scope filters
     if (dto.departmentId) {
-      const deptCodeRows: { code: string }[] = await this.em
-        .getConnection()
-        .execute(
-          'SELECT code FROM department WHERE id = $1 AND deleted_at IS NULL',
-          [dto.departmentId],
-        );
+      const deptCodeRows: { code: string }[] = await this.em.execute(
+        'SELECT code FROM department WHERE id = ? AND deleted_at IS NULL',
+        [dto.departmentId],
+      );
       if (deptCodeRows.length === 0) {
         throw new NotFoundException('Department not found');
       }
@@ -168,12 +168,10 @@ export class ReportsService {
 
     let programCode: string | null = null;
     if (dto.programId) {
-      const progRows: { code: string }[] = await this.em
-        .getConnection()
-        .execute(
-          'SELECT code FROM program WHERE id = $1 AND deleted_at IS NULL',
-          [dto.programId],
-        );
+      const progRows: { code: string }[] = await this.em.execute(
+        'SELECT code FROM program WHERE id = ? AND deleted_at IS NULL',
+        [dto.programId],
+      );
       if (progRows.length === 0) {
         throw new NotFoundException('Program not found');
       }
@@ -185,16 +183,22 @@ export class ReportsService {
       faculty_id: string;
       first_name: string;
       last_name: string;
-    }[] = await this.em.getConnection().execute(
+    }[] = await this.em.execute(
       `SELECT DISTINCT qs.faculty_id, u.first_name, u.last_name
        FROM questionnaire_submission qs
        JOIN "user" u ON u.id = qs.faculty_id
-       WHERE qs.semester_id = $1
-         AND ($2::text[] IS NULL OR qs.department_code_snapshot = ANY($2))
-         AND ($3::text IS NULL OR qs.program_code_snapshot = $3)
+       WHERE qs.semester_id = ?
+         AND (?::text[] IS NULL OR qs.department_code_snapshot = ANY(?))
+         AND (?::text IS NULL OR qs.program_code_snapshot = ?)
          AND qs.deleted_at IS NULL
          AND u.deleted_at IS NULL`,
-      [dto.semesterId, departmentCodes, programCode],
+      [
+        dto.semesterId,
+        departmentCodes ? pgArray(departmentCodes) : null,
+        departmentCodes ? pgArray(departmentCodes) : null,
+        programCode,
+        programCode,
+      ],
     );
 
     // Enforce batch size cap
@@ -347,10 +351,9 @@ export class ReportsService {
     }
 
     // Aggregate counts via SQL
-    const countRows: { status: string; count: string }[] = await this.em
-      .getConnection()
-      .execute(
-        `SELECT status, COUNT(*)::text AS count FROM report_job WHERE batch_id = $1 AND deleted_at IS NULL GROUP BY status`,
+    const countRows: { status: string; count: string }[] =
+      await this.em.execute(
+        `SELECT status, COUNT(*)::text AS count FROM report_job WHERE batch_id = ? AND deleted_at IS NULL GROUP BY status`,
         [batchId],
       );
     const counts = {
@@ -437,11 +440,10 @@ export class ReportsService {
   }
 
   private async validateSemester(semesterId: string): Promise<void> {
-    const rows = await this.em
-      .getConnection()
-      .execute('SELECT id FROM semester WHERE id = $1 AND deleted_at IS NULL', [
-        semesterId,
-      ]);
+    const rows = await this.em.execute(
+      'SELECT id FROM semester WHERE id = ? AND deleted_at IS NULL',
+      [semesterId],
+    );
     if (rows.length === 0) {
       throw new NotFoundException('Semester not found');
     }
@@ -471,12 +473,10 @@ export class ReportsService {
       return; // super admin — unrestricted
     }
 
-    const userRows: { department_id: string }[] = await this.em
-      .getConnection()
-      .execute(
-        'SELECT u.department_id FROM "user" u WHERE u.id = $1 AND u.deleted_at IS NULL',
-        [facultyId],
-      );
+    const userRows: { department_id: string }[] = await this.em.execute(
+      'SELECT u.department_id FROM "user" u WHERE u.id = ? AND u.deleted_at IS NULL',
+      [facultyId],
+    );
 
     if (userRows.length === 0) {
       throw new NotFoundException('Faculty not found');
@@ -490,10 +490,9 @@ export class ReportsService {
   }
 
   private async resolveFacultyName(facultyId: string): Promise<string> {
-    const rows: { first_name: string; last_name: string }[] = await this.em
-      .getConnection()
-      .execute(
-        'SELECT first_name, last_name FROM "user" WHERE id = $1 AND deleted_at IS NULL',
+    const rows: { first_name: string; last_name: string }[] =
+      await this.em.execute(
+        'SELECT first_name, last_name FROM "user" WHERE id = ? AND deleted_at IS NULL',
         [facultyId],
       );
 

--- a/src/modules/reports/reports.service.ts
+++ b/src/modules/reports/reports.service.ts
@@ -1,0 +1,506 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Inject,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import { EntityManager } from '@mikro-orm/postgresql';
+import { UniqueConstraintViolationException } from '@mikro-orm/core';
+import { v4 } from 'uuid';
+import { QueueName } from 'src/configurations/common/queue-names';
+import { env } from 'src/configurations/index.config';
+import { ReportJob, ReportJobStatus } from 'src/entities/report-job.entity';
+import { User } from 'src/entities/user.entity';
+import { UserRole } from 'src/modules/auth/roles.enum';
+import { ScopeResolverService } from 'src/modules/common/services/scope-resolver.service';
+import {
+  StorageProvider,
+  STORAGE_PROVIDER,
+} from './interfaces/storage-provider.interface';
+import { GenerateReportDto } from './dto/generate-report.dto';
+import { GenerateBatchReportDto } from './dto/generate-batch-report.dto';
+import { ReportStatusResponseDto } from './dto/report-status.response.dto';
+import { BatchStatusResponseDto } from './dto/batch-status.response.dto';
+import type { ReportJobMessage } from './processors/report-generation.processor';
+import { ReportJobRepository } from 'src/repositories/report-job.repository';
+import { CurrentUserService } from 'src/modules/common/cls/current-user.service';
+
+const REPORT_TYPE = 'faculty_evaluation';
+
+@Injectable()
+export class ReportsService {
+  private readonly logger = new Logger(ReportsService.name);
+
+  constructor(
+    @InjectQueue(QueueName.REPORT_GENERATION)
+    private readonly reportQueue: Queue,
+    private readonly reportJobRepository: ReportJobRepository,
+    private readonly em: EntityManager,
+    private readonly scopeResolver: ScopeResolverService,
+    private readonly currentUserService: CurrentUserService,
+    @Inject(STORAGE_PROVIDER)
+    private readonly storageProvider: StorageProvider,
+  ) {}
+
+  async GenerateSingle(
+    dto: GenerateReportDto,
+    userId: string,
+  ): Promise<{ jobId: string }> {
+    // Semester validation
+    await this.validateSemester(dto.semesterId);
+
+    // Dedup check
+    const existing = await this.findPendingJob(
+      dto.facultyId,
+      dto.semesterId,
+      dto.questionnaireTypeCode,
+    );
+    if (existing) {
+      return { jobId: existing.id };
+    }
+
+    // Scope validation
+    await this.validateFacultyInScope(dto.facultyId, dto.semesterId);
+
+    // Resolve faculty name
+    const facultyName = await this.resolveFacultyName(dto.facultyId);
+
+    // Create ReportJob entity
+    const fork = this.em.fork();
+    const user = fork.getReference(User, userId);
+    const reportJob = fork.create(ReportJob, {
+      reportType: REPORT_TYPE,
+      status: 'waiting' as ReportJobStatus,
+      requestedBy: user,
+      facultyId: dto.facultyId,
+      facultyName,
+      semesterId: dto.semesterId,
+      questionnaireTypeCode: dto.questionnaireTypeCode,
+    });
+
+    try {
+      await fork.flush();
+    } catch (error) {
+      if (error instanceof UniqueConstraintViolationException) {
+        // Race condition — another request created the same job
+        const raceExisting = await this.findPendingJob(
+          dto.facultyId,
+          dto.semesterId,
+          dto.questionnaireTypeCode,
+        );
+        if (raceExisting) {
+          return { jobId: raceExisting.id };
+        }
+      }
+      throw error;
+    }
+
+    // Enqueue with orphan protection
+    try {
+      const message: ReportJobMessage = {
+        reportJobId: reportJob.id,
+        facultyId: dto.facultyId,
+        semesterId: dto.semesterId,
+        questionnaireTypeCode: dto.questionnaireTypeCode,
+      };
+      await this.reportQueue.add('report', message, {
+        attempts: env.BULLMQ_DEFAULT_ATTEMPTS,
+        removeOnComplete: true,
+        removeOnFail: 100,
+      });
+    } catch (error) {
+      // Clean up orphaned entity
+      await this.em.nativeDelete(ReportJob, { id: reportJob.id });
+      throw error;
+    }
+
+    return { jobId: reportJob.id };
+  }
+
+  async GenerateBatch(
+    dto: GenerateBatchReportDto,
+    userId: string,
+  ): Promise<{ batchId: string; jobCount: number; skippedCount: number }> {
+    // Semester validation
+    await this.validateSemester(dto.semesterId);
+
+    // Resolve allowed department IDs
+    const deptIds = await this.scopeResolver.ResolveDepartmentIds(
+      dto.semesterId,
+    );
+
+    // Translate department IDs to codes
+    let departmentCodes: string[] | null = null;
+    if (deptIds !== null) {
+      if (deptIds.length === 0) {
+        return { batchId: v4(), jobCount: 0, skippedCount: 0 };
+      }
+      const codeRows: { code: string }[] = await this.em
+        .getConnection()
+        .execute(
+          'SELECT DISTINCT code FROM department WHERE id = ANY($1) AND deleted_at IS NULL',
+          [deptIds],
+        );
+      departmentCodes = codeRows.map((r) => r.code);
+    }
+
+    // Apply scope filters
+    if (dto.departmentId) {
+      const deptCodeRows: { code: string }[] = await this.em
+        .getConnection()
+        .execute(
+          'SELECT code FROM department WHERE id = $1 AND deleted_at IS NULL',
+          [dto.departmentId],
+        );
+      if (deptCodeRows.length === 0) {
+        throw new NotFoundException('Department not found');
+      }
+      const filterCode = deptCodeRows[0].code;
+      if (departmentCodes !== null && !departmentCodes.includes(filterCode)) {
+        throw new ForbiddenException('Department is not within your scope');
+      }
+      departmentCodes = [filterCode];
+    }
+
+    let programCode: string | null = null;
+    if (dto.programId) {
+      const progRows: { code: string }[] = await this.em
+        .getConnection()
+        .execute(
+          'SELECT code FROM program WHERE id = $1 AND deleted_at IS NULL',
+          [dto.programId],
+        );
+      if (progRows.length === 0) {
+        throw new NotFoundException('Program not found');
+      }
+      programCode = progRows[0].code;
+    }
+
+    // Resolve faculty via questionnaire_submission
+    const facultyRows: {
+      faculty_id: string;
+      first_name: string;
+      last_name: string;
+    }[] = await this.em.getConnection().execute(
+      `SELECT DISTINCT qs.faculty_id, u.first_name, u.last_name
+       FROM questionnaire_submission qs
+       JOIN "user" u ON u.id = qs.faculty_id
+       WHERE qs.semester_id = $1
+         AND ($2::text[] IS NULL OR qs.department_code_snapshot = ANY($2))
+         AND ($3::text IS NULL OR qs.program_code_snapshot = $3)
+         AND qs.deleted_at IS NULL
+         AND u.deleted_at IS NULL`,
+      [dto.semesterId, departmentCodes, programCode],
+    );
+
+    // Enforce batch size cap
+    if (facultyRows.length > env.REPORT_BATCH_MAX_SIZE) {
+      throw new BadRequestException(
+        `Batch size ${facultyRows.length} exceeds maximum of ${env.REPORT_BATCH_MAX_SIZE}`,
+      );
+    }
+
+    // Bulk dedup check — single query instead of N
+    const allFacultyIds = facultyRows.map((r) => r.faculty_id);
+    const pendingJobs = await this.reportJobRepository.find({
+      facultyId: { $in: allFacultyIds },
+      semesterId: dto.semesterId,
+      questionnaireTypeCode: dto.questionnaireTypeCode,
+      reportType: REPORT_TYPE,
+      status: { $in: ['waiting', 'active'] as ReportJobStatus[] },
+    });
+    const alreadyQueuedFacultyIds = new Set(
+      pendingJobs.map((j) => j.facultyId),
+    );
+
+    const facultyToProcess: {
+      facultyId: string;
+      facultyName: string;
+    }[] = [];
+    let skippedCount = 0;
+
+    for (const row of facultyRows) {
+      if (alreadyQueuedFacultyIds.has(row.faculty_id)) {
+        skippedCount++;
+      } else {
+        facultyToProcess.push({
+          facultyId: row.faculty_id,
+          facultyName: `${row.first_name} ${row.last_name}`,
+        });
+      }
+    }
+
+    if (facultyToProcess.length === 0) {
+      return { batchId: v4(), jobCount: 0, skippedCount };
+    }
+
+    // Create batch
+    const batchId = v4();
+    const fork = this.em.fork();
+    const user = fork.getReference(User, userId);
+
+    const reportJobs: ReportJob[] = [];
+    for (const faculty of facultyToProcess) {
+      const job = fork.create(ReportJob, {
+        reportType: REPORT_TYPE,
+        status: 'waiting' as ReportJobStatus,
+        requestedBy: user,
+        facultyId: faculty.facultyId,
+        facultyName: faculty.facultyName,
+        semesterId: dto.semesterId,
+        questionnaireTypeCode: dto.questionnaireTypeCode,
+        batchId,
+      });
+      reportJobs.push(job);
+    }
+
+    await fork.flush();
+
+    // Enqueue atomically via addBulk — all succeed or all fail
+    const bulkJobs = reportJobs.map((reportJob) => ({
+      name: 'report',
+      data: {
+        reportJobId: reportJob.id,
+        facultyId: reportJob.facultyId,
+        semesterId: dto.semesterId,
+        questionnaireTypeCode: dto.questionnaireTypeCode,
+      } as ReportJobMessage,
+      opts: {
+        attempts: env.BULLMQ_DEFAULT_ATTEMPTS,
+        removeOnComplete: true,
+        removeOnFail: 100,
+      },
+    }));
+
+    try {
+      await this.reportQueue.addBulk(bulkJobs);
+    } catch (error) {
+      // addBulk is atomic — none were enqueued, clean up all entities
+      await this.em.nativeDelete(ReportJob, {
+        id: { $in: reportJobs.map((j) => j.id) },
+      });
+      this.logger.warn(
+        `Batch ${batchId}: cleaned up ${reportJobs.length} orphaned jobs after enqueue failure`,
+      );
+      throw error;
+    }
+
+    return {
+      batchId,
+      jobCount: reportJobs.length,
+      skippedCount,
+    };
+  }
+
+  async GetJobStatus(
+    jobId: string,
+    userId: string,
+  ): Promise<ReportStatusResponseDto> {
+    const reportJob = await this.reportJobRepository.findOne(
+      { id: jobId },
+      { populate: ['requestedBy'] },
+    );
+
+    if (!reportJob) {
+      throw new NotFoundException('Report job not found');
+    }
+
+    // Ownership check
+    const currentUser = this.currentUserService.getOrFail();
+    if (
+      reportJob.requestedBy.id !== userId &&
+      !currentUser.roles.includes(UserRole.SUPER_ADMIN)
+    ) {
+      throw new NotFoundException('Report job not found');
+    }
+
+    return this.mapJobToResponse(reportJob);
+  }
+
+  async GetBatchStatus(
+    batchId: string,
+    userId: string,
+    page = 1,
+    limit = 20,
+  ): Promise<BatchStatusResponseDto> {
+    page = Math.max(1, Math.floor(page));
+    limit = Math.max(1, Math.min(50, Math.floor(limit)));
+
+    // Ownership check via first job (lightweight query)
+    const firstJob = await this.reportJobRepository.findOne(
+      { batchId },
+      { populate: ['requestedBy'] },
+    );
+    if (!firstJob) {
+      throw new NotFoundException('Batch not found');
+    }
+    const currentUser = this.currentUserService.getOrFail();
+    if (
+      firstJob.requestedBy.id !== userId &&
+      !currentUser.roles.includes(UserRole.SUPER_ADMIN)
+    ) {
+      throw new NotFoundException('Batch not found');
+    }
+
+    // Aggregate counts via SQL
+    const countRows: { status: string; count: string }[] = await this.em
+      .getConnection()
+      .execute(
+        `SELECT status, COUNT(*)::text AS count FROM report_job WHERE batch_id = $1 AND deleted_at IS NULL GROUP BY status`,
+        [batchId],
+      );
+    const counts = {
+      completed: 0,
+      failed: 0,
+      skipped: 0,
+      active: 0,
+      waiting: 0,
+    };
+    let totalItems = 0;
+    for (const row of countRows) {
+      if (row.status in counts) {
+        counts[row.status as keyof typeof counts] = Number(row.count);
+      }
+      totalItems += Number(row.count);
+    }
+
+    // DB-level pagination for job details
+    const totalPages = Math.ceil(totalItems / limit) || 0;
+    const offset = (page - 1) * limit;
+    const pageJobs = await this.reportJobRepository.find(
+      { batchId },
+      { orderBy: { createdAt: 'ASC' }, limit, offset },
+    );
+
+    // Generate presigned URLs for completed jobs in current page
+    const jobs = await Promise.all(
+      pageJobs.map((job) => this.mapJobToResponse(job)),
+    );
+
+    return {
+      batchId,
+      total: totalItems,
+      completed: counts.completed,
+      failed: counts.failed,
+      skipped: counts.skipped,
+      active: counts.active,
+      waiting: counts.waiting,
+      jobs,
+      meta: {
+        totalItems,
+        itemCount: jobs.length,
+        itemsPerPage: limit,
+        totalPages,
+        currentPage: page,
+      },
+    };
+  }
+
+  private async mapJobToResponse(
+    job: ReportJob,
+  ): Promise<ReportStatusResponseDto> {
+    const response: ReportStatusResponseDto = {
+      jobId: job.id,
+      status: job.status,
+      facultyName: job.facultyName,
+      createdAt: job.createdAt.toISOString(),
+    };
+
+    if (job.status === 'completed' && job.storageKey) {
+      const expirySeconds = env.REPORT_PRESIGNED_URL_EXPIRY_SECONDS;
+      response.downloadUrl = await this.storageProvider.GetPresignedUrl(
+        job.storageKey,
+        expirySeconds,
+      );
+      response.expiresAt = new Date(
+        Date.now() + expirySeconds * 1000,
+      ).toISOString();
+    }
+
+    if (job.status === 'failed' && job.error) {
+      response.error = job.error;
+    }
+
+    if (job.status === 'skipped') {
+      response.message = 'No evaluation data found';
+    }
+
+    if (job.completedAt) {
+      response.completedAt = job.completedAt.toISOString();
+    }
+
+    return response;
+  }
+
+  private async validateSemester(semesterId: string): Promise<void> {
+    const rows = await this.em
+      .getConnection()
+      .execute('SELECT id FROM semester WHERE id = $1 AND deleted_at IS NULL', [
+        semesterId,
+      ]);
+    if (rows.length === 0) {
+      throw new NotFoundException('Semester not found');
+    }
+  }
+
+  private async findPendingJob(
+    facultyId: string,
+    semesterId: string,
+    questionnaireTypeCode: string,
+  ): Promise<ReportJob | null> {
+    return this.reportJobRepository.findOne({
+      facultyId,
+      semesterId,
+      questionnaireTypeCode,
+      reportType: REPORT_TYPE,
+      status: { $in: ['waiting', 'active'] as ReportJobStatus[] },
+    });
+  }
+
+  private async validateFacultyInScope(
+    facultyId: string,
+    semesterId: string,
+  ): Promise<void> {
+    const deptIds = await this.scopeResolver.ResolveDepartmentIds(semesterId);
+
+    if (deptIds === null) {
+      return; // super admin — unrestricted
+    }
+
+    const userRows: { department_id: string }[] = await this.em
+      .getConnection()
+      .execute(
+        'SELECT u.department_id FROM "user" u WHERE u.id = $1 AND u.deleted_at IS NULL',
+        [facultyId],
+      );
+
+    if (userRows.length === 0) {
+      throw new NotFoundException('Faculty not found');
+    }
+
+    if (!deptIds.includes(userRows[0].department_id)) {
+      throw new ForbiddenException(
+        'You do not have access to this faculty member',
+      );
+    }
+  }
+
+  private async resolveFacultyName(facultyId: string): Promise<string> {
+    const rows: { first_name: string; last_name: string }[] = await this.em
+      .getConnection()
+      .execute(
+        'SELECT first_name, last_name FROM "user" WHERE id = $1 AND deleted_at IS NULL',
+        [facultyId],
+      );
+
+    if (rows.length === 0) {
+      throw new NotFoundException('Faculty not found');
+    }
+
+    return `${rows[0].first_name} ${rows[0].last_name}`;
+  }
+}

--- a/src/modules/reports/services/pdf.service.spec.ts
+++ b/src/modules/reports/services/pdf.service.spec.ts
@@ -1,0 +1,171 @@
+// --- Mocks must be declared before any import that touches them ---
+
+const mockNewPage = jest.fn();
+const mockBrowserClose = jest.fn();
+const mockPageSetContent = jest.fn();
+const mockPagePdf = jest.fn();
+const mockPageClose = jest.fn();
+
+const mockBrowser = {
+  newPage: mockNewPage,
+  close: mockBrowserClose,
+};
+
+const mockPage = {
+  setDefaultTimeout: jest.fn(),
+  setContent: mockPageSetContent,
+  pdf: mockPagePdf,
+  close: mockPageClose,
+};
+
+const mockLaunch = jest.fn();
+
+jest.mock('puppeteer', () => ({
+  launch: (...args: unknown[]) => mockLaunch(...args) as unknown,
+}));
+
+jest.mock('fs', () => ({
+  readFileSync: jest.fn().mockReturnValue('<html>{{faculty.name}}</html>'),
+}));
+
+jest.mock('handlebars', () => {
+  const mockTemplateDelegate = jest
+    .fn()
+    .mockReturnValue('<html>rendered</html>');
+  return {
+    compile: jest.fn().mockReturnValue(mockTemplateDelegate),
+  };
+});
+
+import { PdfService } from './pdf.service';
+import { FacultyReportResponseDto } from 'src/modules/analytics/dto/responses/faculty-report.response.dto';
+import { ReportCommentDto } from 'src/modules/analytics/dto/responses/faculty-report-comments.response.dto';
+
+describe('PdfService', () => {
+  let service: PdfService;
+
+  const mockReportData: FacultyReportResponseDto = {
+    faculty: { id: 'f-1', name: 'Dr. Smith' },
+    semester: {
+      id: 's-1',
+      code: '2024-1',
+      label: 'First Semester',
+      academicYear: '2024-2025',
+    },
+    questionnaireType: { code: 'STUDENT', name: 'Student Evaluation' },
+    courseFilter: null,
+    submissionCount: 42,
+    sections: [
+      {
+        sectionId: 'sec-1',
+        title: 'Teaching Quality',
+        order: 1,
+        weight: 1,
+        questions: [
+          {
+            questionId: 'q-1',
+            order: 1,
+            text: 'Clarity of instruction',
+            average: 4.5,
+            responseCount: 42,
+            interpretation: 'Very Satisfactory',
+          },
+        ],
+        sectionAverage: 4.5,
+        sectionInterpretation: 'Very Satisfactory',
+      },
+    ],
+    overallRating: 4.5,
+    overallInterpretation: 'Very Satisfactory',
+  };
+
+  const mockComments: ReportCommentDto[] = [
+    { text: 'Great professor!', submittedAt: '2024-06-01' },
+    { text: 'Very helpful', submittedAt: '2024-06-02' },
+  ];
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    mockLaunch.mockResolvedValue(mockBrowser);
+    mockNewPage.mockResolvedValue(mockPage);
+    mockPageSetContent.mockResolvedValue(undefined);
+    mockPagePdf.mockResolvedValue(Buffer.from('pdf-bytes'));
+    mockPageClose.mockResolvedValue(undefined);
+    mockBrowserClose.mockResolvedValue(undefined);
+
+    service = new PdfService();
+    await service.onModuleInit();
+  });
+
+  afterEach(async () => {
+    await service.onModuleDestroy();
+  });
+
+  describe('GenerateFacultyEvaluationPdf', () => {
+    it('should return a Buffer', async () => {
+      const result = await service.GenerateFacultyEvaluationPdf(
+        mockReportData,
+        mockComments,
+      );
+
+      expect(result).toBeInstanceOf(Buffer);
+      expect(mockNewPage).toHaveBeenCalledTimes(1);
+      expect(mockPageSetContent).toHaveBeenCalledWith(expect.any(String), {
+        waitUntil: 'networkidle0',
+      });
+      expect(mockPagePdf).toHaveBeenCalledWith({
+        format: 'A4',
+        printBackground: true,
+        margin: { top: '20mm', bottom: '20mm', left: '15mm', right: '15mm' },
+      });
+      expect(mockPageClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should succeed with empty comments array', async () => {
+      const result = await service.GenerateFacultyEvaluationPdf(
+        mockReportData,
+        [],
+      );
+
+      expect(result).toBeInstanceOf(Buffer);
+      expect(mockNewPage).toHaveBeenCalledTimes(1);
+      expect(mockPagePdf).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('browser crash recovery', () => {
+    it('should relaunch browser when newPage fails then succeed', async () => {
+      // First call to newPage throws (simulating a crashed browser)
+      mockNewPage
+        .mockRejectedValueOnce(new Error('Session closed'))
+        .mockResolvedValueOnce(mockPage);
+
+      const result = await service.GenerateFacultyEvaluationPdf(
+        mockReportData,
+        mockComments,
+      );
+
+      expect(result).toBeInstanceOf(Buffer);
+      // Initial launch + relaunch after crash
+      expect(mockLaunch).toHaveBeenCalledTimes(2);
+      // First attempt fails, second succeeds
+      expect(mockNewPage).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('lifecycle hooks', () => {
+    it('should launch browser on module init', () => {
+      expect(mockLaunch).toHaveBeenCalledWith({
+        headless: true,
+        args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-gpu'],
+      });
+    });
+
+    it('should close browser on module destroy', async () => {
+      await service.onModuleDestroy();
+
+      expect(mockBrowserClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/modules/reports/services/pdf.service.ts
+++ b/src/modules/reports/services/pdf.service.ts
@@ -1,0 +1,123 @@
+import {
+  Injectable,
+  Logger,
+  OnModuleInit,
+  OnModuleDestroy,
+} from '@nestjs/common';
+import * as puppeteer from 'puppeteer';
+import * as Handlebars from 'handlebars';
+import * as fs from 'fs';
+import * as path from 'path';
+import { FacultyReportResponseDto } from 'src/modules/analytics/dto/responses/faculty-report.response.dto';
+import { ReportCommentDto } from 'src/modules/analytics/dto/responses/faculty-report-comments.response.dto';
+
+@Injectable()
+export class PdfService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(PdfService.name);
+  private browser: puppeteer.Browser | null = null;
+  private compiledTemplate: Handlebars.TemplateDelegate | null = null;
+  private cssContent: string | null = null;
+  private relaunchPromise: Promise<void> | null = null;
+
+  async onModuleInit(): Promise<void> {
+    await this.launchBrowser();
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.browser) {
+      await this.browser.close().catch(() => {});
+      this.browser = null;
+    }
+  }
+
+  async GenerateFacultyEvaluationPdf(
+    data: FacultyReportResponseDto,
+    comments: ReportCommentDto[],
+  ): Promise<Buffer> {
+    const template = this.getCompiledTemplate();
+    const css = this.getCss();
+
+    const html = template({
+      faculty: data.faculty,
+      semester: data.semester,
+      questionnaireType: data.questionnaireType,
+      submissionCount: data.submissionCount,
+      sections: data.sections,
+      overallRating: data.overallRating,
+      overallInterpretation: data.overallInterpretation,
+      comments,
+      hasComments: comments.length > 0,
+      css,
+    });
+
+    const page = await this.createPage();
+    try {
+      page.setDefaultTimeout(30000);
+      await page.setContent(html, { waitUntil: 'networkidle0' });
+      const pdfBuffer = await page.pdf({
+        format: 'A4',
+        printBackground: true,
+        margin: { top: '20mm', bottom: '20mm', left: '15mm', right: '15mm' },
+      });
+      return Buffer.from(pdfBuffer);
+    } finally {
+      await page.close().catch(() => {});
+    }
+  }
+
+  private async createPage(): Promise<puppeteer.Page> {
+    try {
+      return await this.getBrowser().newPage();
+    } catch {
+      this.logger.warn('Browser crashed, attempting relaunch...');
+      // Mutex: if another job is already relaunching, wait for that instead
+      if (!this.relaunchPromise) {
+        this.relaunchPromise = this.launchBrowser().finally(() => {
+          this.relaunchPromise = null;
+        });
+      }
+      await this.relaunchPromise;
+      return await this.getBrowser().newPage();
+    }
+  }
+
+  private getBrowser(): puppeteer.Browser {
+    if (!this.browser) {
+      throw new Error('Puppeteer browser is not initialized');
+    }
+    return this.browser;
+  }
+
+  private async launchBrowser(): Promise<void> {
+    if (this.browser) {
+      await this.browser.close().catch(() => {});
+    }
+    this.browser = await puppeteer.launch({
+      headless: true,
+      args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-gpu'],
+    });
+    this.logger.log('Puppeteer browser launched');
+  }
+
+  private getCompiledTemplate(): Handlebars.TemplateDelegate {
+    if (!this.compiledTemplate) {
+      const templatePath = path.join(
+        __dirname,
+        '..',
+        'templates',
+        'faculty-evaluation.hbs',
+      );
+      const templateSource = fs.readFileSync(templatePath, 'utf-8');
+      this.compiledTemplate = Handlebars.compile(templateSource);
+    }
+    return this.compiledTemplate;
+  }
+
+  private getCss(): string {
+    if (!this.cssContent) {
+      const cssPath = path.join(__dirname, '..', 'templates', 'report.css');
+      this.cssContent = fs.readFileSync(cssPath, 'utf-8');
+    }
+    return this.cssContent;
+  }
+}

--- a/src/modules/reports/services/pdf.service.ts
+++ b/src/modules/reports/services/pdf.service.ts
@@ -102,8 +102,10 @@ export class PdfService implements OnModuleInit, OnModuleDestroy {
   private getCompiledTemplate(): Handlebars.TemplateDelegate {
     if (!this.compiledTemplate) {
       const templatePath = path.join(
-        __dirname,
-        '..',
+        process.cwd(),
+        'dist',
+        'modules',
+        'reports',
         'templates',
         'faculty-evaluation.hbs',
       );
@@ -115,7 +117,14 @@ export class PdfService implements OnModuleInit, OnModuleDestroy {
 
   private getCss(): string {
     if (!this.cssContent) {
-      const cssPath = path.join(__dirname, '..', 'templates', 'report.css');
+      const cssPath = path.join(
+        process.cwd(),
+        'dist',
+        'modules',
+        'reports',
+        'templates',
+        'report.css',
+      );
       this.cssContent = fs.readFileSync(cssPath, 'utf-8');
     }
     return this.cssContent;

--- a/src/modules/reports/services/r2-storage.service.spec.ts
+++ b/src/modules/reports/services/r2-storage.service.spec.ts
@@ -1,0 +1,217 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+
+// --- Mocks must be declared before any import that touches them ---
+
+const mockSend = jest.fn();
+
+jest.mock('@aws-sdk/client-s3', () => {
+  const PutObjectCommand = jest.fn();
+  const GetObjectCommand = jest.fn();
+  const DeleteObjectCommand = jest.fn();
+  const DeleteObjectsCommand = jest.fn();
+  const ListObjectsV2Command = jest.fn();
+
+  return {
+    S3Client: jest.fn().mockImplementation(() => ({ send: mockSend })),
+    PutObjectCommand,
+    GetObjectCommand,
+    DeleteObjectCommand,
+    DeleteObjectsCommand,
+    ListObjectsV2Command,
+  };
+});
+
+const mockGetSignedUrl = jest.fn();
+jest.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: mockGetSignedUrl,
+}));
+
+// Will be overridden per-describe block via a mutable reference
+const envValues: Record<string, string | undefined> = {
+  CF_ACCOUNT_ID: 'test-account-id',
+  R2_ACCESS_KEY_ID: 'test-access-key',
+  R2_SECRET_ACCESS_KEY: 'test-secret-key',
+  R2_BUCKET_NAME: 'test-bucket',
+};
+
+jest.mock('src/configurations/index.config', () => ({
+  get env() {
+    return envValues;
+  },
+}));
+
+import { R2StorageService } from './r2-storage.service';
+import {
+  PutObjectCommand,
+  GetObjectCommand,
+  DeleteObjectCommand,
+  DeleteObjectsCommand,
+  ListObjectsV2Command,
+} from '@aws-sdk/client-s3';
+
+describe('R2StorageService', () => {
+  describe('when R2 is configured', () => {
+    let service: R2StorageService;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      envValues.CF_ACCOUNT_ID = 'test-account-id';
+      envValues.R2_ACCESS_KEY_ID = 'test-access-key';
+      envValues.R2_SECRET_ACCESS_KEY = 'test-secret-key';
+      envValues.R2_BUCKET_NAME = 'test-bucket';
+
+      service = new R2StorageService();
+    });
+
+    describe('Upload', () => {
+      it('should send PutObjectCommand with correct params', async () => {
+        mockSend.mockResolvedValue({});
+        const buffer = Buffer.from('pdf-content');
+
+        await service.Upload('reports/test.pdf', buffer, 'application/pdf');
+
+        expect(PutObjectCommand).toHaveBeenCalledWith({
+          Bucket: 'test-bucket',
+          Key: 'reports/test.pdf',
+          Body: buffer,
+          ContentType: 'application/pdf',
+        });
+        expect(mockSend).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('GetPresignedUrl', () => {
+      it('should call presigner with correct expiry', async () => {
+        mockGetSignedUrl.mockResolvedValue('https://signed-url.example.com');
+
+        const url = await service.GetPresignedUrl('reports/test.pdf', 3600);
+
+        expect(GetObjectCommand).toHaveBeenCalledWith({
+          Bucket: 'test-bucket',
+          Key: 'reports/test.pdf',
+        });
+        expect(mockGetSignedUrl).toHaveBeenCalledWith(
+          expect.objectContaining({ send: mockSend }),
+          expect.any(Object),
+          { expiresIn: 3600 },
+        );
+        expect(url).toBe('https://signed-url.example.com');
+      });
+    });
+
+    describe('Delete', () => {
+      it('should send DeleteObjectCommand with correct key', async () => {
+        mockSend.mockResolvedValue({});
+
+        await service.Delete('reports/test.pdf');
+
+        expect(DeleteObjectCommand).toHaveBeenCalledWith({
+          Bucket: 'test-bucket',
+          Key: 'reports/test.pdf',
+        });
+        expect(mockSend).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('DeleteByPrefix', () => {
+      it('should list objects then batch-delete them', async () => {
+        mockSend
+          .mockResolvedValueOnce({
+            Contents: [{ Key: 'reports/a.pdf' }, { Key: 'reports/b.pdf' }],
+            IsTruncated: false,
+          })
+          .mockResolvedValueOnce({});
+
+        await service.DeleteByPrefix('reports/');
+
+        expect(ListObjectsV2Command).toHaveBeenCalledWith({
+          Bucket: 'test-bucket',
+          Prefix: 'reports/',
+          ContinuationToken: undefined,
+        });
+        expect(DeleteObjectsCommand).toHaveBeenCalledWith({
+          Bucket: 'test-bucket',
+          Delete: {
+            Objects: [{ Key: 'reports/a.pdf' }, { Key: 'reports/b.pdf' }],
+          },
+        });
+      });
+
+      it('should handle pagination with continuation token', async () => {
+        mockSend
+          // First page
+          .mockResolvedValueOnce({
+            Contents: [{ Key: 'reports/a.pdf' }],
+            IsTruncated: true,
+            NextContinuationToken: 'token-2',
+          })
+          // Delete for first page
+          .mockResolvedValueOnce({})
+          // Second page
+          .mockResolvedValueOnce({
+            Contents: [{ Key: 'reports/b.pdf' }],
+            IsTruncated: false,
+          })
+          // Delete for second page
+          .mockResolvedValueOnce({});
+
+        await service.DeleteByPrefix('reports/');
+
+        expect(ListObjectsV2Command).toHaveBeenCalledTimes(2);
+        expect(DeleteObjectsCommand).toHaveBeenCalledTimes(2);
+      });
+
+      it('should skip delete when no objects found', async () => {
+        mockSend.mockResolvedValueOnce({
+          Contents: [],
+          IsTruncated: false,
+        });
+
+        await service.DeleteByPrefix('empty/');
+
+        expect(ListObjectsV2Command).toHaveBeenCalledTimes(1);
+        expect(DeleteObjectsCommand).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('when R2 is NOT configured', () => {
+    let service: R2StorageService;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      envValues.CF_ACCOUNT_ID = undefined;
+      envValues.R2_ACCESS_KEY_ID = undefined;
+      envValues.R2_SECRET_ACCESS_KEY = undefined;
+      envValues.R2_BUCKET_NAME = 'test-bucket';
+
+      service = new R2StorageService();
+    });
+
+    it('should throw ServiceUnavailableException on Upload', async () => {
+      await expect(
+        service.Upload('key', Buffer.from('x'), 'application/pdf'),
+      ).rejects.toThrow(ServiceUnavailableException);
+    });
+
+    it('should throw ServiceUnavailableException on GetPresignedUrl', async () => {
+      await expect(service.GetPresignedUrl('key', 3600)).rejects.toThrow(
+        ServiceUnavailableException,
+      );
+    });
+
+    it('should throw ServiceUnavailableException on Delete', async () => {
+      await expect(service.Delete('key')).rejects.toThrow(
+        ServiceUnavailableException,
+      );
+    });
+
+    it('should throw ServiceUnavailableException on DeleteByPrefix', async () => {
+      await expect(service.DeleteByPrefix('prefix/')).rejects.toThrow(
+        ServiceUnavailableException,
+      );
+    });
+  });
+});

--- a/src/modules/reports/services/r2-storage.service.ts
+++ b/src/modules/reports/services/r2-storage.service.ts
@@ -1,0 +1,124 @@
+import {
+  Injectable,
+  Logger,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import {
+  S3Client,
+  PutObjectCommand,
+  GetObjectCommand,
+  DeleteObjectCommand,
+  DeleteObjectsCommand,
+  ListObjectsV2Command,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { env } from 'src/configurations/index.config';
+import { StorageProvider } from '../interfaces/storage-provider.interface';
+
+@Injectable()
+export class R2StorageService extends StorageProvider {
+  private readonly logger = new Logger(R2StorageService.name);
+  private readonly client: S3Client | null;
+  private readonly bucket: string;
+  private readonly isConfigured: boolean;
+
+  constructor() {
+    super();
+    this.bucket = env.R2_BUCKET_NAME;
+
+    if (env.CF_ACCOUNT_ID && env.R2_ACCESS_KEY_ID && env.R2_SECRET_ACCESS_KEY) {
+      this.client = new S3Client({
+        region: 'auto',
+        endpoint: `https://${env.CF_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+        credentials: {
+          accessKeyId: env.R2_ACCESS_KEY_ID,
+          secretAccessKey: env.R2_SECRET_ACCESS_KEY,
+        },
+      });
+      this.isConfigured = true;
+    } else {
+      this.client = null;
+      this.isConfigured = false;
+      this.logger.warn(
+        'R2 storage not configured — report generation will be unavailable',
+      );
+    }
+  }
+
+  private ensureConfigured(): S3Client {
+    if (!this.isConfigured || !this.client) {
+      throw new ServiceUnavailableException('R2 storage is not configured');
+    }
+    return this.client;
+  }
+
+  async Upload(
+    key: string,
+    buffer: Buffer,
+    contentType: string,
+  ): Promise<void> {
+    const client = this.ensureConfigured();
+    await client.send(
+      new PutObjectCommand({
+        Bucket: this.bucket,
+        Key: key,
+        Body: buffer,
+        ContentType: contentType,
+      }),
+    );
+  }
+
+  async GetPresignedUrl(
+    key: string,
+    expiresInSeconds: number,
+  ): Promise<string> {
+    const client = this.ensureConfigured();
+    return getSignedUrl(
+      client,
+      new GetObjectCommand({ Bucket: this.bucket, Key: key }),
+      { expiresIn: expiresInSeconds },
+    );
+  }
+
+  async Delete(key: string): Promise<void> {
+    const client = this.ensureConfigured();
+    await client.send(
+      new DeleteObjectCommand({ Bucket: this.bucket, Key: key }),
+    );
+  }
+
+  async DeleteByPrefix(prefix: string): Promise<void> {
+    const client = this.ensureConfigured();
+
+    let continuationToken: string | undefined;
+    do {
+      const listResponse = await client.send(
+        new ListObjectsV2Command({
+          Bucket: this.bucket,
+          Prefix: prefix,
+          ContinuationToken: continuationToken,
+        }),
+      );
+
+      const keys = listResponse.Contents?.map((obj) => obj.Key!).filter(
+        Boolean,
+      );
+      if (keys && keys.length > 0) {
+        // S3 DeleteObjects supports max 1000 keys per call
+        for (let i = 0; i < keys.length; i += 1000) {
+          const batch = keys.slice(i, i + 1000);
+          await client.send(
+            new DeleteObjectsCommand({
+              Bucket: this.bucket,
+              Delete: { Objects: batch.map((Key) => ({ Key })) },
+            }),
+          );
+        }
+      }
+
+      continuationToken = listResponse.IsTruncated
+        ? listResponse.NextContinuationToken
+        : undefined;
+    } while (continuationToken);
+  }
+}

--- a/src/modules/reports/templates/faculty-evaluation.hbs
+++ b/src/modules/reports/templates/faculty-evaluation.hbs
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <style>{{css}}</style>
+</head>
+<body>
+  <div class="report">
+    <div class="header">
+      <div class="header-left">
+        <h1>FACULTY EVALUATION REPORT</h1>
+        <p class="questionnaire-type">{{questionnaireType.name}}</p>
+      </div>
+      <div class="header-right">
+        <p class="semester-code">{{semester.code}}</p>
+        <p class="academic-year">AY {{semester.academicYear}}</p>
+      </div>
+    </div>
+
+    <div class="confidential-banner">CONFIDENTIAL</div>
+
+    <div class="teacher-info">
+      <table class="info-table">
+        <tr>
+          <td class="label">Teacher Name:</td>
+          <td class="value">{{faculty.name}}</td>
+          <td class="label">No. of Respondents:</td>
+          <td class="value">{{submissionCount}}</td>
+        </tr>
+      </table>
+    </div>
+
+    {{#each sections}}
+    <table class="section-table">
+      <thead>
+        <tr class="section-header">
+          <th colspan="3">{{title}} (Weight: {{weight}}%)</th>
+        </tr>
+        <tr class="column-header">
+          <th class="col-question">Question</th>
+          <th class="col-average">Average</th>
+          <th class="col-interpretation">Interpretation</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{#each questions}}
+        <tr>
+          <td class="col-question">{{order}}. {{text}}</td>
+          <td class="col-average">{{average}}</td>
+          <td class="col-interpretation">{{interpretation}}</td>
+        </tr>
+        {{/each}}
+      </tbody>
+      <tfoot>
+        <tr class="section-footer">
+          <td class="col-question"><strong>Section Average</strong></td>
+          <td class="col-average"><strong>{{sectionAverage}}</strong></td>
+          <td class="col-interpretation"><strong>{{sectionInterpretation}}</strong></td>
+        </tr>
+      </tfoot>
+    </table>
+    {{/each}}
+
+    {{#if overallRating}}
+    <table class="overall-table">
+      <tr>
+        <td class="label"><strong>OVERALL WEIGHTED RATING</strong></td>
+        <td class="col-average"><strong>{{overallRating}}</strong></td>
+        <td class="col-interpretation"><strong>{{overallInterpretation}}</strong></td>
+      </tr>
+    </table>
+    {{/if}}
+
+    <div class="comments-section">
+      <h2>Comments / Remarks</h2>
+      {{#if hasComments}}
+      <ul class="comments-list">
+        {{#each comments}}
+        <li>{{text}}</li>
+        {{/each}}
+      </ul>
+      {{else}}
+      <p class="no-comments">No comments submitted.</p>
+      {{/if}}
+    </div>
+  </div>
+</body>
+</html>

--- a/src/modules/reports/templates/report.css
+++ b/src/modules/reports/templates/report.css
@@ -1,0 +1,193 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 10pt;
+  color: #000;
+  line-height: 1.4;
+}
+
+.report {
+  width: 100%;
+  padding: 0;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 8px;
+}
+
+.header-left h1 {
+  font-size: 14pt;
+  font-weight: bold;
+  margin-bottom: 2px;
+}
+
+.header-left .questionnaire-type {
+  font-size: 10pt;
+  color: #333;
+}
+
+.header-right {
+  text-align: right;
+}
+
+.header-right .semester-code {
+  font-size: 12pt;
+  font-weight: bold;
+}
+
+.header-right .academic-year {
+  font-size: 10pt;
+  color: #333;
+}
+
+.confidential-banner {
+  background-color: #000;
+  color: #fff;
+  text-align: center;
+  font-weight: bold;
+  font-size: 10pt;
+  padding: 4px 0;
+  letter-spacing: 2px;
+  margin-bottom: 10px;
+}
+
+.info-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 12px;
+}
+
+.info-table td {
+  padding: 4px 8px;
+  font-size: 10pt;
+}
+
+.info-table .label {
+  font-weight: bold;
+  width: 20%;
+}
+
+.info-table .value {
+  width: 30%;
+}
+
+.section-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 10px;
+  page-break-inside: avoid;
+}
+
+.section-table th,
+.section-table td {
+  border: 1px solid #000;
+  padding: 4px 8px;
+  font-size: 10pt;
+}
+
+.section-header th {
+  background-color: #f0f0f0;
+  text-align: left;
+  font-size: 11pt;
+  font-weight: bold;
+  padding: 6px 8px;
+}
+
+.column-header th {
+  background-color: #e8e8e8;
+  font-weight: bold;
+  text-align: center;
+  font-size: 9pt;
+}
+
+.column-header .col-question {
+  text-align: left;
+}
+
+.col-question {
+  width: 60%;
+  text-align: left;
+}
+
+.col-average {
+  width: 15%;
+  text-align: center;
+}
+
+.col-interpretation {
+  width: 25%;
+  text-align: center;
+  font-size: 9pt;
+}
+
+.section-footer td {
+  background-color: #f8f8f8;
+  font-weight: bold;
+}
+
+.overall-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 16px;
+  page-break-inside: avoid;
+}
+
+.overall-table td {
+  border: 2px solid #000;
+  padding: 8px;
+  font-size: 11pt;
+}
+
+.overall-table .label {
+  width: 60%;
+  background-color: #e0e0e0;
+}
+
+.overall-table .col-average {
+  width: 15%;
+  text-align: center;
+  background-color: #f0f0f0;
+}
+
+.overall-table .col-interpretation {
+  width: 25%;
+  text-align: center;
+  background-color: #f0f0f0;
+}
+
+.comments-section {
+  margin-top: 16px;
+  page-break-inside: avoid;
+}
+
+.comments-section h2 {
+  font-size: 12pt;
+  font-weight: bold;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #000;
+  padding-bottom: 4px;
+}
+
+.comments-list {
+  list-style-type: disc;
+  padding-left: 24px;
+}
+
+.comments-list li {
+  margin-bottom: 4px;
+  font-size: 10pt;
+}
+
+.no-comments {
+  font-style: italic;
+  color: #666;
+  font-size: 10pt;
+}

--- a/src/repositories/report-job.repository.ts
+++ b/src/repositories/report-job.repository.ts
@@ -1,0 +1,23 @@
+import { EntityRepository } from '@mikro-orm/postgresql';
+import { ReportJob, ReportJobStatus } from '../entities/report-job.entity';
+
+export class ReportJobRepository extends EntityRepository<ReportJob> {
+  async FindByJobId(jobId: string): Promise<ReportJob | null> {
+    return this.findOne({ id: jobId });
+  }
+
+  async FindByBatchId(batchId: string): Promise<ReportJob[]> {
+    return this.find({ batchId });
+  }
+
+  async FindExpiredCompleted(cutoffDate: Date): Promise<ReportJob[]> {
+    return this.find({
+      status: 'completed' as ReportJobStatus,
+      completedAt: { $lt: cutoffDate },
+    });
+  }
+
+  async FindByRequestedBy(userId: string): Promise<ReportJob[]> {
+    return this.find({ requestedBy: userId });
+  }
+}


### PR DESCRIPTION
## Summary

- Async PDF report generation for faculty evaluation reports via BullMQ + Puppeteer/Handlebars
- Cloudflare R2 storage with presigned download URLs (1hr expiry)
- Single (`POST /reports/generate`) and batch (`POST /reports/generate/batch`) generation with scope-aware authorization
- `ReportJob` entity with dedup via partial unique index, orphan protection, and daily cleanup cron
- `AnalyticsService` refactored: extracted `BuildFacultyReportData`, added `GetFacultyReportUnscoped` and `GetAllFacultyReportComments` for processor use

## Test plan

- [x] 5 new test suites (53 tests) covering service, processor, R2 storage, PDF service, and cleanup job
- [x] Existing analytics tests (32) updated and passing after refactor
- [x] Lint clean, build succeeds, template assets copied to dist
- [x] Manual: verify PDF renders correctly with real data and R2 credentials
- [x] Manual: verify batch generation with department/program scope filters
- [ ] Manual: verify cleanup cron purges expired reports and orphaned jobs

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)