### PR TITLE
FAC-106 fix: faculty list scoped under caller returns no faculties

### DIFF
--- a/docs/architecture/scope-resolution.md
+++ b/docs/architecture/scope-resolution.md
@@ -1,0 +1,151 @@
+# Scope Resolution
+
+The `ScopeResolverService` enforces role-based data boundaries. Scoped endpoints (faculty list, analytics, reports) call it to determine which departments or programs the current user is authorized to access for a given semester.
+
+## Moodle Category Hierarchy
+
+Scope resolution depends on the Moodle category tree. Each entity in the domain maps 1:1 to a Moodle category at a specific depth:
+
+```
+Depth 1 — Campus       (e.g., "UCMN")
+Depth 2 — Semester      (e.g., "S22526")
+Depth 3 — Department    (e.g., "CCS")
+Depth 4 — Program       (e.g., "BSCS")
+```
+
+Each `MoodleCategory` record stores `depth`, `path` (e.g., `/3/6/8/18`), and `parentMoodleCategoryId`. The domain entities (`Campus`, `Semester`, `Department`, `Program`) each store a `moodleCategoryId` matching their corresponding category.
+
+### Cross-Semester Category IDs
+
+Each semester in Moodle creates a **separate category sub-tree**. The same logical department (e.g., "CCS") has a different `moodleCategoryId` under each semester:
+
+```
+Campus 3 (UCMN)
+  ├── Semester 6 (S22526)
+  │     └── Department moodleCategoryId=8  (CCS)
+  │           └── Program moodleCategoryId=18 (BSCS)
+  └── Semester 50 (S12627)
+        └── Department moodleCategoryId=60 (CCS)   ← different ID, same dept
+              └── Program moodleCategoryId=72 (BSCS)
+```
+
+This means **`moodleCategoryId` is semester-specific** and cannot be used to look up entities across semesters. The scope resolver uses `code` (which equals `MoodleCategory.name` and is consistent across semesters) instead.
+
+## Role Assignment
+
+Institutional roles are stored in `UserInstitutionalRole`, linking a user + role + `MoodleCategory`:
+
+| Role        | Expected Depth | Source             | Assigned At               |
+| ----------- | -------------- | ------------------ | ------------------------- |
+| DEAN        | 3 (department) | `manual`           | Admin endpoint            |
+| CHAIRPERSON | 4 (program)    | `auto` or `manual` | Moodle hydration or admin |
+
+### DEAN Depth Auto-Resolution
+
+The admin endpoint (`POST /admin/users/:id/institutional-roles`) auto-resolves DEAN assignments:
+
+- **Depth 4 (program)**: Automatically navigated to parent department (depth 3) via `parentMoodleCategoryId`
+- **Depth 3 (department)**: Accepted as-is
+- **Other depths**: Rejected with `400 Bad Request`
+
+This prevents misassignment when an admin selects a program-level category for a Dean (a common mistake when promoting a Chairperson to Dean, since the Chairperson's existing role points to a program).
+
+## Resolution Logic
+
+### `ResolveDepartmentIds(semesterId)`
+
+Returns `string[] | null` — the set of department UUIDs the user may access, or `null` for unrestricted.
+
+```mermaid
+flowchart TD
+    Start([ResolveDepartmentIds]) --> SA{SUPER_ADMIN?}
+    SA -->|Yes| Null([return null — unrestricted])
+    SA -->|No| Dean{DEAN?}
+    Dean -->|Yes| DeanResolve[resolveDeanDepartments]
+    Dean -->|No| Chair{CHAIRPERSON?}
+    Chair -->|Yes| ChairResolve[resolveChairpersonDepartments]
+    Chair -->|No| Forbidden([403 Forbidden])
+
+    DeanResolve --> DeanIR[Fetch UserInstitutionalRole<br/>where role=DEAN]
+    DeanIR --> DeanDepth{Category depth?}
+    DeanDepth -->|3| DirectCode[Use category name as dept code]
+    DeanDepth -->|4| ParentLookup[Fetch parent category<br/>via parentMoodleCategoryId]
+    ParentLookup --> DirectCode
+    DirectCode --> DeptQuery[Find Department by code + semester]
+    DeptQuery --> ReturnIds([return department UUIDs])
+
+    ChairResolve --> ChairIR[Fetch UserInstitutionalRole<br/>where role=CHAIRPERSON]
+    ChairIR --> ProgCode[Use category name as program code]
+    ProgCode --> ProgQuery[Find Program by code + semester<br/>populate department]
+    ProgQuery --> ExtractDepts[Extract unique department IDs]
+    ExtractDepts --> ReturnIds
+```
+
+### `ResolveProgramIds(semesterId)`
+
+Returns `string[] | null` — program UUIDs, or `null` for unrestricted.
+
+| Role        | Behavior                                                               |
+| ----------- | ---------------------------------------------------------------------- |
+| SUPER_ADMIN | `null` (unrestricted)                                                  |
+| DEAN        | `null` (sees all programs in their departments)                        |
+| CHAIRPERSON | Returns specific program UUIDs matching their institutional role codes |
+
+## Consumers
+
+The following services call `ScopeResolverService`:
+
+| Service             | Method                   | What It Scopes                               |
+| ------------------- | ------------------------ | -------------------------------------------- |
+| `FacultyService`    | `ListFaculty`            | Faculty list filtered by department          |
+| `AnalyticsService`  | `ResolveDepartmentCodes` | Analytics queries filtered by department     |
+| `ReportsService`    | Various                  | Report generation scoped to department       |
+| `CurriculumService` | Various                  | Curriculum data scoped to department/program |
+
+### How Consumers Use the Result
+
+```typescript
+const departmentIds = await scopeResolver.ResolveDepartmentIds(semesterId);
+
+if (departmentIds === null) {
+  // Unrestricted — no department filter applied
+} else if (departmentIds.length === 0) {
+  // No access — query short-circuits to empty result
+} else {
+  // Filter: WHERE department_id IN (departmentIds)
+}
+```
+
+## Key Design Decisions
+
+### Why Match by Code Instead of moodleCategoryId
+
+`Department.code` and `Program.code` are set from `MoodleCategory.name` during sync (`moodle-category-sync.service.ts`). They are semantically stable across semesters — "CCS" is always "CCS" regardless of which semester sub-tree it lives under.
+
+By contrast, `moodleCategoryId` is a Moodle-internal integer that differs per semester. Matching by it would only work for the specific semester the role was originally assigned under.
+
+### Why DEAN Supports Depth 4 in the Scope Resolver
+
+Even though the admin endpoint now auto-resolves DEAN to depth 3, existing `UserInstitutionalRole` records may still reference depth-4 categories (created before the validation was added). The scope resolver handles both depths defensively:
+
+- **Depth 3**: Uses `moodleCategory.name` directly as the department code
+- **Depth 4**: Fetches the parent `MoodleCategory` (via `parentMoodleCategoryId`) and uses its `name`
+
+### Role Priority
+
+When a user holds multiple roles, the highest-priority role wins:
+
+1. `SUPER_ADMIN` — unrestricted (`null`)
+2. `DEAN` — department-level scope
+3. `CHAIRPERSON` — program-level scope (narrower)
+
+## Source Files
+
+| File                                                          | Purpose                                                      |
+| ------------------------------------------------------------- | ------------------------------------------------------------ |
+| `src/modules/common/services/scope-resolver.service.ts`       | Core resolution logic                                        |
+| `src/modules/common/services/scope-resolver.service.spec.ts`  | Unit tests                                                   |
+| `src/modules/admin/services/admin.service.ts`                 | DEAN depth validation on assignment                          |
+| `src/entities/user-institutional-role.entity.ts`              | Role ↔ MoodleCategory link                                   |
+| `src/entities/moodle-category.entity.ts`                      | Hierarchy fields (depth, path, parentMoodleCategoryId)       |
+| `src/modules/moodle/services/moodle-category-sync.service.ts` | Sets Department.code / Program.code from MoodleCategory.name |

--- a/src/modules/admin/services/admin.service.spec.ts
+++ b/src/modules/admin/services/admin.service.spec.ts
@@ -1,3 +1,4 @@
+import { BadRequestException } from '@nestjs/common';
 import { EntityManager } from '@mikro-orm/postgresql';
 import { Test, TestingModule } from '@nestjs/testing';
 import { User } from 'src/entities/user.entity';
@@ -8,11 +9,25 @@ describe('AdminService', () => {
   let service: AdminService;
   let em: {
     findAndCount: jest.Mock;
+    findOneOrFail: jest.Mock;
+    create: jest.Mock;
+    upsert: jest.Mock;
+    find: jest.Mock;
+    flush: jest.Mock;
+    assign: jest.Mock;
   };
 
   beforeEach(async () => {
     em = {
       findAndCount: jest.fn(),
+      findOneOrFail: jest.fn(),
+      create: jest
+        .fn()
+        .mockImplementation((_entity: unknown, data: unknown) => data),
+      upsert: jest.fn(),
+      find: jest.fn().mockResolvedValue([]),
+      flush: jest.fn(),
+      assign: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -183,6 +198,113 @@ describe('AdminService', () => {
         totalPages: 0,
         currentPage: 1,
       },
+    });
+  });
+
+  describe('AssignInstitutionalRole', () => {
+    const mockUser = {
+      id: 'user-1',
+      roles: [UserRole.FACULTY],
+      updateRolesFromEnrollments: jest.fn(),
+    } as unknown as User;
+
+    it('should auto-resolve DEAN at depth 4 to parent department at depth 3', async () => {
+      const programCategory = {
+        moodleCategoryId: 18,
+        name: 'BSCS',
+        depth: 4,
+        parentMoodleCategoryId: 8,
+      };
+      const deptCategory = {
+        moodleCategoryId: 8,
+        name: 'CCS',
+        depth: 3,
+      };
+
+      em.findOneOrFail
+        .mockResolvedValueOnce(mockUser) // user lookup
+        .mockResolvedValueOnce(programCategory) // initial category lookup
+        .mockResolvedValueOnce(deptCategory); // parent category lookup
+
+      await service.AssignInstitutionalRole({
+        userId: 'user-1',
+        role: UserRole.DEAN,
+        moodleCategoryId: 18,
+      });
+
+      expect(em.create).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ moodleCategory: deptCategory }),
+        expect.anything(),
+      );
+    });
+
+    it('should accept DEAN assignment directly at depth 3', async () => {
+      const deptCategory = {
+        moodleCategoryId: 8,
+        name: 'CCS',
+        depth: 3,
+      };
+
+      em.findOneOrFail
+        .mockResolvedValueOnce(mockUser)
+        .mockResolvedValueOnce(deptCategory);
+
+      await service.AssignInstitutionalRole({
+        userId: 'user-1',
+        role: UserRole.DEAN,
+        moodleCategoryId: 8,
+      });
+
+      expect(em.create).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ moodleCategory: deptCategory }),
+        expect.anything(),
+      );
+    });
+
+    it('should reject DEAN assignment at depth 2', async () => {
+      const semesterCategory = {
+        moodleCategoryId: 6,
+        name: 'S22526',
+        depth: 2,
+      };
+
+      em.findOneOrFail
+        .mockResolvedValueOnce(mockUser)
+        .mockResolvedValueOnce(semesterCategory);
+
+      await expect(
+        service.AssignInstitutionalRole({
+          userId: 'user-1',
+          role: UserRole.DEAN,
+          moodleCategoryId: 6,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should allow CHAIRPERSON assignment at any depth without validation', async () => {
+      const programCategory = {
+        moodleCategoryId: 18,
+        name: 'BSCS',
+        depth: 4,
+      };
+
+      em.findOneOrFail
+        .mockResolvedValueOnce(mockUser)
+        .mockResolvedValueOnce(programCategory);
+
+      await service.AssignInstitutionalRole({
+        userId: 'user-1',
+        role: UserRole.CHAIRPERSON,
+        moodleCategoryId: 18,
+      });
+
+      expect(em.create).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ moodleCategory: programCategory }),
+        expect.anything(),
+      );
     });
   });
 });

