### PR TITLE
FAC-110 feat: add admin endpoint for detailed info about a single user

### DIFF
--- a/_bmad-output/implementation-artifacts/tech-spec-admin-user-detail.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-admin-user-detail.md
@@ -1,0 +1,321 @@
+---
+title: 'Admin User Detail Endpoint'
+slug: 'admin-user-detail'
+created: '2026-04-02'
+status: 'completed'
+stepsCompleted: [1, 2, 3, 4]
+tech_stack:
+  [
+    'NestJS 11',
+    'MikroORM 6',
+    'PostgreSQL',
+    'class-validator',
+    '@nestjs/swagger',
+    'Jest 30',
+  ]
+files_to_modify:
+  - 'src/modules/admin/admin.controller.ts'
+  - 'src/modules/admin/services/admin.service.ts'
+  - 'src/modules/admin/dto/responses/admin-user-detail.response.dto.ts (new)'
+  - 'src/modules/admin/dto/responses/admin-user-item.response.dto.ts'
+  - 'src/modules/admin/admin.module.ts'
+  - 'src/modules/admin/services/admin.service.spec.ts'
+  - 'src/modules/admin/admin.controller.spec.ts'
+code_patterns:
+  - 'PascalCase public service methods (e.g., GetUserDetail)'
+  - 'Static Map() factory on response DTOs for entity-to-DTO conversion'
+  - '@UseJwtGuard(UserRole.SUPER_ADMIN) on controller class'
+  - 'em.findOneOrFail with failHandler for 404s'
+  - 'em.find with populate for relation loading'
+  - '@ApiOperation, @ApiResponse, @ApiParam Swagger decorators on endpoints'
+  - 'AdminUserScopedRelationDto (id, code, name) reusable for scoped relations'
+test_patterns:
+  - 'NestJS TestingModule with mocked EntityManager (jest.fn() per method)'
+  - 'Controller tests override AuthGuard("jwt") and RolesGuard'
+  - 'Service tests mock em.findOneOrFail, em.find, em.findAndCount, em.flush'
+  - 'Tests use as User / as unknown as User for mock data casting'
+---
+
+# Tech-Spec: Admin User Detail Endpoint
+
+**Created:** 2026-04-02
+
+## Overview
+
+### Problem Statement
+
+The admin console has no way to view detailed information about a single user. The existing list endpoint (`GET /admin/users`) returns only summary data (name, roles, active status, scoped relations). Admins need a drill-down view showing enrollments and institutional role assignments to manage users effectively.
+
+### Solution
+
+Add a `GET /admin/users/:id` endpoint (SUPER_ADMIN only) that returns the full user profile plus their active enrollments (with course info) and institutional role assignments (with category context).
+
+### Scope
+
+**In Scope:**
+
+- New `GET /admin/users/:id` endpoint on `AdminController`
+- New `AdminUserDetailResponseDto` with user details + enrollments + institutional roles
+- Populate enrollment → course chain for course names
+- Populate institutional roles → moodleCategory for role context
+- Filter enrollments by `isActive: true` AND `course.isActive: true` to exclude deactivated courses
+- Unit tests for service and controller
+
+**Out of Scope:**
+
+- Editing user details via this endpoint
+- Enrollment management (create/delete)
+- Moodle token exposure
+- Changes to the existing list endpoint
+
+## Context for Development
+
+### Codebase Patterns
+
+- **Service methods** use `PascalCase` (e.g., `ListUsers`, `GetDeanEligibleCategories`)
+- **Response DTOs** use a static `Map()` factory for entity-to-DTO conversion (see `AdminUserItemResponseDto.Map()`)
+- **Admin controller** has class-level `@UseJwtGuard(UserRole.SUPER_ADMIN)` and `@ApiBearerAuth()` — new endpoints inherit these
+- **MikroORM** requires explicit `populate` for relation loading — no eager loading configured
+- **Entity lookups** use `em.findOneOrFail` with `failHandler: () => new NotFoundException(...)` pattern
+- **Enrollment entity** has nullable `section` relation (null when user has no group membership)
+- **Enrollment.role** is a string field with values: `'student'`, `'editingteacher'`, `'teacher'` (see `EnrollmentRole` enum in `questionnaires/lib/questionnaire.types.ts`)
+- **UserInstitutionalRole** has `role` (string: DEAN/CHAIRPERSON), `moodleCategory` (ManyToOne), `source` (AUTO/MANUAL)
+- **MoodleCategory** has `name`, `depth`, `moodleCategoryId` — used for institutional role context
+- **AdminModule** currently imports: Campus, Department, MoodleCategory, Program, Semester, UserInstitutionalRole, User — **Enrollment and Course are NOT imported yet**
+- **Soft delete** is globally enforced via MikroORM filter; all entities inherit `deletedAt` from `CustomBaseEntity`
+
+### Files to Reference
+
+| File                                                                | Purpose                                                                                                                                                                                                           |
+| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/modules/admin/admin.controller.ts`                             | Add new `GET users/:id` endpoint (follows existing `ListUsers` pattern)                                                                                                                                           |
+| `src/modules/admin/services/admin.service.ts`                       | Add `GetUserDetail()` method (follows `GetDeanEligibleCategories` pattern for single-entity lookup)                                                                                                               |
+| `src/modules/admin/dto/responses/admin-user-item.response.dto.ts`   | Export `AdminUserScopedRelationDto` for reuse                                                                                                                                                                     |
+| `src/modules/admin/dto/responses/admin-user-detail.response.dto.ts` | **NEW FILE** — detail response DTO with enrollment + institutional role sub-DTOs                                                                                                                                  |
+| `src/modules/admin/admin.module.ts`                                 | Add `Enrollment` and `Course` to `MikroOrmModule.forFeature()` imports                                                                                                                                            |
+| `src/modules/admin/services/admin.service.spec.ts`                  | Add `GetUserDetail` test describe block (follows existing mock patterns)                                                                                                                                          |
+| `src/modules/admin/admin.controller.spec.ts`                        | Add controller delegation test (follows `ListUsers` pattern)                                                                                                                                                      |
+| `src/entities/user.entity.ts`                                       | User entity — fields: userName, firstName, lastName, fullName, moodleUserId, userProfilePicture, isActive, roles, lastLoginAt, createdAt; relations: campus, department, program, enrollments, institutionalRoles |
+| `src/entities/enrollment.entity.ts`                                 | Enrollment entity — fields: role (string), isActive, timeModified; relations: user, course, section (nullable)                                                                                                    |
+| `src/entities/course.entity.ts`                                     | Course entity — fields: shortname, fullname, moodleCourseId, isActive, isVisible, startDate, endDate; relations: program                                                                                          |
+| `src/entities/user-institutional-role.entity.ts`                    | UserInstitutionalRole entity — fields: role (string), source (AUTO/MANUAL); relations: user, moodleCategory                                                                                                       |
+| `src/entities/moodle-category.entity.ts`                            | MoodleCategory entity — fields: moodleCategoryId, name, depth, path                                                                                                                                               |
+
+### Technical Decisions
+
+1. **Filter enrollments by `course.isActive: true`** — The sync pipeline can leave active enrollments pointing to deactivated courses. Filtering at query time prevents showing stale data.
+2. **Export `AdminUserScopedRelationDto`** — Currently non-exported in `admin-user-item.response.dto.ts`. Add the `export` keyword so the detail DTO can import and reuse it for campus/department/program.
+3. **Separate enrollment and institutional role sub-DTOs** — Keep the response structured with nested arrays.
+4. **Return 404 for missing users** — Use `em.findOneOrFail` with `failHandler` pattern consistent with `GetDeanEligibleCategories`.
+5. **Two separate queries for enrollments and institutional roles** — Rather than deep-populating from the User entity (which would load ALL enrollments including inactive), use targeted `em.find()` calls with explicit filters.
+6. **Populate chain for enrollments: `['course']`** — Course name fields (shortname, fullname) are sufficient. No need to walk up the program->department->semester chain since the user's scoped relations (campus, department, program) are already on the User entity directly.
+7. **Populate chain for institutional roles: `['moodleCategory']`** — Need category name and depth for display context.
+
+## Implementation Plan
+
+### Tasks
+
+- [ ] **Task 1: Register entities in AdminModule**
+  - File: `src/modules/admin/admin.module.ts`
+  - Action: Add `Enrollment` and `Course` to the `MikroOrmModule.forFeature()` array
+  - Notes: Import from `src/entities/enrollment.entity` and `src/entities/course.entity`
+
+- [ ] **Task 2: Export `AdminUserScopedRelationDto`**
+  - File: `src/modules/admin/dto/responses/admin-user-item.response.dto.ts`
+  - Action: Add the `export` keyword to the existing `class AdminUserScopedRelationDto` declaration (line 5)
+  - Notes: Currently `class AdminUserScopedRelationDto` — change to `export class AdminUserScopedRelationDto`. No other changes to this file.
+
+- [ ] **Task 3: Create the detail response DTO**
+  - File: `src/modules/admin/dto/responses/admin-user-detail.response.dto.ts` **(NEW)**
+  - Action: Create `AdminUserDetailResponseDto` with the following structure:
+
+  **Sub-DTOs to define in this file:**
+
+  `AdminEnrollmentItemDto`:
+  - `id` (string) — enrollment ID
+  - `role` (string) — Moodle enrollment role (e.g., `'student'`, `'teacher'`)
+  - `isActive` (boolean)
+  - `course` object:
+    - `id` (string) — course entity ID
+    - `shortname` (string)
+    - `fullname` (string)
+  - Static `Map(enrollment: Enrollment)` method
+
+  `AdminInstitutionalRoleItemDto`:
+  - `id` (string) — institutional role entity ID
+  - `role` (string) — e.g., `'DEAN'`, `'CHAIRPERSON'`
+  - `source` (string) — `'auto'` or `'manual'` (lowercase, per `InstitutionalRoleSource` enum values)
+  - `category` object:
+    - `moodleCategoryId` (number)
+    - `name` (string)
+    - `depth` (number)
+  - Static `Map(ir: UserInstitutionalRole)` method — must null-guard `ir.moodleCategory` (existing production code in `GetDeanEligibleCategories` defensively checks for falsy `moodleCategory` despite the non-nullable entity declaration)
+
+  **Main DTO: `AdminUserDetailResponseDto`:**
+  - `id` (string)
+  - `userName` (string)
+  - `fullName` (string)
+  - `firstName` (string)
+  - `lastName` (string)
+  - `moodleUserId` (number, optional)
+  - `userProfilePicture` (string)
+  - `roles` (UserRole[])
+  - `isActive` (boolean)
+  - `lastLoginAt` (Date)
+  - `createdAt` (Date)
+  - `campus` (AdminUserScopedRelationDto | null) — imported from `admin-user-item.response.dto.ts`
+  - `department` (AdminUserScopedRelationDto | null)
+  - `program` (AdminUserScopedRelationDto | null)
+  - `enrollments` (AdminEnrollmentItemDto[])
+  - `institutionalRoles` (AdminInstitutionalRoleItemDto[])
+  - Static `Map(user: User, enrollments: Enrollment[], institutionalRoles: UserInstitutionalRole[])` method
+
+  Notes:
+  - All properties must have `@ApiProperty` or `@ApiPropertyOptional` decorators
+  - Use `@ApiProperty({ type: [AdminEnrollmentItemDto] })` for array properties
+  - The `Map()` method handles null-safe mapping for campus/department/program (same pattern as `AdminUserItemResponseDto.Map()`)
+  - The `Map()` method must use the `fullName` null-coalescing fallback: `user.fullName ?? \`${user.firstName} ${user.lastName}\`.trim()`(same as`AdminUserItemResponseDto.Map()` line 48)
+  - The `Map()` method must filter out institutional roles where `ir.moodleCategory` is falsy before mapping to prevent runtime TypeError
+
+- [ ] **Task 4: Implement `GetUserDetail()` in AdminService**
+  - File: `src/modules/admin/services/admin.service.ts`
+  - Action: Add the following method to `AdminService`:
+
+  ```typescript
+  async GetUserDetail(userId: string): Promise<AdminUserDetailResponseDto> {
+    // 1. Load user with scoped relations
+    const user = await this.em.findOneOrFail(
+      User,
+      { id: userId },
+      {
+        populate: ['campus', 'department', 'program'],
+        failHandler: () => new NotFoundException('User not found'),
+      },
+    );
+
+    // 2. Load active enrollments with active courses
+    const enrollments = await this.em.find(
+      Enrollment,
+      { user: userId, isActive: true, course: { isActive: true } },
+      {
+        populate: ['course'],
+        orderBy: { timeModified: 'DESC' },
+      },
+    );
+
+    // 3. Load institutional roles with category context
+    const institutionalRoles = await this.em.find(
+      UserInstitutionalRole,
+      { user: userId },
+      { populate: ['moodleCategory'] },
+    );
+
+    return AdminUserDetailResponseDto.Map(user, enrollments, institutionalRoles);
+  }
+  ```
+
+  Notes:
+  - Add `AdminUserDetailResponseDto` to imports
+  - Enrollments ordered by `timeModified DESC` (most recently modified first)
+  - Enrollment filter: `isActive: true` AND `course: { isActive: true }` to exclude deactivated courses
+  - Institutional roles have no active/inactive filter — show all assignments
+
+- [ ] **Task 5: Add controller endpoint**
+  - File: `src/modules/admin/admin.controller.ts`
+  - Action: Add the following endpoint method to `AdminController`, placed after `ListUsers` and before `GetDeanEligibleCategories`:
+
+  ```typescript
+  @Get('users/:id')
+  @ApiOperation({ summary: 'Get detailed information about a single user' })
+  @ApiParam({ name: 'id', type: String, description: 'User UUID' })
+  @ApiResponse({ status: 200, type: AdminUserDetailResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid UUID format' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  async GetUserDetail(@Param('id', ParseUUIDPipe) id: string): Promise<AdminUserDetailResponseDto> {
+    return this.adminService.GetUserDetail(id);
+  }
+  ```
+
+  Notes:
+  - Import `Param, ParseUUIDPipe` from `@nestjs/common` (add to existing import)
+  - Import `ApiParam` from `@nestjs/swagger` (add to existing import)
+  - Import `AdminUserDetailResponseDto` from the new DTO file
+  - `ParseUUIDPipe` validates the `:id` param is a valid UUID, returning 400 for malformed input (consistent with other controllers: `faculty.controller.ts`, `reports.controller.ts`, etc.)
+
+- [ ] **Task 6: Add service unit tests**
+  - File: `src/modules/admin/services/admin.service.spec.ts`
+  - Action: Add a new `describe('GetUserDetail')` block with the following test cases:
+  1. **`should return full user detail with enrollments and institutional roles`**
+     - Mock `em.findOneOrFail` → returns a user with campus/department/program
+     - Mock `em.find` call 1 → returns enrollments with populated course
+     - Mock `em.find` call 2 → returns institutional roles with populated moodleCategory
+     - Assert response contains all user fields, enrollment array, institutional roles array
+
+  2. **`should return empty arrays when user has no enrollments or roles`**
+     - Mock `em.findOneOrFail` → returns a user
+     - Mock `em.find` → returns `[]` for both calls
+     - Assert `enrollments: []` and `institutionalRoles: []`
+
+  3. **`should throw NotFoundException when user does not exist`**
+     - Mock `em.findOneOrFail` to invoke `failHandler`
+     - Assert throws `NotFoundException`
+
+  4. **`should filter enrollments by isActive and course.isActive`**
+     - Mock `em.findOneOrFail` → returns user
+     - Mock `em.find` → returns `[]`
+     - Assert `em.find` was called with `Enrollment` and filter `{ user: userId, isActive: true, course: { isActive: true } }`
+
+  Notes: Follow existing test patterns — use `em.findOneOrFail.mockResolvedValueOnce()` and `em.find.mockResolvedValueOnce()` sequencing. Use mock data objects cast with `as unknown as User`, etc.
+
+- [ ] **Task 7: Add controller unit test**
+  - File: `src/modules/admin/admin.controller.spec.ts`
+  - Action: Add `GetUserDetail` to the mock service object and add a test:
+  1. Add `GetUserDetail: jest.fn().mockResolvedValue({})` to the `adminService` mock
+  2. Add test: `it('should delegate user detail to the admin service')` — call `controller.GetUserDetail('user-1')`, assert `adminService.GetUserDetail` was called with `'user-1'`
+
+### Acceptance Criteria
+
+- [ ] **AC 1:** Given a SUPER_ADMIN is authenticated, when they call `GET /admin/users/:id` with a valid user UUID, then they receive a 200 response with the full user profile including `enrollments[]` and `institutionalRoles[]` arrays.
+
+- [ ] **AC 2:** Given a SUPER_ADMIN calls `GET /admin/users/:id` with a UUID that does not match any user, when the request is processed, then they receive a 404 response with message `'User not found'`.
+
+- [ ] **AC 2b:** Given a SUPER_ADMIN calls `GET /admin/users/:id` with a malformed (non-UUID) string, when the request is processed, then they receive a 400 response before hitting the database.
+
+- [ ] **AC 3:** Given a user has active enrollments in both active and deactivated courses, when the detail endpoint is called, then only enrollments where both `enrollment.isActive = true` AND `course.isActive = true` are returned.
+
+- [ ] **AC 4:** Given a user has no enrollments, when the detail endpoint is called, then the `enrollments` array is empty (`[]`) and the response still includes all other user fields.
+
+- [ ] **AC 5:** Given a user has institutional roles (DEAN/CHAIRPERSON), when the detail endpoint is called, then the `institutionalRoles` array contains each role with its `moodleCategory` name, depth, and source (AUTO/MANUAL).
+
+- [ ] **AC 6:** Given a user has no institutional role assignments, when the detail endpoint is called, then the `institutionalRoles` array is empty (`[]`).
+
+- [ ] **AC 7:** Given the response DTO, when Swagger docs are generated, then the endpoint and its response schema are fully documented with `@ApiOperation`, `@ApiParam`, `@ApiResponse`, and `@ApiProperty` decorators.
+
+- [ ] **AC 8:** Given the unit test suite, when `npm run test -- --testPathPattern=admin` is run, then all existing and new tests pass.
+
+## Additional Context
+
+### Dependencies
+
+- No new packages required
+- **Enrollment** and **Course** entities must be added to `AdminModule`'s `MikroOrmModule.forFeature()` array (Task 1)
+- No database migrations needed — reads existing data only
+
+### Testing Strategy
+
+- **Unit tests (service):** Mock EntityManager methods. Test happy path (full data), empty relations, 404, and filter correctness. 4 test cases in `admin.service.spec.ts`.
+- **Unit tests (controller):** Mock AdminService. Verify delegation. 1 test case in `admin.controller.spec.ts`.
+- **Manual testing:** Call `GET /admin/users/:id` via Swagger UI or curl with a valid JWT. Verify:
+  - Response shape matches DTO
+  - Enrollments are filtered correctly (compare with DB records)
+  - Institutional roles include category names
+
+### Notes
+
+- Investigation confirmed: enrollment → course data is always present in normal operations (sync ordering: categories → courses → enrollments). The `course.isActive` filter is a defensive measure for the edge case where courses are deactivated post-enrollment.
+- `Section` on enrollment is nullable by design (no group membership) — excluded from the DTO since the admin console doesn't need group-level detail.
+- `AdminUserScopedRelationDto` is currently a non-exported class inside `admin-user-item.response.dto.ts`. Task 2 exports it so the detail DTO can reuse it.
+- The enrollment `role` field is a raw string from Moodle (e.g., `'student'`, `'editingteacher'`). Passed through as-is — no enum enforcement at the DTO level.
+- Enrollment ordering: `timeModified DESC` gives admins the most recently active enrollments first.
+- **Soft-deleted users:** The global MikroORM soft-delete filter will exclude soft-deleted users, returning a 404 indistinguishable from "user never existed." This is intentional and consistent with the list endpoint behavior — the admin console cannot list deleted users, so it cannot navigate to their detail view.
+- **E2E test risk (deferred):** The nested MikroORM filter `course: { isActive: true }` cannot be validated by unit tests with mocked `em.find`. If MikroORM changes how nested relation filters generate SQL, unit tests will pass while the endpoint silently breaks. An E2E test seeding a user with active/inactive course enrollments and asserting correct filtering would catch this. Deferred for now — manual testing covers it, but consider adding E2E coverage later.

