### PR TITLE
fix: use runtime DNS resolution in Nginx for optional API containers

### DIFF
--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -3,6 +3,9 @@ events {
 }
 
 http {
+    # Use Docker's embedded DNS for runtime resolution
+    resolver 127.0.0.11 valid=10s;
+
     # Shared settings
     client_max_body_size 10m;
     gzip on;
@@ -31,7 +34,8 @@ http {
         ssl_prefer_server_ciphers on;
 
         location / {
-            proxy_pass http://api-production:5200;
+            set $upstream_prod http://api-production:5200;
+            proxy_pass $upstream_prod;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -55,7 +59,8 @@ http {
         ssl_prefer_server_ciphers on;
 
         location / {
-            proxy_pass http://api-staging:5201;
+            set $upstream_staging http://api-staging:5201;
+            proxy_pass $upstream_staging;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Nginx fails at startup when upstream host doesn't exist. Use variables with Docker DNS resolver to defer resolution to request time.