### PR TITLE
FAC-107 fix: populate campus, program, and department on users during sync and login

### DIFF
--- a/src/modules/auth/dto/responses/me.response.dto.ts
+++ b/src/modules/auth/dto/responses/me.response.dto.ts
@@ -10,6 +10,8 @@ export class MeResponse {
   fullName: string;
   roles: string[];
   campus?: { id: string; name?: string; code: string };
+  program?: { id: string; name?: string; code: string };
+  department?: { id: string; name?: string; code: string };
 
   static Map(user: User): MeResponse {
     return {
@@ -23,6 +25,20 @@ export class MeResponse {
       roles: user.roles,
       campus: user.campus
         ? { id: user.campus.id, name: user.campus.name, code: user.campus.code }
+        : undefined,
+      program: user.program
+        ? {
+            id: user.program.id,
+            name: user.program.name,
+            code: user.program.code,
+          }
+        : undefined,
+      department: user.department
+        ? {
+            id: user.department.id,
+            name: user.department.name,
+            code: user.department.code,
+          }
         : undefined,
     };
   }

--- a/src/modules/common/data-loaders/user.loader.ts
+++ b/src/modules/common/data-loaders/user.loader.ts
@@ -15,7 +15,7 @@ export class UserLoader {
             id: { $in: [...userIds] },
           },
           {
-            populate: ['campus'],
+            populate: ['campus', 'program', 'department'],
           },
         );
 

--- a/src/modules/moodle/services/moodle-enrollment-sync.service.ts
+++ b/src/modules/moodle/services/moodle-enrollment-sync.service.ts
@@ -3,6 +3,8 @@ import { Injectable, Logger } from '@nestjs/common';
 import pLimit from 'p-limit';
 import { Course } from 'src/entities/course.entity';
 import { Section } from 'src/entities/section.entity';
+import { Campus } from 'src/entities/campus.entity';
+import { Program } from 'src/entities/program.entity';
 import { env } from 'src/configurations/env';
 import { Enrollment } from 'src/entities/enrollment.entity';
 import { User } from 'src/entities/user.entity';
@@ -80,6 +82,14 @@ export class EnrollmentSyncService {
           `Failed to sync enrollments for course ${course.moodleCourseId}: ${message}`,
         );
       }
