### PR TITLE
fix: skip lifecycle scripts in production Docker stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM node:24-alpine
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev --ignore-scripts
 
 COPY --from=build /app/dist ./dist
 


### PR DESCRIPTION
Husky prepare script fails in production stage. Add --ignore-scripts to npm ci --omit=dev.