### PR TITLE
fix: correct dist entry point path in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ ENV NODE_ENV=production
 
 EXPOSE 5200
 
-CMD ["node", "dist/main"]
+CMD ["node", "dist/src/main"]


### PR DESCRIPTION
NestJS build outputs to dist/src/main.js, not dist/main.js.