+    }
+
+    // Phase 4: Backfill campus, program, department on users
+    try {
+      await this.backfillUserScopes(fetched);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Failed to backfill user scopes: ${message}`);
     }
 
     const inserted = Math.max(0, enrollmentUpserts - enrollmentCountBefore);
@@ -312,5 +322,116 @@ export class EnrollmentSyncService {
     }
 
     return sectionMap;
+  }
+
+  private async backfillUserScopes(
+    fetched: { course: Course; remoteUsers: MoodleEnrolledUser[] }[],
+  ) {
+    // 1. Build user → program mapping (most course enrollments wins)
+    const userProgramCounts = new Map<number, Map<string, number>>();
+
+    for (const { course, remoteUsers } of fetched) {
+      const programRef = course.program;
+      if (!programRef) continue;
+      const programId =
+        typeof programRef === 'object' ? programRef.id : String(programRef);
+
+      for (const remote of remoteUsers) {
+        if (remote.id == null || !remote.username) continue;
+        if (!userProgramCounts.has(remote.id)) {
+          userProgramCounts.set(remote.id, new Map());
+        }
+        const counts = userProgramCounts.get(remote.id)!;
+        counts.set(programId, (counts.get(programId) ?? 0) + 1);
+      }
+    }
+
+    // 2. Resolve primary program per user (most enrollments, alphabetical ID tiebreaker)
+    const userPrimaryProgram = new Map<number, string>();
+    for (const [moodleUserId, counts] of userProgramCounts) {
+      let maxCount = 0;
+      let primaryProgramId = '';
+      for (const [programId, count] of counts) {
+        if (
+          count > maxCount ||
+          (count === maxCount && programId < primaryProgramId)
+        ) {
+          maxCount = count;
+          primaryProgramId = programId;
+        }
+      }
+      if (primaryProgramId) {
+        userPrimaryProgram.set(moodleUserId, primaryProgramId);
+      }
+    }
+
+    if (userPrimaryProgram.size === 0) return;
+
+    // 3. Load programs with department → semester → campus chain
+    const programIds = [...new Set(userPrimaryProgram.values())];
+    const fork = this.em.fork();
+    const programs = await fork.find(
+      Program,
+      { id: { $in: programIds } },
+      {
+        populate: [
+          'department',
+          'department.semester',
+          'department.semester.campus',
+        ],
+      },
+    );
+    const programMap = new Map(programs.map((p) => [p.id, p]));
+
+    // 4. Load all campuses for username prefix lookup
+    const campuses = await fork.find(Campus, {});
+    const campusByCode = new Map(campuses.map((c) => [c.code, c]));
+
+    // 5. Load users and update scope fields
+    const moodleUserIds = [...userPrimaryProgram.keys()];
+    const users = await fork.find(User, {
+      moodleUserId: { $in: moodleUserIds },
+    });
+
+    let updated = 0;
+    for (const user of users) {
+      if (!user.moodleUserId) continue;
+
+      const programId = userPrimaryProgram.get(user.moodleUserId);
+      if (!programId) continue;
+
+      const program = programMap.get(programId);
+      if (!program) continue;
+
+      const changed =
+        user.program?.id !== program.id ||
+        user.department?.id !== program.department?.id;
+
+      user.program = program;
+
+      if (program.department) {
+        user.department = program.department;
+      }
+
+      // Campus: username prefix first, fallback to category hierarchy
+      const parts = user.userName.split('-');
+      const campusCode = parts.length > 1 ? parts[0].toUpperCase() : null;
+      const campus = campusCode ? campusByCode.get(campusCode) : undefined;
+      const resolvedCampus = campus ?? program.department?.semester?.campus;
+      const campusChanged = user.campus?.id !== resolvedCampus?.id;
+
+      if (resolvedCampus) {
+        user.campus = resolvedCampus;
+      }
+
+      if (changed || campusChanged) {
+        updated++;
+      }
+    }
+
+    if (updated > 0) {
+      await fork.flush();
+      this.logger.log(`Backfilled scope fields for ${updated} users`);
+    }
   }
 }

--- a/src/modules/moodle/services/moodle-user-hydration.service.ts
+++ b/src/modules/moodle/services/moodle-user-hydration.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { User } from 'src/entities/user.entity';
 import { Program } from 'src/entities/program.entity';
+import { Campus } from 'src/entities/campus.entity';
 import { Course } from 'src/entities/course.entity';
 import { Enrollment } from 'src/entities/enrollment.entity';
 import { Section } from 'src/entities/section.entity';
@@ -249,6 +250,10 @@ export class MoodleUserHydrationService {
       const institutionalRoles = await tx.find(UserInstitutionalRole, { user });
 
       user.updateRolesFromEnrollments(activeEnrollments, institutionalRoles);
+
+      // Derive scope fields: program, department, campus
+      await this.deriveUserScopes(user, programCache, remoteCourses, tx);
+
       tx.persist(user);
     });
 
@@ -256,6 +261,69 @@ export class MoodleUserHydrationService {
     this.logger.log(
       `Finished hydrating courses for Moodle user ${moodleUserId} in ${duration}ms`,
     );
+  }
+
+  private async deriveUserScopes(
+    user: User,
+    programCache: Map<number, Program>,
+    remoteCourses: MoodleCourse[],
+    tx: EntityManager,
+  ) {
+    // Pick primary program: most course enrollments
+    const programCounts = new Map<
+      string,
+      { program: Program; count: number }
+    >();
+    for (const rc of remoteCourses) {
+      const program = programCache.get(rc.category);
+      if (!program) continue;
+      const entry = programCounts.get(program.id);
+      if (entry) {
+        entry.count++;
+      } else {
+        programCounts.set(program.id, { program, count: 1 });
+      }
+    }
+
+    let primaryProgram: Program | undefined;
+    let maxCount = 0;
+    for (const { program, count } of programCounts.values()) {
+      if (
+        count > maxCount ||
+        (count === maxCount &&
+          (!primaryProgram || program.id < primaryProgram.id))
+      ) {
+        maxCount = count;
+        primaryProgram = program;
+      }
+    }
+
+    if (!primaryProgram) return;
+
+    // Populate department → semester → campus chain
+    await tx.populate(primaryProgram, [
+      'department',
+      'department.semester',
+      'department.semester.campus',
+    ]);
+
+    user.program = primaryProgram;
+
+    if (primaryProgram.department) {
+      user.department = primaryProgram.department;
+    }
+
+    // Campus: username prefix first, fallback to category hierarchy
+    const parts = user.userName.split('-');
+    const campusCode = parts.length > 1 ? parts[0].toUpperCase() : null;
+    const campus = campusCode
+      ? await tx.findOne(Campus, { code: campusCode })
+      : null;
+    if (campus) {
+      user.campus = campus;
+    } else if (primaryProgram.department?.semester?.campus) {
+      user.campus = primaryProgram.department.semester.campus;
+    }
   }
 
   private async resolveInstitutionalRoles(


### PR DESCRIPTION
## Summary
- Adds `backfillUserScopes()` to `EnrollmentSyncService` — derives campus, program, and department for all users after each Moodle sync via the course → program → department → semester → campus chain
- Adds `deriveUserScopes()` to `MoodleUserHydrationService` — sets scope fields on every Moodle login for immediate consistency
- Campus uses two-tier derivation: username prefix lookup (primary), category hierarchy walk (fallback for non-standard usernames like `harvie`)
- Exposes `program` and `department` in `GET /auth/me` response
- Adds `program` and `department` to `UserLoader` populate list

Closes #247

## Test plan
- [ ] Trigger a manual sync (`POST /moodle/sync`) and verify `campus_id`, `program_id`, `department_id` are populated on the `user` table for enrolled users
- [ ] Log in as a Moodle user with standard username (e.g., `ucmn-XXXX`) and verify `GET /auth/me` returns campus, program, and department
- [ ] Log in as a Moodle user with non-standard username (e.g., `harvie`) and verify campus is derived via the category hierarchy fallback
- [ ] Verify existing unit tests pass (692/692)
- [ ] Verify admin `GET /admin/users` still returns campus, program, department correctly