--- a/src/modules/admin/admin.controller.spec.ts
+++ b/src/modules/admin/admin.controller.spec.ts
@@ -21,6 +21,7 @@ describe('AdminController', () => {
           currentPage: 1,
         },
       }),
+      GetUserDetail: jest.fn().mockResolvedValue({}),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -39,6 +40,12 @@ describe('AdminController', () => {
       .compile();
 
     controller = module.get(AdminController);
+  });
+
+  it('should delegate user detail to the admin service', async () => {
+    await controller.GetUserDetail('user-1');
+
+    expect(adminService.GetUserDetail).toHaveBeenCalledWith('user-1');
   });
 
   it('should delegate user listing to the admin service', async () => {

--- a/src/modules/admin/admin.controller.ts
+++ b/src/modules/admin/admin.controller.ts
@@ -1,7 +1,17 @@
-import { Body, Controller, Delete, Get, Post, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Query,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOperation,
+  ApiParam,
   ApiQuery,
   ApiResponse,
   ApiTags,
@@ -13,6 +23,7 @@ import { AssignInstitutionalRoleDto } from './dto/requests/assign-institutional-
 import { RemoveInstitutionalRoleDto } from './dto/requests/remove-institutional-role.request.dto';
 import { ListUsersQueryDto } from './dto/requests/list-users-query.dto';
 import { DeanEligibleCategoriesQueryDto } from './dto/requests/dean-eligible-categories-query.dto';
+import { AdminUserDetailResponseDto } from './dto/responses/admin-user-detail.response.dto';
 import { AdminUserListResponseDto } from './dto/responses/admin-user-list.response.dto';
 import { DeanEligibleCategoryResponseDto } from './dto/responses/dean-eligible-category.response.dto';
 
@@ -86,6 +97,18 @@ export class AdminController {
     @Query() query: ListUsersQueryDto,
   ): Promise<AdminUserListResponseDto> {
     return this.adminService.ListUsers(query);
+  }
+
+  @Get('users/:id')
+  @ApiOperation({ summary: 'Get detailed information about a single user' })
+  @ApiParam({ name: 'id', type: String, description: 'User UUID' })
+  @ApiResponse({ status: 200, type: AdminUserDetailResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid UUID format' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  async GetUserDetail(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<AdminUserDetailResponseDto> {
+    return this.adminService.GetUserDetail(id);
   }
 
   @Get('institutional-roles/dean-eligible-categories')

--- a/src/modules/admin/admin.module.ts
+++ b/src/modules/admin/admin.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { Campus } from 'src/entities/campus.entity';
+import { Course } from 'src/entities/course.entity';
 import { Department } from 'src/entities/department.entity';
+import { Enrollment } from 'src/entities/enrollment.entity';
 import { MoodleCategory } from 'src/entities/moodle-category.entity';
 import { Program } from 'src/entities/program.entity';
 import { Semester } from 'src/entities/semester.entity';
@@ -16,7 +18,9 @@ import { AdminFiltersService } from './services/admin-filters.service';
   imports: [
     MikroOrmModule.forFeature([
       Campus,
+      Course,
       Department,
+      Enrollment,
       MoodleCategory,
       Program,
       Semester,

--- a/src/modules/admin/dto/responses/admin-user-detail.response.dto.ts
+++ b/src/modules/admin/dto/responses/admin-user-detail.response.dto.ts
@@ -1,0 +1,179 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Enrollment } from 'src/entities/enrollment.entity';
+import { UserInstitutionalRole } from 'src/entities/user-institutional-role.entity';
+import { User } from 'src/entities/user.entity';
+import { UserRole } from 'src/modules/auth/roles.enum';
+import { AdminUserScopedRelationDto } from './admin-user-item.response.dto';
+
+class AdminEnrollmentCourseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  shortname: string;
+
+  @ApiProperty()
+  fullname: string;
+}
+
+class AdminInstitutionalRoleCategoryDto {
+  @ApiProperty()
+  moodleCategoryId: number;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  depth: number;
+}
+
+export class AdminEnrollmentItemDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  role: string;
+
+  @ApiProperty()
+  isActive: boolean;
+
+  @ApiProperty({ type: AdminEnrollmentCourseDto })
+  course: AdminEnrollmentCourseDto;
+
+  static Map(enrollment: Enrollment): AdminEnrollmentItemDto {
+    return {
+      id: enrollment.id,
+      role: enrollment.role,
+      isActive: enrollment.isActive,
+      course: {
+        id: enrollment.course.id,
+        shortname: enrollment.course.shortname,
+        fullname: enrollment.course.fullname,
+      },
+    };
+  }
+}
+
+export class AdminInstitutionalRoleItemDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  role: string;
+
+  @ApiProperty()
+  source: string;
+
+  @ApiProperty({ type: AdminInstitutionalRoleCategoryDto })
+  category: AdminInstitutionalRoleCategoryDto;
+
+  static Map(ir: UserInstitutionalRole): AdminInstitutionalRoleItemDto | null {
+    if (!ir.moodleCategory) return null;
+
+    return {
+      id: ir.id,
+      role: ir.role,
+      source: ir.source,
+      category: {
+        moodleCategoryId: ir.moodleCategory.moodleCategoryId,
+        name: ir.moodleCategory.name,
+        depth: ir.moodleCategory.depth,
+      },
+    };
+  }
+}
+
+export class AdminUserDetailResponseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  userName: string;
+
+  @ApiProperty()
+  fullName: string;
+
+  @ApiProperty()
+  firstName: string;
+
+  @ApiProperty()
+  lastName: string;
+
+  @ApiPropertyOptional()
+  moodleUserId?: number;
+
+  @ApiProperty()
+  userProfilePicture: string;
+
+  @ApiProperty({ enum: UserRole, isArray: true })
+  roles: UserRole[];
+
+  @ApiProperty()
+  isActive: boolean;
+
+  @ApiProperty()
+  lastLoginAt: Date;
+
+  @ApiProperty()
+  createdAt: Date;
+
+  @ApiPropertyOptional({ type: AdminUserScopedRelationDto, nullable: true })
+  campus: AdminUserScopedRelationDto | null;
+
+  @ApiPropertyOptional({ type: AdminUserScopedRelationDto, nullable: true })
+  department: AdminUserScopedRelationDto | null;
+
+  @ApiPropertyOptional({ type: AdminUserScopedRelationDto, nullable: true })
+  program: AdminUserScopedRelationDto | null;
+
+  @ApiProperty({ type: [AdminEnrollmentItemDto] })
+  enrollments: AdminEnrollmentItemDto[];
+
+  @ApiProperty({ type: [AdminInstitutionalRoleItemDto] })
+  institutionalRoles: AdminInstitutionalRoleItemDto[];
+
+  static Map(
+    user: User,
+    enrollments: Enrollment[],
+    institutionalRoles: UserInstitutionalRole[],
+  ): AdminUserDetailResponseDto {
+    return {
+      id: user.id,
+      userName: user.userName,
+      fullName: user.fullName ?? `${user.firstName} ${user.lastName}`.trim(),
+      firstName: user.firstName,
+      lastName: user.lastName,
+      moodleUserId: user.moodleUserId,
+      userProfilePicture: user.userProfilePicture,
+      roles: user.roles,
+      isActive: user.isActive,
+      lastLoginAt: user.lastLoginAt,
+      createdAt: user.createdAt,
+      campus: user.campus
+        ? {
+            id: user.campus.id,
+            code: user.campus.code,
+            name: user.campus.name,
+          }
+        : null,
+      department: user.department
+        ? {
+            id: user.department.id,
+            code: user.department.code,
+            name: user.department.name,
+          }
+        : null,
+      program: user.program
+        ? {
+            id: user.program.id,
+            code: user.program.code,
+            name: user.program.name,
+          }
+        : null,
+      enrollments: enrollments.map((e) => AdminEnrollmentItemDto.Map(e)),
+      institutionalRoles: institutionalRoles
+        .map((ir) => AdminInstitutionalRoleItemDto.Map(ir))
+        .filter((dto): dto is AdminInstitutionalRoleItemDto => dto !== null),
+    };
+  }
+}

--- a/src/modules/admin/dto/responses/admin-user-item.response.dto.ts
+++ b/src/modules/admin/dto/responses/admin-user-item.response.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { User } from 'src/entities/user.entity';
 import { UserRole } from 'src/modules/auth/roles.enum';
 
-class AdminUserScopedRelationDto {
+export class AdminUserScopedRelationDto {
   @ApiProperty()
   id: string;
 

--- a/src/modules/admin/services/admin.service.spec.ts
+++ b/src/modules/admin/services/admin.service.spec.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { EntityManager } from '@mikro-orm/postgresql';
 import { Test, TestingModule } from '@nestjs/testing';
+import { Enrollment } from 'src/entities/enrollment.entity';
 import { User } from 'src/entities/user.entity';
 import { UserRole } from 'src/modules/auth/roles.enum';
 import { AdminService } from './admin.service';
@@ -198,6 +199,144 @@ describe('AdminService', () => {
         totalPages: 0,
         currentPage: 1,
       },
+    });
+  });
+
+  describe('GetUserDetail', () => {
+    const mockUser = {
+      id: 'user-1',
+      userName: 'jdoe',
+      fullName: 'John Doe',
+      firstName: 'John',
+      lastName: 'Doe',
+      moodleUserId: 123,
+      userProfilePicture: 'https://example.com/pic.jpg',
+      roles: [UserRole.FACULTY],
+      isActive: true,
+      lastLoginAt: new Date('2026-03-01'),
+      createdAt: new Date('2026-01-01'),
+      campus: { id: 'campus-1', code: 'UCMN', name: 'Main' },
+      department: { id: 'dept-1', code: 'CCS', name: 'Computer Studies' },
+      program: { id: 'prog-1', code: 'BSCS', name: 'Computer Science' },
+    } as unknown as User;
+
+    it('should return full user detail with enrollments and institutional roles', async () => {
+      const mockEnrollments = [
+        {
+          id: 'enr-1',
+          role: 'student',
+          isActive: true,
+          course: {
+            id: 'course-1',
+            shortname: 'CS101',
+            fullname: 'Intro to CS',
+          },
+        },
+      ];
+      const mockInstitutionalRoles = [
+        {
+          id: 'ir-1',
+          role: UserRole.DEAN,
+          source: 'manual',
+          moodleCategory: {
+            moodleCategoryId: 8,
+            name: 'CCS',
+            depth: 3,
+          },
+        },
+      ];
+
+      em.findOneOrFail.mockResolvedValueOnce(mockUser);
+      em.find
+        .mockResolvedValueOnce(mockEnrollments)
+        .mockResolvedValueOnce(mockInstitutionalRoles);
+
+      const result = await service.GetUserDetail('user-1');
+
+      expect(result.id).toBe('user-1');
+      expect(result.userName).toBe('jdoe');
+      expect(result.fullName).toBe('John Doe');
+      expect(result.enrollments).toHaveLength(1);
+      expect(result.enrollments[0]).toEqual({
+        id: 'enr-1',
+        role: 'student',
+        isActive: true,
+        course: {
+          id: 'course-1',
+          shortname: 'CS101',
+          fullname: 'Intro to CS',
+        },
+      });
+      expect(result.institutionalRoles).toHaveLength(1);
+      expect(result.institutionalRoles[0]).toEqual({
+        id: 'ir-1',
+        role: UserRole.DEAN,
+        source: 'manual',
+        category: {
+          moodleCategoryId: 8,
+          name: 'CCS',
+          depth: 3,
+        },
+      });
+    });
+
+    it('should use fullName fallback when fullName is null', async () => {
+      const userWithoutFullName = {
+        ...mockUser,
+        fullName: null,
+        firstName: 'Anna',
+        lastName: 'Smith',
+      } as unknown as User;
+
+      em.findOneOrFail.mockResolvedValueOnce(userWithoutFullName);
+      em.find.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      const result = await service.GetUserDetail('user-1');
+
+      expect(result.fullName).toBe('Anna Smith');
+    });
+
+    it('should return empty arrays when user has no enrollments or roles', async () => {
+      em.findOneOrFail.mockResolvedValueOnce(mockUser);
+      em.find.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      const result = await service.GetUserDetail('user-1');
+
+      expect(result.enrollments).toEqual([]);
+      expect(result.institutionalRoles).toEqual([]);
+      expect(result.id).toBe('user-1');
+    });
+
+    it('should throw NotFoundException when user does not exist', async () => {
+      em.findOneOrFail.mockImplementationOnce(
+        (
+          _entity: unknown,
+          _filter: unknown,
+          opts: { failHandler: () => Error },
+        ) => {
+          throw opts.failHandler();
+        },
+      );
+
+      await expect(service.GetUserDetail('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should filter enrollments by isActive and course.isActive', async () => {
+      em.findOneOrFail.mockResolvedValueOnce(mockUser);
+      em.find.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      await service.GetUserDetail('user-1');
+
+      expect(em.find).toHaveBeenCalledWith(
+        Enrollment,
+        { user: 'user-1', isActive: true, course: { isActive: true } },
+        expect.objectContaining({
+          populate: ['course'],
+          orderBy: { timeModified: 'DESC' },
+        }),
+      );
     });
   });
 

--- a/src/modules/admin/services/admin.service.ts
+++ b/src/modules/admin/services/admin.service.ts
@@ -17,6 +17,7 @@ import { AssignInstitutionalRoleDto } from '../dto/requests/assign-institutional
 import { RemoveInstitutionalRoleDto } from '../dto/requests/remove-institutional-role.request.dto';
 import { ListUsersQueryDto } from '../dto/requests/list-users-query.dto';
 import { AdminUserItemResponseDto } from '../dto/responses/admin-user-item.response.dto';
+import { AdminUserDetailResponseDto } from '../dto/responses/admin-user-detail.response.dto';
 import { AdminUserListResponseDto } from '../dto/responses/admin-user-list.response.dto';
 import { DeanEligibleCategoryResponseDto } from '../dto/responses/dean-eligible-category.response.dto';
 
@@ -50,6 +51,39 @@ export class AdminService {
         currentPage: page,
       },
     };
+  }
+
+  async GetUserDetail(userId: string): Promise<AdminUserDetailResponseDto> {
+    const user = await this.em.findOneOrFail(
+      User,
+      { id: userId },
+      {
+        populate: ['campus', 'department', 'program'],
+        failHandler: () => new NotFoundException('User not found'),
+      },
+    );
+
+    const [enrollments, institutionalRoles] = await Promise.all([
+      this.em.find(
+        Enrollment,
+        { user: userId, isActive: true, course: { isActive: true } },
+        {
+          populate: ['course'],
+          orderBy: { timeModified: 'DESC' },
+        },
+      ),
+      this.em.find(
+        UserInstitutionalRole,
+        { user: userId },
+        { populate: ['moodleCategory'] },
+      ),
+    ]);
+
+    return AdminUserDetailResponseDto.Map(
+      user,
+      enrollments,
+      institutionalRoles,
+    );
   }
 
   async AssignInstitutionalRole(dto: AssignInstitutionalRoleDto) {


### PR DESCRIPTION
## Summary

- Add `GET /admin/users/:id` endpoint (SUPER_ADMIN only) returning full user profile with active enrollments and institutional role assignments
- New `AdminUserDetailResponseDto` with enrollment and institutional role sub-DTOs, Swagger-documented
- Enrollments filtered by `isActive` and `course.isActive` to exclude stale data; institutional roles include moodleCategory context
- `ParseUUIDPipe` validates path param; parallel queries via `Promise.all`; null guards on `moodleCategory`

## Test plan

- [x] 32 unit tests passing (6 new) — `npx jest --testPathPatterns=admin`
- [x] Lint clean — `npm run lint`
- [ ] Manual test: call `GET /admin/users/:id` with valid UUID, verify response shape
- [ ] Manual test: call with non-existent UUID, verify 404
- [ ] Manual test: call with malformed string, verify 400
- [ ] Verify Swagger docs render the new endpoint and response schema

Closes #250