--- a/src/modules/admin/services/admin.service.ts
+++ b/src/modules/admin/services/admin.service.ts
@@ -1,5 +1,9 @@
 import { FilterQuery } from '@mikro-orm/core';
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { EntityManager } from '@mikro-orm/postgresql';
 import {
   UserInstitutionalRole,
@@ -8,6 +12,7 @@ import {
 import { User } from 'src/entities/user.entity';
 import { MoodleCategory } from 'src/entities/moodle-category.entity';
 import { Enrollment } from 'src/entities/enrollment.entity';
+import { UserRole } from 'src/modules/auth/roles.enum';
 import { AssignInstitutionalRoleDto } from '../dto/requests/assign-institutional-role.request.dto';
 import { RemoveInstitutionalRoleDto } from '../dto/requests/remove-institutional-role.request.dto';
 import { ListUsersQueryDto } from '../dto/requests/list-users-query.dto';
@@ -53,11 +58,32 @@ export class AdminService {
       { failHandler: () => new NotFoundException('User not found') },
     );
 
-    const moodleCategory = await this.em.findOneOrFail(
+    let moodleCategory = await this.em.findOneOrFail(
       MoodleCategory,
       { moodleCategoryId: dto.moodleCategoryId },
       { failHandler: () => new NotFoundException('Moodle category not found') },
     );
+
+    // DEAN must be assigned at the department level (depth 3).
+    // If a program-level category (depth 4) is provided, auto-resolve to its parent department.
+    if (dto.role === UserRole.DEAN) {
+      if (moodleCategory.depth === 4) {
+        moodleCategory = await this.em.findOneOrFail(
+          MoodleCategory,
+          { moodleCategoryId: moodleCategory.parentMoodleCategoryId },
+          {
+            failHandler: () =>
+              new NotFoundException('Parent department category not found'),
+          },
+        );
+      }
+
+      if (moodleCategory.depth !== 3) {
+        throw new BadRequestException(
+          `DEAN role must be assigned to a department-level category (depth 3), got depth ${moodleCategory.depth}`,
+        );
+      }
+    }
 
     const roleData = this.em.create(
       UserInstitutionalRole,

--- a/src/modules/common/services/scope-resolver.service.spec.ts
+++ b/src/modules/common/services/scope-resolver.service.spec.ts
@@ -43,12 +43,12 @@ describe('ScopeResolverService', () => {
     expect(em.find).not.toHaveBeenCalled();
   });
 
-  it('should return department IDs for dean with one department', async () => {
+  it('should return department IDs for dean with one depth-3 department', async () => {
     const user = createUser([UserRole.DEAN]);
     currentUserService.getOrFail.mockReturnValue(user);
 
     em.find
-      .mockResolvedValueOnce([{ moodleCategory: { moodleCategoryId: 100 } }])
+      .mockResolvedValueOnce([{ moodleCategory: { name: 'CCS', depth: 3 } }])
       .mockResolvedValueOnce([{ id: 'dept-1' }]);
 
     const result = await service.ResolveDepartmentIds(semesterId);
@@ -57,14 +57,36 @@ describe('ScopeResolverService', () => {
     expect(em.find).toHaveBeenCalledTimes(2);
   });
 
+  it('should return department IDs for dean at depth 4 by resolving parent', async () => {
+    const user = createUser([UserRole.DEAN]);
+    currentUserService.getOrFail.mockReturnValue(user);
+
+    em.find
+      // institutional roles — depth 4 (program-level)
+      .mockResolvedValueOnce([
+        {
+          moodleCategory: { name: 'BSCS', depth: 4, parentMoodleCategoryId: 8 },
+        },
+      ])
+      // parent category lookup
+      .mockResolvedValueOnce([{ name: 'CCS', moodleCategoryId: 8 }])
+      // department lookup by code
+      .mockResolvedValueOnce([{ id: 'dept-1' }]);
+
+    const result = await service.ResolveDepartmentIds(semesterId);
+
+    expect(result).toEqual(['dept-1']);
+    expect(em.find).toHaveBeenCalledTimes(3);
+  });
+
   it('should return multiple department IDs for dean with multiple departments', async () => {
     const user = createUser([UserRole.DEAN]);
     currentUserService.getOrFail.mockReturnValue(user);
 
     em.find
       .mockResolvedValueOnce([
-        { moodleCategory: { moodleCategoryId: 100 } },
-        { moodleCategory: { moodleCategoryId: 200 } },
+        { moodleCategory: { name: 'CCS', depth: 3 } },
+        { moodleCategory: { name: 'COE', depth: 3 } },
       ])
       .mockResolvedValueOnce([{ id: 'dept-1' }, { id: 'dept-2' }]);
 
@@ -90,7 +112,7 @@ describe('ScopeResolverService', () => {
     currentUserService.getOrFail.mockReturnValue(user);
 
     em.find
-      .mockResolvedValueOnce([{ moodleCategory: { moodleCategoryId: 13 } }]) // institutional roles
+      .mockResolvedValueOnce([{ moodleCategory: { name: 'BSCS' } }]) // institutional roles
       .mockResolvedValueOnce([{ id: 'prog-1', department: { id: 'dept-1' } }]); // programs
 
     const result = await service.ResolveDepartmentIds(semesterId);
@@ -105,8 +127,8 @@ describe('ScopeResolverService', () => {
 
     em.find
       .mockResolvedValueOnce([
-        { moodleCategory: { moodleCategoryId: 13 } },
-        { moodleCategory: { moodleCategoryId: 18 } },
+        { moodleCategory: { name: 'BSCS' } },
+        { moodleCategory: { name: 'BSIT' } },
       ])
       .mockResolvedValueOnce([
         { id: 'prog-1', department: { id: 'dept-1' } },
@@ -135,7 +157,7 @@ describe('ScopeResolverService', () => {
     currentUserService.getOrFail.mockReturnValue(user);
 
     em.find
-      .mockResolvedValueOnce([{ moodleCategory: { moodleCategoryId: 100 } }])
+      .mockResolvedValueOnce([{ moodleCategory: { name: 'CCS', depth: 3 } }])
       .mockResolvedValueOnce([{ id: 'dept-1' }]);
 
     const result = await service.ResolveDepartmentIds(semesterId);

--- a/src/modules/common/services/scope-resolver.service.ts
+++ b/src/modules/common/services/scope-resolver.service.ts
@@ -2,6 +2,7 @@ import { ForbiddenException, Injectable } from '@nestjs/common';
 import { EntityManager } from '@mikro-orm/postgresql';
 import { UserRole } from 'src/modules/auth/roles.enum';
 import { UserInstitutionalRole } from 'src/entities/user-institutional-role.entity';
+import { MoodleCategory } from 'src/entities/moodle-category.entity';
 import { Department } from 'src/entities/department.entity';
 import { Program } from 'src/entities/program.entity';
 import { CurrentUserService } from '../cls/current-user.service';
@@ -59,16 +60,16 @@ export class ScopeResolverService {
         { populate: ['moodleCategory'] },
       );
 
-      const moodleCategoryIds = institutionalRoles
-        .filter((ir) => ir.moodleCategory?.moodleCategoryId != null)
-        .map((ir) => ir.moodleCategory.moodleCategoryId);
+      const programCodes = institutionalRoles
+        .filter((ir) => ir.moodleCategory?.name != null)
+        .map((ir) => ir.moodleCategory.name);
 
-      if (moodleCategoryIds.length === 0) {
+      if (programCodes.length === 0) {
         return [];
       }
 
       const programs = await this.em.find(Program, {
-        moodleCategoryId: { $in: moodleCategoryIds },
+        code: { $in: programCodes },
         department: { semester: semesterId },
       });
 
@@ -90,16 +91,38 @@ export class ScopeResolverService {
       { populate: ['moodleCategory'] },
     );
 
-    const moodleCategoryIds = institutionalRoles
-      .filter((ir) => ir.moodleCategory?.moodleCategoryId != null)
-      .map((ir) => ir.moodleCategory.moodleCategoryId);
+    if (institutionalRoles.length === 0) {
+      return [];
+    }
 
-    if (moodleCategoryIds.length === 0) {
+    const directCodes: string[] = [];
+    const parentMoodleCategoryIds: number[] = [];
+
+    for (const ir of institutionalRoles) {
+      const cat = ir.moodleCategory;
+      if (!cat) continue;
+
+      if (cat.depth === 3) {
+        directCodes.push(cat.name);
+      } else if (cat.depth === 4) {
+        parentMoodleCategoryIds.push(cat.parentMoodleCategoryId);
+      }
+    }
+
+    if (parentMoodleCategoryIds.length > 0) {
+      const parentCats = await this.em.find(MoodleCategory, {
+        moodleCategoryId: { $in: parentMoodleCategoryIds },
+      });
+      directCodes.push(...parentCats.map((c) => c.name));
+    }
+
+    const departmentCodes = [...new Set(directCodes)];
+    if (departmentCodes.length === 0) {
       return [];
     }
 
     const departments = await this.em.find(Department, {
-      moodleCategoryId: { $in: moodleCategoryIds },
+      code: { $in: departmentCodes },
       semester: semesterId,
     });
 
@@ -116,11 +139,11 @@ export class ScopeResolverService {
       { populate: ['moodleCategory'] },
     );
 
-    const moodleCategoryIds = institutionalRoles
-      .filter((ir) => ir.moodleCategory?.moodleCategoryId != null)
-      .map((ir) => ir.moodleCategory.moodleCategoryId);
+    const programCodes = institutionalRoles
+      .filter((ir) => ir.moodleCategory?.name != null)
+      .map((ir) => ir.moodleCategory.name);
 
-    if (moodleCategoryIds.length === 0) {
+    if (programCodes.length === 0) {
       return [];
     }
 
@@ -128,7 +151,7 @@ export class ScopeResolverService {
     const programs = await this.em.find(
       Program,
       {
-        moodleCategoryId: { $in: moodleCategoryIds },
+        code: { $in: programCodes },
         department: { semester: semesterId },
       },
       { populate: ['department'] },


### PR DESCRIPTION
## Summary

- Fix `ScopeResolverService` to resolve departments/programs by `code` instead of `moodleCategoryId`, which is semester-specific in Moodle's category hierarchy
- Handle Dean roles assigned at depth 4 (program) by navigating to parent department (depth 3) via `parentMoodleCategoryId`
- Add DEAN depth auto-resolution to admin assignment endpoint — depth 4 auto-resolves to parent, invalid depths rejected with 400
- Add `docs/architecture/scope-resolution.md` documenting the mechanism

## Root Cause

A Dean was manually assigned to a program-level category (depth 4, `moodleCategoryId=18`, "BSCS") instead of the department-level category (depth 3, `moodleCategoryId=8`, "CCS"). The scope resolver looked for `Department WHERE moodle_category_id IN (18)` — found nothing because 18 is a program, not a department. The `1 = 0` short-circuit then killed the faculty query.

Additionally, even at the correct depth, `moodleCategoryId` is semester-specific (each semester creates new category IDs in Moodle), making cross-semester lookups brittle.

Verified fix on Neon DB: query returns **6 faculty** (was 0).

## Test plan

- [x] All 692 unit tests pass
- [x] Lint clean
- [x] Build clean
- [x] Manual verification: Dean user calling `GET /faculty?semesterId=...` returns faculty list

Closes #235