### PR TITLE
Release April 03, 2026 — FAC-107–112: Moodle Sync Fixes, Dean Promotion, Versioned Questionnaires & Role Derivation

### DIFF
--- a/_bmad-output/implementation-artifacts/tech-spec-admin-user-detail.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-admin-user-detail.md
@@ -1,0 +1,321 @@
+---
+title: 'Admin User Detail Endpoint'
+slug: 'admin-user-detail'
+created: '2026-04-02'
+status: 'completed'
+stepsCompleted: [1, 2, 3, 4]
+tech_stack:
+  [
+    'NestJS 11',
+    'MikroORM 6',
+    'PostgreSQL',
+    'class-validator',
+    '@nestjs/swagger',
+    'Jest 30',
+  ]
+files_to_modify:
+  - 'src/modules/admin/admin.controller.ts'
+  - 'src/modules/admin/services/admin.service.ts'
+  - 'src/modules/admin/dto/responses/admin-user-detail.response.dto.ts (new)'
+  - 'src/modules/admin/dto/responses/admin-user-item.response.dto.ts'
+  - 'src/modules/admin/admin.module.ts'
+  - 'src/modules/admin/services/admin.service.spec.ts'
+  - 'src/modules/admin/admin.controller.spec.ts'
+code_patterns:
+  - 'PascalCase public service methods (e.g., GetUserDetail)'
+  - 'Static Map() factory on response DTOs for entity-to-DTO conversion'
+  - '@UseJwtGuard(UserRole.SUPER_ADMIN) on controller class'
+  - 'em.findOneOrFail with failHandler for 404s'
+  - 'em.find with populate for relation loading'
+  - '@ApiOperation, @ApiResponse, @ApiParam Swagger decorators on endpoints'
+  - 'AdminUserScopedRelationDto (id, code, name) reusable for scoped relations'
+test_patterns:
+  - 'NestJS TestingModule with mocked EntityManager (jest.fn() per method)'
+  - 'Controller tests override AuthGuard("jwt") and RolesGuard'
+  - 'Service tests mock em.findOneOrFail, em.find, em.findAndCount, em.flush'
+  - 'Tests use as User / as unknown as User for mock data casting'
+---
+
+# Tech-Spec: Admin User Detail Endpoint
+
+**Created:** 2026-04-02
+
+## Overview
+
+### Problem Statement
+
+The admin console has no way to view detailed information about a single user. The existing list endpoint (`GET /admin/users`) returns only summary data (name, roles, active status, scoped relations). Admins need a drill-down view showing enrollments and institutional role assignments to manage users effectively.
+
+### Solution
+
+Add a `GET /admin/users/:id` endpoint (SUPER_ADMIN only) that returns the full user profile plus their active enrollments (with course info) and institutional role assignments (with category context).
+
+### Scope
+
+**In Scope:**
+
+- New `GET /admin/users/:id` endpoint on `AdminController`
+- New `AdminUserDetailResponseDto` with user details + enrollments + institutional roles
+- Populate enrollment → course chain for course names
+- Populate institutional roles → moodleCategory for role context
+- Filter enrollments by `isActive: true` AND `course.isActive: true` to exclude deactivated courses
+- Unit tests for service and controller
+
+**Out of Scope:**
+
+- Editing user details via this endpoint
+- Enrollment management (create/delete)
+- Moodle token exposure
+- Changes to the existing list endpoint
+
+## Context for Development
+
+### Codebase Patterns
+
+- **Service methods** use `PascalCase` (e.g., `ListUsers`, `GetDeanEligibleCategories`)
+- **Response DTOs** use a static `Map()` factory for entity-to-DTO conversion (see `AdminUserItemResponseDto.Map()`)
+- **Admin controller** has class-level `@UseJwtGuard(UserRole.SUPER_ADMIN)` and `@ApiBearerAuth()` — new endpoints inherit these
+- **MikroORM** requires explicit `populate` for relation loading — no eager loading configured
+- **Entity lookups** use `em.findOneOrFail` with `failHandler: () => new NotFoundException(...)` pattern
+- **Enrollment entity** has nullable `section` relation (null when user has no group membership)
+- **Enrollment.role** is a string field with values: `'student'`, `'editingteacher'`, `'teacher'` (see `EnrollmentRole` enum in `questionnaires/lib/questionnaire.types.ts`)
+- **UserInstitutionalRole** has `role` (string: DEAN/CHAIRPERSON), `moodleCategory` (ManyToOne), `source` (AUTO/MANUAL)
+- **MoodleCategory** has `name`, `depth`, `moodleCategoryId` — used for institutional role context
+- **AdminModule** currently imports: Campus, Department, MoodleCategory, Program, Semester, UserInstitutionalRole, User — **Enrollment and Course are NOT imported yet**
+- **Soft delete** is globally enforced via MikroORM filter; all entities inherit `deletedAt` from `CustomBaseEntity`
+
+### Files to Reference
+
+| File                                                                | Purpose                                                                                                                                                                                                           |
+| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/modules/admin/admin.controller.ts`                             | Add new `GET users/:id` endpoint (follows existing `ListUsers` pattern)                                                                                                                                           |
+| `src/modules/admin/services/admin.service.ts`                       | Add `GetUserDetail()` method (follows `GetDeanEligibleCategories` pattern for single-entity lookup)                                                                                                               |
+| `src/modules/admin/dto/responses/admin-user-item.response.dto.ts`   | Export `AdminUserScopedRelationDto` for reuse                                                                                                                                                                     |
+| `src/modules/admin/dto/responses/admin-user-detail.response.dto.ts` | **NEW FILE** — detail response DTO with enrollment + institutional role sub-DTOs                                                                                                                                  |
+| `src/modules/admin/admin.module.ts`                                 | Add `Enrollment` and `Course` to `MikroOrmModule.forFeature()` imports                                                                                                                                            |
+| `src/modules/admin/services/admin.service.spec.ts`                  | Add `GetUserDetail` test describe block (follows existing mock patterns)                                                                                                                                          |
+| `src/modules/admin/admin.controller.spec.ts`                        | Add controller delegation test (follows `ListUsers` pattern)                                                                                                                                                      |
+| `src/entities/user.entity.ts`                                       | User entity — fields: userName, firstName, lastName, fullName, moodleUserId, userProfilePicture, isActive, roles, lastLoginAt, createdAt; relations: campus, department, program, enrollments, institutionalRoles |
+| `src/entities/enrollment.entity.ts`                                 | Enrollment entity — fields: role (string), isActive, timeModified; relations: user, course, section (nullable)                                                                                                    |
+| `src/entities/course.entity.ts`                                     | Course entity — fields: shortname, fullname, moodleCourseId, isActive, isVisible, startDate, endDate; relations: program                                                                                          |
+| `src/entities/user-institutional-role.entity.ts`                    | UserInstitutionalRole entity — fields: role (string), source (AUTO/MANUAL); relations: user, moodleCategory                                                                                                       |
+| `src/entities/moodle-category.entity.ts`                            | MoodleCategory entity — fields: moodleCategoryId, name, depth, path                                                                                                                                               |
+
+### Technical Decisions
+
+1. **Filter enrollments by `course.isActive: true`** — The sync pipeline can leave active enrollments pointing to deactivated courses. Filtering at query time prevents showing stale data.
+2. **Export `AdminUserScopedRelationDto`** — Currently non-exported in `admin-user-item.response.dto.ts`. Add the `export` keyword so the detail DTO can import and reuse it for campus/department/program.
+3. **Separate enrollment and institutional role sub-DTOs** — Keep the response structured with nested arrays.
+4. **Return 404 for missing users** — Use `em.findOneOrFail` with `failHandler` pattern consistent with `GetDeanEligibleCategories`.
+5. **Two separate queries for enrollments and institutional roles** — Rather than deep-populating from the User entity (which would load ALL enrollments including inactive), use targeted `em.find()` calls with explicit filters.
+6. **Populate chain for enrollments: `['course']`** — Course name fields (shortname, fullname) are sufficient. No need to walk up the program->department->semester chain since the user's scoped relations (campus, department, program) are already on the User entity directly.
+7. **Populate chain for institutional roles: `['moodleCategory']`** — Need category name and depth for display context.
+
+## Implementation Plan
+
+### Tasks
+
+- [ ] **Task 1: Register entities in AdminModule**
+  - File: `src/modules/admin/admin.module.ts`
+  - Action: Add `Enrollment` and `Course` to the `MikroOrmModule.forFeature()` array
+  - Notes: Import from `src/entities/enrollment.entity` and `src/entities/course.entity`
+
+- [ ] **Task 2: Export `AdminUserScopedRelationDto`**
+  - File: `src/modules/admin/dto/responses/admin-user-item.response.dto.ts`
+  - Action: Add the `export` keyword to the existing `class AdminUserScopedRelationDto` declaration (line 5)
+  - Notes: Currently `class AdminUserScopedRelationDto` — change to `export class AdminUserScopedRelationDto`. No other changes to this file.
+
+- [ ] **Task 3: Create the detail response DTO**
+  - File: `src/modules/admin/dto/responses/admin-user-detail.response.dto.ts` **(NEW)**
+  - Action: Create `AdminUserDetailResponseDto` with the following structure:
+
+  **Sub-DTOs to define in this file:**
+
+  `AdminEnrollmentItemDto`:
+  - `id` (string) — enrollment ID
+  - `role` (string) — Moodle enrollment role (e.g., `'student'`, `'teacher'`)
+  - `isActive` (boolean)
+  - `course` object:
+    - `id` (string) — course entity ID
+    - `shortname` (string)
+    - `fullname` (string)
+  - Static `Map(enrollment: Enrollment)` method
+
+  `AdminInstitutionalRoleItemDto`:
+  - `id` (string) — institutional role entity ID
+  - `role` (string) — e.g., `'DEAN'`, `'CHAIRPERSON'`
+  - `source` (string) — `'auto'` or `'manual'` (lowercase, per `InstitutionalRoleSource` enum values)
+  - `category` object:
+    - `moodleCategoryId` (number)
+    - `name` (string)
+    - `depth` (number)
+  - Static `Map(ir: UserInstitutionalRole)` method — must null-guard `ir.moodleCategory` (existing production code in `GetDeanEligibleCategories` defensively checks for falsy `moodleCategory` despite the non-nullable entity declaration)
+
+  **Main DTO: `AdminUserDetailResponseDto`:**
+  - `id` (string)
+  - `userName` (string)
+  - `fullName` (string)
+  - `firstName` (string)
+  - `lastName` (string)
+  - `moodleUserId` (number, optional)
+  - `userProfilePicture` (string)
+  - `roles` (UserRole[])
+  - `isActive` (boolean)
+  - `lastLoginAt` (Date)
+  - `createdAt` (Date)
+  - `campus` (AdminUserScopedRelationDto | null) — imported from `admin-user-item.response.dto.ts`
+  - `department` (AdminUserScopedRelationDto | null)
+  - `program` (AdminUserScopedRelationDto | null)
+  - `enrollments` (AdminEnrollmentItemDto[])
+  - `institutionalRoles` (AdminInstitutionalRoleItemDto[])
+  - Static `Map(user: User, enrollments: Enrollment[], institutionalRoles: UserInstitutionalRole[])` method
+
+  Notes:
+  - All properties must have `@ApiProperty` or `@ApiPropertyOptional` decorators
+  - Use `@ApiProperty({ type: [AdminEnrollmentItemDto] })` for array properties
+  - The `Map()` method handles null-safe mapping for campus/department/program (same pattern as `AdminUserItemResponseDto.Map()`)
+  - The `Map()` method must use the `fullName` null-coalescing fallback: `user.fullName ?? \`${user.firstName} ${user.lastName}\`.trim()`(same as`AdminUserItemResponseDto.Map()` line 48)
+  - The `Map()` method must filter out institutional roles where `ir.moodleCategory` is falsy before mapping to prevent runtime TypeError
+
+- [ ] **Task 4: Implement `GetUserDetail()` in AdminService**
+  - File: `src/modules/admin/services/admin.service.ts`
+  - Action: Add the following method to `AdminService`:
+
+  ```typescript
+  async GetUserDetail(userId: string): Promise<AdminUserDetailResponseDto> {
+    // 1. Load user with scoped relations
+    const user = await this.em.findOneOrFail(
+      User,
+      { id: userId },
+      {
+        populate: ['campus', 'department', 'program'],
+        failHandler: () => new NotFoundException('User not found'),
+      },
+    );
+
+    // 2. Load active enrollments with active courses
+    const enrollments = await this.em.find(
+      Enrollment,
+      { user: userId, isActive: true, course: { isActive: true } },
+      {
+        populate: ['course'],
+        orderBy: { timeModified: 'DESC' },
+      },
+    );
+
+    // 3. Load institutional roles with category context
+    const institutionalRoles = await this.em.find(
+      UserInstitutionalRole,
+      { user: userId },
+      { populate: ['moodleCategory'] },
+    );
+
+    return AdminUserDetailResponseDto.Map(user, enrollments, institutionalRoles);
+  }
+  ```
+
+  Notes:
+  - Add `AdminUserDetailResponseDto` to imports
+  - Enrollments ordered by `timeModified DESC` (most recently modified first)
+  - Enrollment filter: `isActive: true` AND `course: { isActive: true }` to exclude deactivated courses
+  - Institutional roles have no active/inactive filter — show all assignments
+
+- [ ] **Task 5: Add controller endpoint**
+  - File: `src/modules/admin/admin.controller.ts`
+  - Action: Add the following endpoint method to `AdminController`, placed after `ListUsers` and before `GetDeanEligibleCategories`:
+
+  ```typescript
+  @Get('users/:id')
+  @ApiOperation({ summary: 'Get detailed information about a single user' })
+  @ApiParam({ name: 'id', type: String, description: 'User UUID' })
+  @ApiResponse({ status: 200, type: AdminUserDetailResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid UUID format' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  async GetUserDetail(@Param('id', ParseUUIDPipe) id: string): Promise<AdminUserDetailResponseDto> {
+    return this.adminService.GetUserDetail(id);
+  }
+  ```
+
+  Notes:
+  - Import `Param, ParseUUIDPipe` from `@nestjs/common` (add to existing import)
+  - Import `ApiParam` from `@nestjs/swagger` (add to existing import)
+  - Import `AdminUserDetailResponseDto` from the new DTO file
+  - `ParseUUIDPipe` validates the `:id` param is a valid UUID, returning 400 for malformed input (consistent with other controllers: `faculty.controller.ts`, `reports.controller.ts`, etc.)
+
+- [ ] **Task 6: Add service unit tests**
+  - File: `src/modules/admin/services/admin.service.spec.ts`
+  - Action: Add a new `describe('GetUserDetail')` block with the following test cases:
+  1. **`should return full user detail with enrollments and institutional roles`**
+     - Mock `em.findOneOrFail` → returns a user with campus/department/program
+     - Mock `em.find` call 1 → returns enrollments with populated course
+     - Mock `em.find` call 2 → returns institutional roles with populated moodleCategory
+     - Assert response contains all user fields, enrollment array, institutional roles array
+
+  2. **`should return empty arrays when user has no enrollments or roles`**
+     - Mock `em.findOneOrFail` → returns a user
+     - Mock `em.find` → returns `[]` for both calls
+     - Assert `enrollments: []` and `institutionalRoles: []`
+
+  3. **`should throw NotFoundException when user does not exist`**
+     - Mock `em.findOneOrFail` to invoke `failHandler`
+     - Assert throws `NotFoundException`
+
+  4. **`should filter enrollments by isActive and course.isActive`**
+     - Mock `em.findOneOrFail` → returns user
+     - Mock `em.find` → returns `[]`
+     - Assert `em.find` was called with `Enrollment` and filter `{ user: userId, isActive: true, course: { isActive: true } }`
+
+  Notes: Follow existing test patterns — use `em.findOneOrFail.mockResolvedValueOnce()` and `em.find.mockResolvedValueOnce()` sequencing. Use mock data objects cast with `as unknown as User`, etc.
+
+- [ ] **Task 7: Add controller unit test**
+  - File: `src/modules/admin/admin.controller.spec.ts`
+  - Action: Add `GetUserDetail` to the mock service object and add a test:
+  1. Add `GetUserDetail: jest.fn().mockResolvedValue({})` to the `adminService` mock
+  2. Add test: `it('should delegate user detail to the admin service')` — call `controller.GetUserDetail('user-1')`, assert `adminService.GetUserDetail` was called with `'user-1'`
+
+### Acceptance Criteria
+
+- [ ] **AC 1:** Given a SUPER_ADMIN is authenticated, when they call `GET /admin/users/:id` with a valid user UUID, then they receive a 200 response with the full user profile including `enrollments[]` and `institutionalRoles[]` arrays.
+
+- [ ] **AC 2:** Given a SUPER_ADMIN calls `GET /admin/users/:id` with a UUID that does not match any user, when the request is processed, then they receive a 404 response with message `'User not found'`.
+
+- [ ] **AC 2b:** Given a SUPER_ADMIN calls `GET /admin/users/:id` with a malformed (non-UUID) string, when the request is processed, then they receive a 400 response before hitting the database.
+
+- [ ] **AC 3:** Given a user has active enrollments in both active and deactivated courses, when the detail endpoint is called, then only enrollments where both `enrollment.isActive = true` AND `course.isActive = true` are returned.
+
+- [ ] **AC 4:** Given a user has no enrollments, when the detail endpoint is called, then the `enrollments` array is empty (`[]`) and the response still includes all other user fields.
+
+- [ ] **AC 5:** Given a user has institutional roles (DEAN/CHAIRPERSON), when the detail endpoint is called, then the `institutionalRoles` array contains each role with its `moodleCategory` name, depth, and source (AUTO/MANUAL).
+
+- [ ] **AC 6:** Given a user has no institutional role assignments, when the detail endpoint is called, then the `institutionalRoles` array is empty (`[]`).
+
+- [ ] **AC 7:** Given the response DTO, when Swagger docs are generated, then the endpoint and its response schema are fully documented with `@ApiOperation`, `@ApiParam`, `@ApiResponse`, and `@ApiProperty` decorators.
+
+- [ ] **AC 8:** Given the unit test suite, when `npm run test -- --testPathPattern=admin` is run, then all existing and new tests pass.
+
+## Additional Context
+
+### Dependencies
+
+- No new packages required
+- **Enrollment** and **Course** entities must be added to `AdminModule`'s `MikroOrmModule.forFeature()` array (Task 1)
+- No database migrations needed — reads existing data only
+
+### Testing Strategy
+
+- **Unit tests (service):** Mock EntityManager methods. Test happy path (full data), empty relations, 404, and filter correctness. 4 test cases in `admin.service.spec.ts`.
+- **Unit tests (controller):** Mock AdminService. Verify delegation. 1 test case in `admin.controller.spec.ts`.
+- **Manual testing:** Call `GET /admin/users/:id` via Swagger UI or curl with a valid JWT. Verify:
+  - Response shape matches DTO
+  - Enrollments are filtered correctly (compare with DB records)
+  - Institutional roles include category names
+
+### Notes
+
+- Investigation confirmed: enrollment → course data is always present in normal operations (sync ordering: categories → courses → enrollments). The `course.isActive` filter is a defensive measure for the edge case where courses are deactivated post-enrollment.
+- `Section` on enrollment is nullable by design (no group membership) — excluded from the DTO since the admin console doesn't need group-level detail.
+- `AdminUserScopedRelationDto` is currently a non-exported class inside `admin-user-item.response.dto.ts`. Task 2 exports it so the detail DTO can reuse it.
+- The enrollment `role` field is a raw string from Moodle (e.g., `'student'`, `'editingteacher'`). Passed through as-is — no enum enforcement at the DTO level.
+- Enrollment ordering: `timeModified DESC` gives admins the most recently active enrollments first.
+- **Soft-deleted users:** The global MikroORM soft-delete filter will exclude soft-deleted users, returning a 404 indistinguishable from "user never existed." This is intentional and consistent with the list endpoint behavior — the admin console cannot list deleted users, so it cannot navigate to their detail view.
+- **E2E test risk (deferred):** The nested MikroORM filter `course: { isActive: true }` cannot be validated by unit tests with mocked `em.find`. If MikroORM changes how nested relation filters generate SQL, unit tests will pass while the endpoint silently breaks. An E2E test seeding a user with active/inactive course enrollments and asserting correct filtering would catch this. Deferred for now — manual testing covers it, but consider adding E2E coverage later.

--- a/_bmad-output/implementation-artifacts/tech-spec-derive-roles-during-sync.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-derive-roles-during-sync.md
@@ -1,0 +1,225 @@
+---
+title: 'Derive User Roles During Moodle Sync'
+slug: 'derive-roles-during-sync'
+created: '2026-04-03'
+status: 'completed'
+stepsCompleted: [1, 2, 3, 4]
+tech_stack:
+  - NestJS 11
+  - MikroORM 6
+  - BullMQ
+  - Jest 30
+files_to_modify:
+  - src/entities/user.entity.ts
+  - src/modules/moodle/services/moodle-enrollment-sync.service.ts
+  - src/entities/user.entity.spec.ts (new)
+code_patterns:
+  - updateRolesFromEnrollments() for role derivation (user.entity.ts:93-114)
+  - MoodleRoleMapping for Moodle-to-app role translation (roles.enum.ts:10-16)
+  - backfillUserScopes() as precedent for post-enrollment-sync user processing (moodle-enrollment-sync.service.ts:327-436)
+  - refreshUserRoles() in AdminService as reference for loading enrollments + institutional roles (admin.service.ts:242-253)
+  - Login-time role derivation in hydrateUserCourses() (moodle-user-hydration.service.ts:245-252)
+  - PascalCase for public service methods
+  - Forked EntityManager for batch operations
+  - UnitOfWork for transactional integrity
+test_patterns:
+  - Unit tests alongside source with .spec.ts suffix
+  - NestJS TestingModule with jest.fn() mocks
+  - No existing test for EnrollmentSyncService or User entity
+  - moodle-sync.processor.spec.ts exists as reference for processor tests
+---
+
+# Tech-Spec: Derive User Roles During Moodle Sync
+
+**Created:** 2026-04-03
+
+## Overview
+
+### Problem Statement
+
+User roles (`user.roles`) are only populated during login via `MoodleUserHydrationService.hydrateUserCourses()`. Users who are synced from Moodle but have never logged in appear with empty roles in the admin dashboard. The enrollment data needed to derive basic roles (STUDENT, FACULTY) already exists after the enrollment sync phase but is never used to update `user.roles`.
+
+### Solution
+
+Add a role derivation phase to the Moodle sync pipeline that calls `updateRolesFromEnrollments()` for each touched user after the enrollment sync completes. This uses existing enrollment records and institutional role records to populate `user.roles` without requiring a login.
+
+### Scope
+
+**In Scope:**
+
+- New role derivation phase in the sync processor (after enrollment sync + scope backfill)
+- Load `UserInstitutionalRole` records alongside enrollments to preserve DEAN/CHAIRPERSON
+- Protect non-enrollment-derived roles (SUPER_ADMIN, ADMIN) from being overwritten by `updateRolesFromEnrollments()`
+- Backfill via manual sync trigger post-deploy (no migration script)
+
+**Out of Scope:**
+
+- Username pattern parsing for role inference (deferred)
+- Detecting new DEAN/CHAIRPERSON roles during sync (stays login-only, requires user token)
+- Dedicated backfill migration script
+- Changes to the login-time role derivation flow
+
+## Context for Development
+
+### Codebase Patterns
+
+- **Sync pipeline phases:** `MoodleSyncProcessor.process()` runs Category → Course → Enrollment phases sequentially. Enrollment phase includes 4 sub-phases: HTTP fetch → user upsert → per-course enrollment upsert → scope backfill. Role derivation will be a 5th sub-phase.
+- **backfillUserScopes()** (`moodle-enrollment-sync.service.ts:327-436`): Already iterates all touched users after enrollment upsert. Uses a forked `EntityManager`, batch-loads users by `moodleUserId`, updates fields, single `flush()` at end. This is the structural template for the new role derivation phase.
+- **updateRolesFromEnrollments()** (`user.entity.ts:93-114`): Full replace of `this.roles`. Takes `Enrollment[]` + optional `UserInstitutionalRole[]` (defaults to `[]`). Uses `MoodleRoleMapping` lookup → uppercase fallback → `Set` deduplication → `Boolean` filter. Does NOT preserve any pre-existing roles on the user.
+- **refreshUserRoles()** (`admin.service.ts:242-253`): Reference for correct role refresh — loads both `Enrollment { user, isActive: true }` and `UserInstitutionalRole { user }`, then calls `updateRolesFromEnrollments()`.
+- **Login-time derivation** (`moodle-user-hydration.service.ts:245-252`): Same pattern as `refreshUserRoles()` — loads active enrollments + all institutional roles, calls `updateRolesFromEnrollments()`.
+- **User upsert during sync** (`moodle-enrollment-sync.service.ts:130-191`): Sets `roles: []` on new users (line 143). The `mergeFields` array (lines 149-157) does NOT include `roles`, so existing user roles are not overwritten by the upsert itself.
+- **Method naming:** Public service methods use PascalCase (e.g., `SyncAllCourses`). Private methods use camelCase (e.g., `backfillUserScopes`, `syncAllUsers`).
+- **EntityManager forking:** Batch operations fork the EM (`this.em.fork()`) to avoid polluting the request-scoped identity map.
+
+### Files to Reference
+
+| File                                                                   | Purpose                                                                                                    |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `src/modules/moodle/services/moodle-enrollment-sync.service.ts`        | Enrollment sync service — `backfillUserScopes()` is the structural template; new method added here         |
+| `src/entities/user.entity.ts`                                          | `updateRolesFromEnrollments()` — needs protected-roles guard                                               |
+| `src/modules/auth/roles.enum.ts`                                       | `UserRole` enum and `MoodleRoleMapping`                                                                    |
+| `src/entities/enrollment.entity.ts`                                    | Enrollment entity — `role: string`, `isActive: boolean`                                                    |
+| `src/entities/user-institutional-role.entity.ts`                       | `UserInstitutionalRole` entity — `role: string`, `source: 'auto' \| 'manual'`                              |
+| `src/modules/moodle/processors/moodle-sync.processor.ts`               | Sync processor — no changes needed (role derivation lives inside `EnrollmentSyncService.SyncAllCourses()`) |
+| `src/modules/moodle/services/moodle-user-hydration.service.ts:245-252` | Login-time role derivation — reference implementation                                                      |
+| `src/modules/admin/services/admin.service.ts:242-253`                  | `refreshUserRoles()` — reference implementation                                                            |
+| `src/modules/moodle/processors/moodle-sync.processor.spec.ts`          | Existing processor test — reference for test patterns                                                      |
+
+### Technical Decisions
+
+- **Protected roles:** `updateRolesFromEnrollments()` will preserve `SUPER_ADMIN` and `ADMIN` roles already present on `this.roles`, since these are never derived from enrollments or institutional roles. This is safe because: (1) `MoodleRoleMapping` never produces these values, (2) `UserInstitutionalRole.role` currently only stores DEAN/CHAIRPERSON (no schema constraint enforces this — it's observed behavior, so if new institutional role types are added in the future, revisit the protected-roles set), (3) these roles are assigned locally via seeder or manual DB operations.
+- **Institutional role loading:** During sync, `UserInstitutionalRole` records must be loaded for each user so existing DEAN/CHAIRPERSON roles are preserved. Without this, the full-replace behavior of `updateRolesFromEnrollments()` would silently drop them.
+- **No changes to sync processor:** The role derivation phase lives inside `EnrollmentSyncService.SyncAllCourses()` as Phase 5, after `backfillUserScopes()`. No changes to `MoodleSyncProcessor` needed.
+- **No username pattern parsing:** Enrollment data is sufficient for STUDENT/FACULTY derivation. Username heuristics deferred.
+- **Backfill strategy:** Manual sync trigger post-deploy (option B). No dedicated migration.
+- **Convergence:** The sync-time and login-time derivation are convergent — both derive roles from the same data sources (enrollments + institutional roles) using the same `MoodleRoleMapping`. Any divergence from concurrent execution (e.g., a user logging in mid-sync) is corrected by the next sync or login. Running both is safe. Note: if Phase 3 partially fails for a specific course, stale enrollment data may feed Phase 5 — see Known Limitations.
+
+## Implementation Plan
+
+### Tasks
+
+- [x] Task 1: Add protected-roles guard to `updateRolesFromEnrollments()`
+  - File: `src/entities/user.entity.ts`
+  - Action: At the start of `updateRolesFromEnrollments()` (line 93), capture any `SUPER_ADMIN` or `ADMIN` roles already present on `this.roles`. After deriving enrollment + institutional roles, merge the protected roles back into the final `Set` before assigning to `this.roles`.
+  - Implementation:
+    ```typescript
+    const protectedRoles = this.roles.filter(
+      (r) => r === UserRole.SUPER_ADMIN || r === UserRole.ADMIN,
+    );
+    ```
+    Then change the final assignment to:
+    ```typescript
+    this.roles = [
+      ...new Set([...protectedRoles, ...enrollmentRoles, ...instRoles]),
+    ].filter(Boolean);
+    ```
+  - Notes: This is a behavioral change that affects all callers (login-time hydration, admin `refreshUserRoles()`, and the new sync-time derivation). All callers benefit from this fix — none of them should be stripping SUPER_ADMIN/ADMIN.
+
+- [x] Task 2: Add `deriveUserRoles()` private method to `EnrollmentSyncService`
+  - File: `src/modules/moodle/services/moodle-enrollment-sync.service.ts`
+  - Action: Add a new private method following the `backfillUserScopes()` pattern. It receives the same `fetched` parameter.
+  - Implementation approach:
+    1. Collect unique `moodleUserId` values from `fetched` by iterating ALL remote users across all courses. Note: this differs from `backfillUserScopes()` which skips users in courses without program references — role derivation has no reason to apply that filter.
+    2. Fork the `EntityManager`
+    3. Batch-load users by Moodle ID: `fork.find(User, { moodleUserId: { $in: moodleUserIds } })`
+    4. Extract entity UUIDs: `const userUuids = users.map(u => u.id)`
+    5. Batch-load active enrollments by entity UUID: `fork.find(Enrollment, { user: { $in: userUuids }, isActive: true })` — no `populate` needed, only scalar fields (`role`, `isActive`) are accessed by `updateRolesFromEnrollments()`
+    6. Batch-load institutional roles by entity UUID: `fork.find(UserInstitutionalRole, { user: { $in: userUuids } })` — no `populate` needed, only `role` scalar is accessed; `moodleCategory` is not used by the derivation
+    7. Group enrollments and institutional roles by `user.id` (UUID) using `Map<string, Enrollment[]>` and `Map<string, UserInstitutionalRole[]>`
+    8. For each user, snapshot `oldRoles = [...user.roles].sort()`, call `user.updateRolesFromEnrollments(userEnrollments, userInstRoles)`, compare via `JSON.stringify(oldRoles) !== JSON.stringify([...user.roles].sort())` to track change count for logging
+    9. Always call `fork.flush()` — this is a deliberate departure from `backfillUserScopes()` which conditionally flushes (`if updated > 0`). For roles, array change detection is unreliable as a persistence gate. MikroORM's change-tracking only generates UPDATE statements for entities with actual column-level changes, so this is a no-op at the DB level if roles haven't logically changed. The change counter is for logging only.
+    10. Log the count of users whose roles changed
+  - Notes: Add imports for `Enrollment`, `UserInstitutionalRole` at the top of the file. `Enrollment` is already imported. `UserInstitutionalRole` needs to be added.
+
+- [x] Task 3: Call `deriveUserRoles()` as Phase 5 in `SyncAllCourses()`
+  - File: `src/modules/moodle/services/moodle-enrollment-sync.service.ts`
+  - Action: After the `backfillUserScopes()` call (line 88-93), add a new Phase 5 block that calls `this.deriveUserRoles(fetched)` with the same try/catch + error logging pattern used for Phase 4.
+  - Implementation:
+    ```typescript
+    // Phase 5: Derive user roles from enrollments + institutional roles
+    try {
+      await this.deriveUserRoles(fetched);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Failed to derive user roles: ${message}`);
+    }
+    ```
+  - Notes: Phase 5 failure should not fail the overall sync — same non-fatal pattern as Phase 4 (`backfillUserScopes`).
+
+- [x] Task 4: Add unit tests for `updateRolesFromEnrollments()` protected-roles behavior
+  - File: `src/entities/user.entity.spec.ts` (new file)
+  - Action: Test that SUPER_ADMIN and ADMIN roles are preserved through `updateRolesFromEnrollments()`. Cover:
+    - User with SUPER_ADMIN + enrollments → SUPER_ADMIN preserved alongside enrollment-derived roles
+    - User with ADMIN + enrollments → ADMIN preserved
+    - User with no protected roles → behavior unchanged (only enrollment-derived + institutional roles)
+    - User with SUPER_ADMIN + no enrollments + no institutional roles → roles = [SUPER_ADMIN]
+    - User with enrollment as teacher + institutional role as DEAN → roles contain both FACULTY and DEAN (order-agnostic)
+    - User with `manager` enrollment role → roles contain DEAN (via `MoodleRoleMapping`)
+    - User with no protected roles + no enrollments + no institutional roles → roles = []
+    - User with enrollments where all have `isActive: false` + no institutional roles → roles = [] (validates the `.filter(e => e.isActive)` guard)
+  - Notes: Plain unit tests — no NestJS TestingModule needed. This will be the first test file in `src/entities/`; entity-level tests are appropriate here because `updateRolesFromEnrollments()` is pure logic with no DI dependencies. Create `Enrollment` and `UserInstitutionalRole` stubs with just the fields `updateRolesFromEnrollments()` accesses (`role`, `isActive`). Use `as unknown as Enrollment` / `as unknown as UserInstitutionalRole` type assertions for stub objects (consistent with existing test patterns, e.g., `admin.service.spec.ts`). Use `expect.arrayContaining` for role assertions — array order is not guaranteed and should not be tested.
+
+### Acceptance Criteria
+
+- [ ] AC 1: Given a user synced from Moodle with `editingteacher` enrollments who has never logged in, when the Moodle sync completes, then `user.roles` contains `FACULTY`.
+- [ ] AC 2: Given a user synced from Moodle with `student` enrollments who has never logged in, when the Moodle sync completes, then `user.roles` contains `STUDENT`.
+- [ ] AC 3: Given a user with both `student` and `editingteacher` enrollments across different courses, when the Moodle sync completes, then `user.roles` contains both `STUDENT` and `FACULTY` (deduplicated).
+- [ ] AC 4: Given a user with `SUPER_ADMIN` in their roles and active enrollments, when the Moodle sync completes, then `user.roles` still contains `SUPER_ADMIN` alongside their enrollment-derived roles.
+- [ ] AC 5: Given a user with `ADMIN` in their roles, when `updateRolesFromEnrollments()` is called from any caller (sync, login, admin refresh), then `ADMIN` is preserved in the resulting roles array.
+- [ ] AC 6: Given a user with a manually assigned `DEAN` institutional role, when the Moodle sync completes, then `user.roles` contains `DEAN` alongside their enrollment-derived roles.
+- [ ] AC 7: Given the Moodle sync's role derivation phase completes, then only users present in the current sync batch have their roles re-derived. Users not in the batch (e.g., removed from all Moodle courses) retain their last-known roles until a login or manual admin refresh.
+- [ ] AC 8: Given the Moodle sync's role derivation phase fails, when the sync completes, then the overall sync status is not `failed` — scope backfill and enrollment data remain intact.
+- [ ] AC 9: Given a user with a `manager` enrollment role (Moodle role shortname), when the Moodle sync completes, then `user.roles` contains `DEAN` via `MoodleRoleMapping`. This is consistent with existing login-time behavior — `MoodleRoleMapping["manager"]` → `UserRole.DEAN`. The sync does not introduce a new privilege path; it replicates the same mapping the login flow already performs.
+
+## Additional Context
+
+### Dependencies
+
+- No new dependencies required. All role mapping and derivation logic already exists.
+- `UserInstitutionalRole` import needs to be added to `moodle-enrollment-sync.service.ts`.
+
+### Testing Strategy
+
+**Unit Tests:**
+
+- `src/entities/user.entity.spec.ts` (new) — Tests for `updateRolesFromEnrollments()`:
+  - Protected roles preservation (SUPER_ADMIN, ADMIN)
+  - Enrollment role mapping via `MoodleRoleMapping`
+  - Institutional role inclusion
+  - Deduplication behavior
+  - Empty enrollments / empty institutional roles edge cases
+
+**Manual Testing:**
+
+1. Deploy to staging
+2. Verify admin dashboard shows users with empty roles (pre-condition)
+3. Trigger a manual Moodle sync from the admin console
+4. Refresh admin dashboard — users should now show STUDENT/FACULTY roles
+5. Verify the SUPER_ADMIN user's roles are unchanged
+6. Verify any users with DEAN/CHAIRPERSON institutional roles still have those roles
+
+### Notes
+
+- The login-time flow (`hydrateUserCourses()`) will continue to work as before — it does its own call to `updateRolesFromEnrollments()` with fresh enrollment data. The sync-time derivation and login-time derivation are idempotent and produce the same result for the same data.
+- Party mode discussion surfaced the SUPER_ADMIN overwrite risk and the need to load institutional roles — both are critical correctness requirements.
+- The protected-roles guard in Task 1 is a defensive fix that benefits all existing callers, not just the new sync-time path. If a SUPER_ADMIN user had ever logged in before this fix, their SUPER_ADMIN role would have been silently dropped by the login-time `updateRolesFromEnrollments()` call. This has likely not manifested because the superadmin user is locally created and probably has no Moodle enrollments.
+- Post-deploy backfill: After deploying, trigger a manual sync from the admin console to populate roles for all existing users. No migration script needed.
+
+### Known Limitations (from adversarial review)
+
+- **Stale roles for fully-removed users:** Users removed from all Moodle courses won't appear in the `fetched` data, so `deriveUserRoles()` never visits them. Their roles persist until a login or manual admin refresh. This is acceptable for v1 — these users are effectively inactive.
+- **Pre-existing stale `this.roles` in admin path:** `AdminService.refreshUserRoles()` does not re-load the User entity before capturing protected roles. If the user was loaded earlier in the same request with different roles, the guard reads stale data. This is a pre-existing issue, not introduced by this feature. Out of scope.
+- **`MoodleRoleMapping` dead code for institutional roles:** `updateRolesFromEnrollments()` runs institutional role values (e.g., `"DEAN"`) through `MoodleRoleMapping`, which never matches (keys are lowercase Moodle names). The uppercase fallback produces the correct result by coincidence. Refactoring this is out of scope but noted for future cleanup.
+- **`updatedAt` not explicitly refreshed:** When `deriveUserRoles()` mutates `user.roles`, `CustomBaseEntity.updatedAt` is not explicitly set to `new Date()`. MikroORM only persists changed columns, so `updatedAt` remains stale. No current consumer relies on `User.updatedAt` for change detection, so this is acceptable for v1.
+- **Unbounded enrollment query at scale:** The batch query `find(Enrollment, { user: { $in: userUuids }, isActive: true })` loads all enrollments for all touched users in a single SELECT. At 57 users this is trivial. If the user base grows past ~5,000 users, consider chunking the query. Not a concern for v1.
+- **Sync/login concurrency:** If a user logs in during a sync (between Phase 3 and Phase 5), the login may derive a more complete role set (from the user's own token), which Phase 5 could then overwrite with its batch-derived view. The next login or sync corrects this. The window is negligible.
+- **`manager` enrollment → DEAN without capability check:** `MoodleRoleMapping["manager"]` → `UserRole.DEAN` is applied to enrollment roles during derivation. This means a user with `manager` as their Moodle course role will get DEAN in `user.roles` without the `moodle/category:manage` capability check that the login-time `resolveInstitutionalRoles()` performs. This is **not a new behavior** — the login-time flow applies the same mapping via `updateRolesFromEnrollments()`. The sync just makes it fire earlier. If this is a security concern, `MoodleRoleMapping` should be audited as a separate task to remove or gate the `manager`/`chairperson` entries.
+- **Phase 3 partial failure → stale enrollments in Phase 5:** If Phase 3 fails for a specific course (per-course try/catch at `SyncAllCourses` line 73-84), enrollments for that course retain their previous `isActive` state. Phase 5 reads whatever is committed, so it may derive roles from stale enrollment data for that course. This divergence persists if the same course continues to fail across syncs. The login-time flow is more authoritative in this case.
+
+## Review Notes
+
+- Adversarial review completed
+- Findings: 12 total, 2 fixed, 10 skipped (noise/pre-existing)
+- Resolution approach: auto-fix
+- Fixes applied: extracted `groupByUserId` helper (DRY), added unknown-role fallback test

--- a/_bmad-output/implementation-artifacts/tech-spec-questionnaire-version-templating.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-questionnaire-version-templating.md
@@ -1,0 +1,374 @@
+---
+title: 'Questionnaire Version Templating'
+slug: 'questionnaire-version-templating'
+created: '2026-04-03'
+status: 'implementation-complete'
+stepsCompleted: [1, 2, 3, 4]
+tech_stack:
+  [
+    'NestJS 11',
+    'MikroORM 6',
+    'PostgreSQL',
+    'Zod',
+    'class-validator',
+    'Swagger/OpenAPI',
+    'Next.js 16',
+    'React 19',
+    'Zustand',
+    'TanStack Query',
+  ]
+files_to_modify:
+  - 'api: src/modules/questionnaires/services/questionnaire.service.ts'
+  - 'api: src/modules/questionnaires/questionnaire.controller.ts'
+  - 'api: src/modules/questionnaires/dto/requests/create-version-from-template-request.dto.ts (NEW)'
+  - 'api: src/modules/questionnaires/services/questionnaire.service.spec.ts'
+  - 'api: src/modules/questionnaires/questionnaire.controller.spec.ts'
+  - 'app: features/questionnaires/api/questionnaire.requests.ts'
+  - 'app: features/questionnaires/hooks/use-create-version-from-template.ts (NEW)'
+  - 'app: features/questionnaires/components/questionnaire-list-toolbar.tsx'
+  - 'app: app/(dashboard)/superadmin/questionnaires/_components/questionnaire-list-screen.tsx'
+  - 'app: app/(dashboard)/superadmin/questionnaires/page.tsx'
+  - 'app: network/endpoints.ts'
+code_patterns:
+  - 'PascalCase public service methods (e.g., CreateVersion, CreateVersionFromTemplate)'
+  - 'DTOs use class-validator + @ApiProperty decorators'
+  - 'Controller endpoints have full Swagger decorators (@ApiOperation, @ApiResponse)'
+  - 'Service uses versionRepo.findOne() for lookups, versionRepo.create() for creation (outside transactions)'
+  - 'Transactions use UnitOfWork.runInTransaction(async (em) => { ... }) — inside: em.findOne(), em.create(), no em.persist() needed (managed by default in v6). Outside transactions: use injected repos.'
+  - 'Cache invalidation via cacheService.invalidateNamespace() after mutations'
+  - '@UseJwtGuard(UserRole.SUPER_ADMIN, UserRole.ADMIN) for admin-only endpoints'
+  - 'Response DTOs have static Map() factory method'
+test_patterns:
+  - 'Spec files co-located with source (.spec.ts suffix)'
+  - 'createMockRepo() helper pattern for repository mocks'
+  - 'getRepositoryToken() for DI in test module'
+  - 'Controller specs override guards/interceptors via builder pattern'
+  - 'auditTestProviders() + overrideAuditInterceptors() helpers for audit decorator support'
+---
+
+# Tech-Spec: Questionnaire Version Templating
+
+**Created:** 2026-04-03
+
+## Overview
+
+### Problem Statement
+
+Admins must build questionnaire schemas from scratch every time they create a new version, even when the structure is nearly identical to a previous version. This is tedious and error-prone for complex questionnaires with many sections, nested subsections, questions, weights, and dimension codes.
+
+### Solution
+
+Add a backend endpoint that creates a new DRAFT version by deep-copying the `schemaSnapshot` from an existing version within the same questionnaire. On the frontend, enhance the "Create Draft" flow with an optional template selection modal so admins can pick a past version as a starting point. The builder loads the new draft via the existing flow — no builder changes needed.
+
+### Scope
+
+**In Scope:**
+
+- New API endpoint: `POST /questionnaires/:id/versions/from-template` accepting `{ sourceVersionId }`
+- Deep-copy of `schemaSnapshot` JSON into a new DRAFT version
+- Enforce existing single-draft rule (409 if a DRAFT already exists)
+- Source version can be any non-DRAFT status (ACTIVE, DEPRECATED, ARCHIVED)
+- Source version must belong to the same questionnaire
+- Frontend: template selection modal on "Create Draft" click
+- Frontend: dropdown lists non-DRAFT versions from existing version list hook
+- Frontend: new mutation hook `useCreateVersionFromTemplate()`
+- Frontend: navigate to builder with new draft's `versionId` after creation
+
+**Out of Scope:**
+
+- Cross-questionnaire-type templating (copying from a different questionnaire)
+- Template library / browsing UI
+- Changes to the questionnaire builder component itself
+- Changes to the existing version creation or publishing flow
+- Template metadata (name, description, tags) — no "saved templates" concept
+
+## Context for Development
+
+### Codebase Patterns
+
+**Backend (api.faculytics):**
+
+- Public service methods use PascalCase (e.g., `CreateVersion`, `PublishVersion`)
+- DTOs split into `dto/requests/` and `dto/responses/`, use `class-validator` + `@ApiProperty`
+- Response DTOs have a static `Map(entity)` factory method
+- Controller endpoints decorated with `@ApiOperation`, `@ApiResponse`, `@ApiTags`
+- Admin endpoints use `@UseJwtGuard(UserRole.SUPER_ADMIN, UserRole.ADMIN)`
+- Cache invalidation via `cacheService.invalidateNamespace(CacheNamespace.QUESTIONNAIRE_VERSIONS)` after mutations
+- `QuestionnaireVersion.schemaSnapshot` is a `json` column holding `QuestionnaireSchemaSnapshot`
+- `CreateVersion()` at service:236 is the anchor method — enforces archived check, single-draft rule, auto-increments version number, persists, invalidates cache
+
+**Frontend (app.faculytics):**
+
+- Feature-sliced structure: `features/questionnaires/{api,hooks,store,components,types}/`
+- API requests in `features/questionnaires/api/questionnaire.requests.ts`
+- Mutation hooks wrap TanStack Query `useMutation` with cache invalidation
+- Builder loads existing versions via `loadDraftFromServer()` in Zustand store
+- `deserializeQuestionnaireVersionToDraft()` converts wire schema to editor state
+- "Create Draft" button in `QuestionnaireListToolbar` navigates to `/superadmin/questionnaires/new?type=TYPE`
+- Endpoints registered in `network/endpoints.ts`
+
+### Files to Reference
+
+| File                                                                         | Purpose                                                                              |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `api: src/modules/questionnaires/services/questionnaire.service.ts`          | `CreateVersion()` — anchor method to model validation logic after                    |
+| `api: src/modules/common/unit-of-work/index.ts`                              | `UnitOfWork` (default export) — transaction wrapper, inject into service constructor |
+| `api: src/modules/questionnaires/questionnaire.controller.ts:153`            | `createVersion()` endpoint — pattern for new endpoint                                |
+| `api: src/modules/questionnaires/dto/requests/create-version-request.dto.ts` | Existing DTO — reference for new DTO structure                                       |
+| `api: src/entities/questionnaire-version.entity.ts`                          | Version entity — `schemaSnapshot: json`, `versionNumber`, `status`                   |
+| `api: src/modules/questionnaires/lib/questionnaire.types.ts`                 | `QuestionnaireSchemaSnapshot`, `QuestionnaireStatus` types                           |
+| `api: src/modules/questionnaires/services/questionnaire.service.spec.ts`     | Service tests — `createMockRepo()` pattern, mock setup                               |
+| `api: src/modules/questionnaires/questionnaire.controller.spec.ts`           | Controller tests — guard/interceptor override pattern                                |
+| `app: features/questionnaires/api/questionnaire.requests.ts`                 | API request functions — add new request here                                         |
+| `app: features/questionnaires/hooks/`                                        | Mutation hooks — model new hook after existing patterns                              |
+| `app: features/questionnaires/components/questionnaire-list-toolbar.tsx`     | "Create Draft" button — enhance with template modal                                  |
+| `app: features/questionnaires/store/questionnaire-builder-store.ts`          | Zustand store — `loadDraftFromServer()` (no changes needed)                          |
+| `app: network/endpoints.ts`                                                  | Endpoint registry — add new endpoint constant                                        |
+
+### Technical Decisions
+
+- **Backend copies, not frontend:** The API endpoint performs the deep-copy atomically. This ensures single-draft rule enforcement before copying and prevents stale/manipulated schemas.
+- **Same-questionnaire only:** Source version must belong to the target questionnaire (`version.questionnaire.id === questionnaireId`). Cross-type templating deferred to avoid `meta.questionnaireType` mismatch complexity.
+- **Reuse `CreateVersion()` internals:** The new `CreateVersionFromTemplate()` method mirrors the same draft-check + version-numbering + persist logic from `CreateVersion()`. The only difference is the schema source: fetched from an existing version instead of received in the request body.
+- **Transaction wrapping:** `CreateVersionFromTemplate()` wraps all DB steps in `this.unitOfWork.runInTransaction(async (em) => { ... })` using the project's `UnitOfWork` pattern. All reads and writes inside the callback must use the forked `em` parameter (e.g., `em.findOne(Questionnaire, ...)`, `em.create(...)`, `em.persist(...)`) — NOT the injected repository instances, which are bound to the request-scoped EntityManager and would bypass the transaction. Cache invalidation goes AFTER `runInTransaction()` resolves to avoid invalidating before commit. The existing `CreateVersion()` has the same race-condition gap (no transaction, no partial unique index enforcing single-draft at DB level) but fixing it is out of scope for this PR.
+- **Deep copy via `structuredClone()`:** `schemaSnapshot` is a plain JSON object. `structuredClone()` provides a safe deep copy with no prototype chain issues. Available natively in Node 17+. The `meta.version` field inside the snapshot is a schema format version (always `1`), not the questionnaire version number — it is copied as-is.
+- **No new entities or repositories:** Purely a new service method + endpoint + DTO.
+- **Frontend modal, not page:** A lightweight modal on "Create Draft" click — one extra decision point, then into the existing builder via the same `loadDraftFromServer()` path.
+
+## Implementation Plan
+
+### Tasks
+
+#### Backend (api.faculytics)
+
+- [x] Task 1: Create the request DTO
+  - File: `src/modules/questionnaires/dto/requests/create-version-from-template-request.dto.ts` (NEW)
+  - Action: Create a DTO with a single field `sourceVersionId: string` validated as `@IsUUID()` and `@IsNotEmpty()`, decorated with `@ApiProperty({ description: 'UUID of the version to copy the schema from' })`
+
+- [x] Task 2: Add `CreateVersionFromTemplate()` service method
+  - File: `src/modules/questionnaires/services/questionnaire.service.ts`
+  - Prerequisites: Add `UnitOfWork` as a constructor dependency via injection. **Important:** `UnitOfWork` is a **default export** — import as `import UnitOfWork from '../../common/unit-of-work'` (NOT a named import — the service is in `services/` subdir, so two levels up). Also import `Questionnaire`, `QuestionnaireVersion` entity classes for use with the forked `em`.
+  - Action: Add a new public method `CreateVersionFromTemplate(questionnaireId: string, sourceVersionId: string)` structured as:
+
+    ```typescript
+    async CreateVersionFromTemplate(questionnaireId: string, sourceVersionId: string) {
+      const versionId = await this.unitOfWork.runInTransaction(async (em) => {
+        // ALL reads/writes inside use `em`, NOT injected repos (this.versionRepo, etc.)
+
+        // 1. Fetch questionnaire (404 if not found, 400 if ARCHIVED)
+        const questionnaire = await em.findOne(Questionnaire, questionnaireId, { populate: ['type'] });
+
+        // 2. Fetch source version (404 if not found)
+        const sourceVersion = await em.findOne(QuestionnaireVersion, sourceVersionId, { populate: ['questionnaire'] });
+
+        // 3. Validate source belongs to same questionnaire (400 if mismatch)
+        // 4. Validate source is not DRAFT (400)
+        // 5. Enforce single-draft rule (409)
+        const existingDraft = await em.findOne(QuestionnaireVersion, { questionnaire, status: QuestionnaireStatus.DRAFT });
+
+        // 6. Determine next version number
+        const latestVersion = await em.findOne(QuestionnaireVersion, { questionnaire }, { orderBy: { versionNumber: 'DESC' } });
+
+        // 7. Deep-copy schema
+        const schema = structuredClone(sourceVersion.schemaSnapshot);
+
+        // 8. Create new version (MikroORM v6 em.create() defaults to managed: true, no em.persist() needed)
+        const version = em.create(QuestionnaireVersion, { questionnaire, versionNumber, schemaSnapshot: schema, status: QuestionnaireStatus.DRAFT, isActive: false });
+
+        // 9. Return the ID — NOT the entity (identity map isolation)
+        return version.id;
+      });
+
+      // Cache invalidation AFTER transaction commits
+      await this.cacheService.invalidateNamespace(CacheNamespace.QUESTIONNAIRE_VERSIONS);
+
+      // Re-fetch with full populate for the response mapper (populating 'questionnaire.type'
+      // also loads questionnaire.title as a side effect, which Map() needs)
+      const version = await this.versionRepo.findOne(versionId, { populate: ['questionnaire.type'] });
+      if (!version) {
+        throw new NotFoundException(`Version ${versionId} not found after creation.`);
+      }
+      return version;
+    }
+    ```
+
+  - Notes: The method mirrors `CreateVersion()` validation logic but wraps it in `unitOfWork.runInTransaction()` for atomicity. All DB operations inside the callback use the forked `em` parameter — never injected repository instances. The transaction returns only the version `id`; the fully-populated entity is fetched _after_ commit to avoid identity-map isolation issues (the forked `em`'s loaded relations don't carry over). Cache invalidation is placed after `runInTransaction()` resolves so readers never see stale pre-commit data. The existing `CreateVersion()` has the same race-condition gap but fixing it is out of scope for this PR.
+
+- [x] Task 3: Add controller endpoint
+  - File: `src/modules/questionnaires/questionnaire.controller.ts`
+  - Action: Add a new endpoint directly after the existing `createVersion()` method:
+    ```typescript
+    @Post(':id/versions/from-template')
+    @UseJwtGuard(UserRole.SUPER_ADMIN, UserRole.ADMIN)
+    @ApiOperation({ summary: 'Create a new version from an existing version template' })
+    @ApiResponse({ status: 201, description: 'Version created from template', type: QuestionnaireVersionDetailResponse })
+    @ApiResponse({ status: 400, description: 'Source version is a draft, archived questionnaire, or belongs to different questionnaire' })
+    @ApiResponse({ status: 404, description: 'Questionnaire or source version not found' })
+    @ApiResponse({ status: 409, description: 'Draft version already exists' })
+    async createVersionFromTemplate(
+      @Param('id') id: string,
+      @Body() data: CreateVersionFromTemplateRequest,
+    ): Promise<QuestionnaireVersionDetailResponse> {
+      const version = await this.questionnaireService.CreateVersionFromTemplate(id, data.sourceVersionId);
+      return QuestionnaireVersionDetailResponse.Map(version);
+    }
+    ```
+  - Notes: Add import for `CreateVersionFromTemplateRequest` at the top of the file. The endpoint is protected with `@UseJwtGuard(UserRole.SUPER_ADMIN, UserRole.ADMIN)` since only admins manage questionnaire versions. Note: the existing `createVersion` endpoint is currently unguarded — that is a pre-existing issue and out of scope for this PR.
+
+- [x] Task 4: Add service unit tests
+  - File: `src/modules/questionnaires/services/questionnaire.service.spec.ts`
+  - Prerequisites: Add a `UnitOfWork` mock provider to the `beforeEach` block so the entire test suite doesn't break (Task 2 adds `UnitOfWork` as a constructor dependency):
+
+    ```typescript
+    // In beforeEach, create a mock transactional EntityManager:
+    const mockTransactionalEm = {
+      findOne: jest.fn(),
+      create: jest.fn().mockImplementation((Entity, data) => ({ ...data, id: 'new-version-id' })),
+    };
+
+    // Add to providers array:
+    {
+      provide: UnitOfWork,  // default import: import UnitOfWork from '../common/unit-of-work'
+      useValue: {
+        runInTransaction: jest.fn().mockImplementation((cb) => cb(mockTransactionalEm)),
+      },
+    }
+    ```
+
+    Note: `UnitOfWork` is a **default export** — import as `import UnitOfWork from '../../common/unit-of-work'`.
+
+  - Action: Add a `describe('CreateVersionFromTemplate')` block with tests for:
+    1. **Happy path:** configure `mockTransactionalEm.findOne` with `mockResolvedValueOnce` chaining for the 4 sequential queries (questionnaire, source version, draft check → null, latest version). Verify `mockTransactionalEm.create` is called with the deep-copied schema and correct version number. Verify `versionRepo.findOne` is called after the transaction with the returned ID and `populate: ['questionnaire.type']`.
+    2. **404 — questionnaire not found:** `mockTransactionalEm.findOne` returns null on first call → throws `NotFoundException`
+    3. **400 — archived questionnaire:** questionnaire has `status: ARCHIVED` → throws `BadRequestException`
+    4. **404 — source version not found:** `mockTransactionalEm.findOne` returns null on second call → throws `NotFoundException`
+    5. **400 — source belongs to different questionnaire:** source version's `questionnaire.id` differs → throws `BadRequestException`
+    6. **400 — source is a DRAFT:** source version has `status: DRAFT` → throws `BadRequestException`
+    7. **409 — draft already exists:** `mockTransactionalEm.findOne` returns a draft on third call → throws `ConflictException`
+    8. **Happy path — cache invalidation assertion:** within the happy-path test (test 1), also verify `cacheService.invalidateNamespace` is called with `CacheNamespace.QUESTIONNAIRE_VERSIONS` after the transaction succeeds
+  - Notes: All reads inside the transaction use `mockTransactionalEm.findOne`, NOT the injected `versionRepo` or `questionnaireRepo`. The injected `versionRepo.findOne` is only used for the post-commit re-fetch. Use `mockResolvedValueOnce` chaining on `mockTransactionalEm.findOne` to control each sequential query's return value.
+
+- [x] Task 5: Add controller unit tests
+  - File: `src/modules/questionnaires/questionnaire.controller.spec.ts`
+  - Action: Add `CreateVersionFromTemplate: jest.fn()` to the mock service value object in **all four existing `describe` blocks'** `beforeEach` setups (each block independently creates its own mock — they all need the new method to avoid missing-dependency errors). Add a new test in a `describe('createVersionFromTemplate')` block that verifies the endpoint calls `CreateVersionFromTemplate` with correct args and maps the response via `QuestionnaireVersionDetailResponse.Map`.
+
+#### Frontend (app.faculytics)
+
+- [x] Task 6: Add endpoint constant
+  - File: `network/endpoints.ts`
+  - Action: Add a new enum member to the existing endpoints enum, following the established pattern of static strings with `:id` placeholders. E.g.: `questionnaireVersionFromTemplate = "/api/v1/questionnaires/:id/versions/from-template"`. The request function (Task 7) will call `.replace(":id", questionnaireId)` at the call site.
+
+- [x] Task 7: Add API request function
+  - File: `features/questionnaires/api/questionnaire.requests.ts`
+  - Action: Add a `createVersionFromTemplate(questionnaireId: string, sourceVersionId: string)` function that POSTs to the new endpoint with `{ sourceVersionId }` body. Returns `QuestionnaireVersionDetail`.
+
+- [x] Task 8: Add mutation hook
+  - File: `features/questionnaires/hooks/use-create-version-from-template.ts` (NEW)
+  - Action: Create a TanStack Query `useMutation` hook wrapping `createVersionFromTemplate()`. On success, invalidate the questionnaire versions query cache (follow existing mutation hook patterns for cache invalidation).
+
+- [x] Task 9: Thread props and add template selection modal
+  - Files:
+    - `features/questionnaires/components/questionnaire-list-toolbar.tsx` — add modal, new props, refactor navigation
+    - `app/(dashboard)/superadmin/questionnaires/_components/questionnaire-list-screen.tsx` — thread new props from hook data down to toolbar (this is the immediate parent that renders `QuestionnaireListToolbar`)
+    - `app/(dashboard)/superadmin/questionnaires/page.tsx` — pass `questionnaireId` and version data from the page hook output to `QuestionnaireListScreen` props
+  - Action:
+    1. **Thread new props through the component chain (page → screen → toolbar):**
+       - The `questionnaireId` value comes from `activeTypeSummary?.questionnaireId` in the `useQuestionnaireListPage` hook return. The page component (`page.tsx`) must extract this and pass it as a prop to `QuestionnaireListScreen`.
+       - `QuestionnaireListScreen` receives the new props and passes them down to `QuestionnaireListToolbar`.
+       - The toolbar receives two new props:
+         - `questionnaireId: string | null` — needed for the mutation call. **The toolbar must guard against null** (disable the template option when `questionnaireId` is null — this means no questionnaire exists for the type yet).
+         - `templateVersions: VersionItem[]` — non-DRAFT versions derived from the **unfiltered** version rows (NOT `filteredRows`), so that search/status filters don't affect which templates are available. Filter: `v.status !== 'DRAFT'`.
+    2. **Modify "Create Draft" button behavior:**
+       - If `templateVersions.length > 0`, clicking "Create Draft" opens a dialog/modal
+       - The modal offers two choices:
+         - "Start from scratch" → navigates to `/superadmin/questionnaires/new?type=TYPE` (existing flow)
+         - "Use a previous version as template" → shows a dropdown of template versions (version number, status, publishedAt date)
+       - On template selection + confirm → calls `createVersionFromTemplate` mutation with `questionnaireId` and selected `sourceVersionId` → on success, navigates to `/superadmin/questionnaires/new?type=TYPE&versionId={newVersion.id}` (the `versionId` query param is required for the builder to call `loadDraftFromServer()` and load the newly created draft; without it the builder opens blank)
+       - If `templateVersions.length === 0`, the button behaves exactly as it does today (direct navigation, no modal)
+    3. **Refactor "Create Draft" button navigation:** The current toolbar renders the "Create Draft" button as a `<Link>` component (declarative navigation). Since the modal flow requires an async mutation before navigating, replace the `<Link>` with a `<Button onClick={...}>` and use `useRouter().push()` for imperative navigation after the mutation succeeds (or for the "Start from scratch" path). Import `useRouter` from `next/navigation` in the toolbar.
+    4. **Loading state:** Disable the confirm button and show a spinner while the mutation is pending. Use `isPending` from the mutation hook to prevent double-clicks.
+    5. **Error handling:** On mutation error, show a toast. On 409, show "A draft already exists — edit it or deprecate it first." On other errors, show generic "Failed to create version from template."
+  - Notes: The `useQuestionnaireVersions` hook already returns `status`, `publishedAt`, and `createdAt` per version — no hook modifications needed. The "Create Draft" button is already hidden when `hasDraftVersion` is true, so the 409 error path is purely a server-side safety net — the frontend prevents this scenario by conditionally rendering the button. The modal is only shown when the button is visible (no draft exists) AND template versions are available.
+
+### Acceptance Criteria
+
+**Backend:**
+
+- [ ] AC 1: Given a questionnaire with an ACTIVE version (v1), when an admin POSTs to `/questionnaires/:id/versions/from-template` with `{ sourceVersionId: v1.id }`, then a new DRAFT version (v2) is created with `schemaSnapshot` identical to v1's schema, `status: DRAFT`, `isActive: false`, and `versionNumber: 2`.
+
+- [ ] AC 2: Given a questionnaire with a DEPRECATED version (v1) and an ACTIVE version (v2), when an admin uses v1 as a template, then a new DRAFT version (v3) is created with v1's schema — deprecated versions are valid template sources.
+
+- [ ] AC 3: Given a questionnaire that already has a DRAFT version, when an admin tries to create a version from template, then a 409 Conflict is returned with message "A draft version already exists for this questionnaire."
+
+- [ ] AC 4: Given a source version that belongs to a different questionnaire, when an admin tries to use it as a template, then a 400 Bad Request is returned.
+
+- [ ] AC 5: Given a source version with status DRAFT, when an admin tries to use it as a template, then a 400 Bad Request is returned with message "Cannot use a draft version as a template."
+
+- [ ] AC 6: Given an ARCHIVED questionnaire, when an admin tries to create a version from template, then a 400 Bad Request is returned.
+
+- [ ] AC 7: Given a non-existent questionnaire ID or source version ID, when an admin calls the endpoint, then a 404 Not Found is returned.
+
+- [ ] AC 8: Given a successful template creation, when the new draft's schema is subsequently modified in the builder, then the source version's schema remains unchanged (deep copy verified).
+
+**Frontend:**
+
+- [ ] AC 9: Given an admin on the questionnaire management page with a type that has previous versions, when they click "Create Draft", then a modal appears offering "Start from scratch" or "Use a previous version as template."
+
+- [ ] AC 10: Given the template modal is open, when the admin selects a previous version and confirms, then a new draft is created via the API and the builder opens with the pre-populated schema.
+
+- [ ] AC 11: Given a questionnaire type with no previous versions, when the admin clicks "Create Draft", then the existing direct navigation flow is used (no modal).
+
+## Additional Context
+
+### Dependencies
+
+- No new npm packages required (backend or frontend)
+- No database migrations needed
+- No new environment variables
+- Backend endpoint must be deployed before the frontend modal can be used
+
+### Testing Strategy
+
+**Unit Tests (Backend):**
+
+- `questionnaire.service.spec.ts`: 8 test cases covering happy path, all error conditions, and deep-copy verification (Task 4)
+- `questionnaire.controller.spec.ts`: 1-2 test cases verifying endpoint wiring and response mapping (Task 5)
+
+**Manual Testing:**
+
+1. Create a questionnaire with an ACTIVE version containing sections, questions, and weights
+2. Call `POST /questionnaires/:id/versions/from-template` with the active version's ID
+3. Verify the new DRAFT version has an identical schema via `GET /questionnaires/versions/:newId`
+4. Edit the new draft's schema and verify the source version's schema is unchanged
+5. Try creating another version from template while a draft exists — verify 409
+6. Try using a draft version as source — verify 400
+7. Try using a version from a different questionnaire — verify 400
+8. Frontend: click "Create Draft" with previous versions available → verify modal appears
+9. Frontend: select a template version → verify builder opens with pre-populated schema
+
+### Notes
+
+- The `schemaSnapshot` JSON includes `meta.questionnaireType` which stays consistent since we're scoping to same-questionnaire-only
+- `QuestionnaireVersion` is immutable once submissions exist, but we're copying FROM it (not modifying it), so no immutability concerns
+- The frontend builder doesn't need to know the draft came from a template — it loads via the same `loadDraftFromServer()` path
+- If a future need arises for cross-type templating, the service method can be extended with an optional `targetQuestionnaireType` parameter that remaps `meta.questionnaireType` in the copied schema
+- The shared logic between `CreateVersion()` and `CreateVersionFromTemplate()` (draft check, version numbering, persist) could be extracted to a private helper if a third call site emerges
+- The 409 "draft already exists" error is purely a server-side safety net — the frontend hides the "Create Draft" button (and thus the template modal) when `hasDraftVersion` is true, so this path should never be triggered by normal UI usage
+
+## Review Notes
+
+### Backend (Tasks 1-5)
+
+- Adversarial review completed
+- Findings: 14 total, 1 fixed, 13 skipped (noise/invalid/out-of-scope)
+- Resolution approach: auto-fix
+- Fixed: F12 — removed redundant `@IsNotEmpty()` decorator from DTO (already covered by `@IsUUID()`)
+- Notable out-of-scope: F1 (race condition on single-draft rule) — pre-existing gap shared with `CreateVersion()`, acknowledged in tech-spec
+
+### Frontend (Tasks 6-9)
+
+- All tasks implemented: endpoint constant, API request, mutation hook, template modal
+- TypeScript typecheck: clean
+- ESLint: clean
+- Template modal uses toggle buttons (scratch vs template) since RadioGroup component not in shadcn registry
+- `templateVersions` derived from unfiltered `rows` in screen component to avoid filter interference

--- a/_bmad-output/implementation-artifacts/tech-spec-streamline-dean-promotion.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-streamline-dean-promotion.md
@@ -1,0 +1,272 @@
+---
+title: 'Streamline Dean Promotion Flow'
+slug: 'streamline-dean-promotion'
+created: '2026-04-02'
+status: 'completed'
+stepsCompleted: [1, 2, 3, 4]
+tech_stack:
+  [
+    'NestJS 11',
+    'MikroORM 6',
+    'PostgreSQL',
+    'TypeScript 5.7',
+    'class-validator',
+    '@nestjs/swagger',
+  ]
+files_to_modify:
+  - 'src/modules/admin/admin.controller.ts'
+  - 'src/modules/admin/services/admin.service.ts'
+  - 'src/modules/admin/services/admin.service.spec.ts'
+  - 'src/modules/admin/dto/requests/dean-eligible-categories-query.dto.ts (new)'
+  - 'src/modules/admin/dto/responses/dean-eligible-category.response.dto.ts (new)'
+code_patterns:
+  - 'Controllers use @UseJwtGuard(UserRole.SUPER_ADMIN) for auth'
+  - 'Services inject EntityManager directly'
+  - 'DTOs use class-validator + @nestjs/swagger decorators'
+  - 'Response DTOs have static Map() methods'
+  - 'Public service methods use PascalCase'
+  - 'findOneOrFail always uses failHandler for NestJS exceptions'
+  - 'UserInstitutionalRole.role is string, compare with (UserRole.X as string)'
+test_patterns:
+  - 'Tests use Test.createTestingModule with mocked EntityManager'
+  - 'Tests co-located with source as .spec.ts'
+  - 'Jest mocks for em methods: find, findOneOrFail, etc.'
+---
+
+# Tech-Spec: Streamline Dean Promotion Flow
+
+**Created:** 2026-04-02
+**Issue:** [#249](https://github.com/CtrlAltElite-Devs/api.faculytics/issues/249)
+
+## Overview
+
+### Problem Statement
+
+The `POST /admin/institutional-roles` endpoint requires a numeric `moodleCategoryId` to assign a DEAN role, but admins have no reliable way to discover the correct ID. The admin console currently presents a raw text input, forcing admins to manually look up Moodle category IDs. CHAIRPERSON roles are auto-assigned via Moodle sync (`category:manage` capability check), so only DEAN promotion needs a manual flow.
+
+### Solution
+
+Create a new endpoint that returns the eligible depth-3 (department-level) Moodle categories for a given user, derived from their existing institutional role assignments. The user's CHAIRPERSON roles (auto-synced from Moodle or manually assigned) are resolved up the category tree to depth 3. The admin console can then present a dropdown of valid targets, and the selected `moodleCategoryId` is sent to the existing assignment endpoint.
+
+### Scope
+
+**In Scope:**
+
+- New API endpoint: `GET /admin/institutional-roles/dean-eligible-categories?userId=<uuid>`
+- Query the user's existing `UserInstitutionalRole` records where `role === CHAIRPERSON`, resolve to depth 3
+- Exclude categories where user is already DEAN
+- Return list of eligible department-level categories with `moodleCategoryId` and `name`
+- Super admin access guard
+- Unit tests
+
+**Out of Scope:**
+
+- Admin console UI changes (separate repo: `admin.faculytics`)
+- Changes to the existing `POST /admin/institutional-roles` contract
+- CHAIRPERSON assignment (handled by Moodle sync)
+- Moodle sync modifications
+
+## Context for Development
+
+### Codebase Patterns
+
+- **Auth:** Controller-level `@UseJwtGuard(UserRole.SUPER_ADMIN)` — already applied to `AdminController`
+- **Entity queries:** Services inject `EntityManager` directly, use `em.find()` with `populate` for relations
+- **DTOs:** Request DTOs use `class-validator` decorators (`IsUUID`, `IsString`, etc.), response DTOs use `@nestjs/swagger` decorators (`ApiProperty` with `description` and `example`) with static `Map()` factory methods
+- **Method naming:** Public service methods use PascalCase (e.g., `ListUsers`, `AssignInstitutionalRole`)
+- **Error handling:** Standard NestJS exceptions (`NotFoundException`, `BadRequestException`). All `findOneOrFail` calls must use `{ failHandler: () => new NotFoundException(...) }` — bare `findOneOrFail` throws MikroORM's `NotFoundError` (500), not NestJS's `NotFoundException` (404)
+- **Query DTOs:** See `FilterDepartmentsQueryDto` pattern — single optional/required field with `@ApiPropertyOptional`/`@ApiProperty` + validators
+- **String enum comparison:** `UserInstitutionalRole.role` is typed as `string`, not `UserRole` enum. Compare using `ir.role === (UserRole.DEAN as string)` pattern (see `moodle-user-hydration.service.ts` line 393)
+- **Read-only methods:** This new method is a pure query — no `flush()` or `refreshUserRoles()` needed
+
+### Files to Reference
+
+| File                                                             | Purpose                                                                                            |
+| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `src/modules/admin/admin.controller.ts`                          | Existing admin endpoints — add new GET here                                                        |
+| `src/modules/admin/services/admin.service.ts`                    | Service with `AssignInstitutionalRole` — add query method here                                     |
+| `src/modules/admin/services/admin.service.spec.ts`               | Existing tests — add new tests here                                                                |
+| `src/entities/user-institutional-role.entity.ts`                 | `UserInstitutionalRole` — links user→role→moodleCategory, unique on `(user, moodleCategory, role)` |
+| `src/entities/moodle-category.entity.ts`                         | `MoodleCategory` — `moodleCategoryId`, `name`, `depth`, `parentMoodleCategoryId`                   |
+| `src/modules/admin/dto/responses/filter-option.response.dto.ts`  | Pattern reference for response DTO with static `Map()`                                             |
+| `src/modules/admin/dto/requests/filter-departments-query.dto.ts` | Pattern reference for query DTO                                                                    |
+| `src/modules/admin/admin.module.ts`                              | Module already imports all needed entities                                                         |
+| `src/modules/common/services/scope-resolver.service.ts`          | Pattern reference for batch `$in` query on `moodleCategoryId`                                      |
+
+### Technical Decisions
+
+- **User-centric query:** Resolve eligible categories from the user's own `UserInstitutionalRole` records, not from a global category list
+- **Explicit CHAIRPERSON filter:** Only roles where `role === (UserRole.CHAIRPERSON as string)` are considered candidates. Do NOT use "everything that isn't DEAN" — this prevents future role types from being silently included
+- **Both source types included:** All CHAIRPERSON roles regardless of `source` (auto or manual) are considered eligible. The `source` distinction is for sync cleanup logic, not eligibility
+- **Depth resolution:** For depth 4 categories, follow `parentMoodleCategoryId` to get the depth 3 parent. For depth 3 categories, use directly. Other depths are skipped
+- **Batch parent resolution:** Collect all `parentMoodleCategoryId`s from depth-4 candidates and batch-fetch with `em.find(MoodleCategory, { moodleCategoryId: { $in: [...ids] } })` — no N+1 queries
+- **Null guard on populated relations:** Skip any `UserInstitutionalRole` where `moodleCategory` is null after populate (handles edge case of soft-deleted `MoodleCategory`)
+- **Exclusion:** Filter out categories where the user already holds a DEAN role
+- **Deduplication:** Multiple CHAIRPERSON roles at depth 4 under the same department collapse to one entry
+- **No new entities or module changes:** `AdminModule` already imports `UserInstitutionalRole`, `MoodleCategory`, and `User`
+- **Response shape:** `{ moodleCategoryId: number, name: string }` — minimal, directly usable by the assignment DTO
+
+## Implementation Plan
+
+### Tasks
+
+- [ ] Task 1: Create response DTO
+  - File: `src/modules/admin/dto/responses/dean-eligible-category.response.dto.ts` (new)
+  - Action: Create DTO with `moodleCategoryId` (number) and `name` (string), `@ApiProperty` decorators with `description` and `example` values, and static `Map(category: MoodleCategory)` factory method
+  - Example:
+
+    ```typescript
+    export class DeanEligibleCategoryResponseDto {
+      @ApiProperty({
+        description: 'Moodle category ID for the department',
+        example: 8,
+      })
+      moodleCategoryId: number;
+
+      @ApiProperty({ description: 'Department name', example: 'CCS' })
+      name: string;
+
+      static Map(category: MoodleCategory): DeanEligibleCategoryResponseDto {
+        return {
+          moodleCategoryId: category.moodleCategoryId,
+          name: category.name,
+        };
+      }
+    }
+    ```
+
+- [ ] Task 2: Create request query DTO
+  - File: `src/modules/admin/dto/requests/dean-eligible-categories-query.dto.ts` (new)
+  - Action: Create DTO with required `userId` field, `@ApiProperty({ description: '...' })` + `@IsUUID()` validators
+  - Notes: Follow `FilterDepartmentsQueryDto` pattern but with `userId` as required (not optional)
+
+- [ ] Task 3: Add service method `GetDeanEligibleCategories`
+  - File: `src/modules/admin/services/admin.service.ts`
+  - Action: Add new public method with this logic:
+    1. Validate user exists:
+       ```typescript
+       await this.em.findOneOrFail(
+         User,
+         { id: userId },
+         {
+           failHandler: () => new NotFoundException('User not found'),
+         },
+       );
+       ```
+    2. Fetch all institutional roles with populated moodleCategory:
+       ```typescript
+       const roles = await this.em.find(
+         UserInstitutionalRole,
+         { user: userId },
+         { populate: ['moodleCategory'] },
+       );
+       ```
+    3. Build DEAN exclusion set — collect `moodleCategoryId` from roles where `ir.role === (UserRole.DEAN as string)`:
+       ```typescript
+       const deanCategoryIds = new Set(
+         roles
+           .filter(
+             (ir) => ir.role === (UserRole.DEAN as string) && ir.moodleCategory,
+           )
+           .map((ir) => ir.moodleCategory.moodleCategoryId),
+       );
+       ```
+    4. Filter CHAIRPERSON candidates (explicitly, not "non-DEAN"), skip null moodleCategory:
+       ```typescript
+       const chairpersonRoles = roles.filter(
+         (ir) =>
+           ir.role === (UserRole.CHAIRPERSON as string) && ir.moodleCategory,
+       );
+       ```
+    5. Separate depth-3 (direct) and depth-4 (need parent resolution):
+       - Depth 3 → add directly to candidates `Map<number, MoodleCategory>`
+       - Depth 4 → collect `parentMoodleCategoryId` for batch fetch
+       - Other depths → skip
+    6. Batch-fetch depth-4 parents (no N+1):
+       ```typescript
+       const parentCategories = await this.em.find(MoodleCategory, {
+         moodleCategoryId: { $in: [...parentIds] },
+       });
+       ```
+       Add resolved parents to candidates map.
+    7. Exclude any `moodleCategoryId` in the DEAN exclusion set.
+    8. Return mapped through `DeanEligibleCategoryResponseDto.Map()`, sorted by `name`.
+  - Notes: Method signature: `async GetDeanEligibleCategories(userId: string): Promise<DeanEligibleCategoryResponseDto[]>`. This is a read-only query — no `flush()` or `refreshUserRoles()` needed.
+
+- [ ] Task 4: Add controller endpoint
+  - File: `src/modules/admin/admin.controller.ts`
+  - Action: Add new GET endpoint in `AdminController`:
+    ```typescript
+    @Get('institutional-roles/dean-eligible-categories')
+    @ApiOperation({ summary: 'List eligible department categories for DEAN promotion' })
+    @ApiQuery({ name: 'userId', required: true, type: String, description: 'UUID of the user to check eligibility for' })
+    @ApiResponse({ status: 200, type: [DeanEligibleCategoryResponseDto] })
+    @ApiResponse({ status: 404, description: 'User not found' })
+    async GetDeanEligibleCategories(
+      @Query() query: DeanEligibleCategoriesQueryDto,
+    ): Promise<DeanEligibleCategoryResponseDto[]> {
+      return this.adminService.GetDeanEligibleCategories(query.userId);
+    }
+    ```
+  - Notes: Import the new DTOs. No route ordering concern — GET `institutional-roles/dean-eligible-categories` and POST `institutional-roles` are different HTTP methods and different paths; no ambiguity.
+
+- [ ] Task 5: Add unit tests
+  - File: `src/modules/admin/services/admin.service.spec.ts`
+  - Action: Add new `describe('GetDeanEligibleCategories')` block with these test cases:
+    1. **Happy path — depth 4 resolved to depth 3:** User has CHAIRPERSON at depth 4 (programCatId=18, parentMoodleCategoryId=8) → batch-fetches parent → returns dept category (catId=8, name='CCS'). Mock `em.findOneOrFail` with `failHandler` for user lookup, `em.find` for roles (returns CHAIRPERSON role with depth-4 moodleCategory), `em.find` for batch parent fetch (returns depth-3 category).
+    2. **Happy path — depth 3 used directly (manual-assignment scenario):** User has CHAIRPERSON at depth 3 (catId=8) → returns that category directly. Note: Moodle sync only creates CHAIRPERSON at depth 4; depth-3 CHAIRPERSON comes from manual assignment via `POST /admin/institutional-roles`.
+    3. **Deduplication:** User has CHAIRPERSON at two depth-4 categories (catId=18, catId=19) both with same parentMoodleCategoryId=8 → batch-fetches one parent → returns one entry.
+    4. **Exclusion of existing DEAN:** User has DEAN at dept catId=8 AND CHAIRPERSON at catId=18 (child of 8) → resolved parent matches DEAN exclusion set → returns empty array.
+    5. **User not found:** `em.findOneOrFail` `failHandler` invoked → throws `NotFoundException`.
+    6. **No institutional roles:** User exists, `em.find` returns empty array → returns empty array.
+    7. **Mixed scenario:** User has CHAIRPERSON at programs under dept A (catId=8) and dept B (catId=12), already DEAN at dept A → returns only dept B (catId=12).
+  - Notes: Follow existing test patterns. Mock `em.findOneOrFail` with `failHandler` support, `em.find` for institutional roles and batch parent fetch.
+
+### Acceptance Criteria
+
+- [ ] AC 1: Given a user with CHAIRPERSON roles at depth-4 categories, when `GET /admin/institutional-roles/dean-eligible-categories?userId=<uuid>` is called, then the response contains the resolved depth-3 parent departments with `moodleCategoryId` and `name`
+- [ ] AC 2: Given a user with CHAIRPERSON roles at depth-3 categories (manually assigned), when the endpoint is called, then those categories are returned directly
+- [ ] AC 3: Given a user with multiple CHAIRPERSON roles under the same department, when the endpoint is called, then only one entry per department is returned (deduplication)
+- [ ] AC 4: Given a user who already has a DEAN role at a department, when the endpoint is called, then that department is excluded from the results
+- [ ] AC 5: Given a user with no institutional roles, when the endpoint is called, then an empty array is returned
+- [ ] AC 6: Given an invalid userId, when the endpoint is called, then a 404 NotFoundException is returned
+- [ ] AC 7: Given an unauthenticated request or a non-SUPER_ADMIN user, when the endpoint is called, then a 401/403 response is returned
+- [ ] AC 8: Given the endpoint response, then each item's `moodleCategoryId` corresponds to a valid depth-3 MoodleCategory in the database
+
+## Additional Context
+
+### Dependencies
+
+- No new package dependencies required
+- All entities already imported in `AdminModule`: `User`, `UserInstitutionalRole`, `MoodleCategory`
+- Depends on Moodle sync having run at least once for the target user (CHAIRPERSON roles populated via `MoodleUserHydrationService.resolveInstitutionalRoles()`)
+- Global `ValidationPipe` must be enabled for `@IsUUID()` on the query DTO to validate at the HTTP level
+
+### Testing Strategy
+
+**Unit Tests (Task 5):**
+
+- 7 test cases covering happy paths, deduplication, exclusion, error handling, and edge cases
+- Mock `EntityManager` methods: `findOneOrFail` (with `failHandler`), `find` (for roles and batch parent fetch)
+- Follow existing patterns in `admin.service.spec.ts`
+
+**Manual Testing:**
+
+- Call `GET /admin/institutional-roles/dean-eligible-categories?userId=<uuid>` via Swagger or curl
+- Verify response contains correct department categories for a user with known CHAIRPERSON roles
+- Verify empty response for user with no roles or user who is already DEAN everywhere
+- Verify 404 for nonexistent userId
+- Verify end-to-end: select a `moodleCategoryId` from the response and send it to `POST /admin/institutional-roles` to confirm DEAN assignment succeeds
+
+### Notes
+
+- Consumer: `admin.faculytics` (React + Vite admin console) — the role assignment dialog at `src/features/admin/role-action-dialog.tsx` can replace its raw number input with a dropdown populated by this endpoint
+- CHAIRPERSON roles are auto-synced during login via `MoodleUserHydrationService.resolveInstitutionalRoles()` — users who have `moodle/category:manage` on a course's program category get CHAIRPERSON at that depth-4 category
+- A user who has never logged in will have no institutional roles and thus no eligible categories — this is expected and the admin should trigger a sync or wait for the user to log in
+
+## Review Notes
+
+- Adversarial spec review completed: 13 findings, 10 fixed, 3 skipped (noise)
+- Adversarial code review completed: 12 findings, 3 fixed, 9 skipped (noise/systemic/by-design)
+- Code fixes applied: depth-3 validation on batch-fetched parents, test for unexpected depths, test for sort order
+- Resolution approach: auto-fix on real findings

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -7,6 +7,8 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in shell env}
       POSTGRES_DB: postgres
     command: postgres -c shared_buffers=512MB -c work_mem=8MB
+    ports:
+      - '127.0.0.1:5432:5432'
     volumes:
       - pg_data:/var/lib/postgresql/data
       - ./deploy/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql:ro

--- a/src/entities/user.entity.spec.ts
+++ b/src/entities/user.entity.spec.ts
@@ -1,0 +1,113 @@
+import { User } from './user.entity';
+import { UserRole } from '../modules/auth/roles.enum';
+import { Enrollment } from './enrollment.entity';
+import { UserInstitutionalRole } from './user-institutional-role.entity';
+
+function stubEnrollment(role: string, isActive = true): Enrollment {
+  return { role, isActive } as unknown as Enrollment;
+}
+
+function stubInstRole(role: string): UserInstitutionalRole {
+  return { role } as unknown as UserInstitutionalRole;
+}
+
+describe('User.updateRolesFromEnrollments', () => {
+  let user: User;
+
+  beforeEach(() => {
+    user = new User();
+    user.roles = [];
+  });
+
+  it('should preserve SUPER_ADMIN alongside enrollment-derived roles', () => {
+    user.roles = [UserRole.SUPER_ADMIN];
+
+    user.updateRolesFromEnrollments([stubEnrollment('student')]);
+
+    expect(user.roles).toEqual(
+      expect.arrayContaining([UserRole.SUPER_ADMIN, UserRole.STUDENT]),
+    );
+    expect(user.roles).toHaveLength(2);
+  });
+
+  it('should preserve ADMIN alongside enrollment-derived roles', () => {
+    user.roles = [UserRole.ADMIN];
+
+    user.updateRolesFromEnrollments([stubEnrollment('editingteacher')]);
+
+    expect(user.roles).toEqual(
+      expect.arrayContaining([UserRole.ADMIN, UserRole.FACULTY]),
+    );
+    expect(user.roles).toHaveLength(2);
+  });
+
+  it('should derive roles from enrollments without protected roles', () => {
+    user.updateRolesFromEnrollments([
+      stubEnrollment('student'),
+      stubEnrollment('editingteacher'),
+    ]);
+
+    expect(user.roles).toEqual(
+      expect.arrayContaining([UserRole.STUDENT, UserRole.FACULTY]),
+    );
+    expect(user.roles).toHaveLength(2);
+  });
+
+  it('should keep SUPER_ADMIN when no enrollments and no institutional roles', () => {
+    user.roles = [UserRole.SUPER_ADMIN];
+
+    user.updateRolesFromEnrollments([]);
+
+    expect(user.roles).toEqual([UserRole.SUPER_ADMIN]);
+  });
+
+  it('should include both enrollment and institutional roles', () => {
+    user.updateRolesFromEnrollments(
+      [stubEnrollment('teacher')],
+      [stubInstRole(UserRole.DEAN)],
+    );
+
+    expect(user.roles).toEqual(
+      expect.arrayContaining([UserRole.FACULTY, UserRole.DEAN]),
+    );
+    expect(user.roles).toHaveLength(2);
+  });
+
+  it('should map manager enrollment role to DEAN via MoodleRoleMapping', () => {
+    user.updateRolesFromEnrollments([stubEnrollment('manager')]);
+
+    expect(user.roles).toEqual(expect.arrayContaining([UserRole.DEAN]));
+    expect(user.roles).toHaveLength(1);
+  });
+
+  it('should return empty roles when no protected roles, no enrollments, no institutional roles', () => {
+    user.updateRolesFromEnrollments([]);
+
+    expect(user.roles).toEqual([]);
+  });
+
+  it('should ignore inactive enrollments', () => {
+    user.updateRolesFromEnrollments([
+      stubEnrollment('student', false),
+      stubEnrollment('editingteacher', false),
+    ]);
+
+    expect(user.roles).toEqual([]);
+  });
+
+  it('should deduplicate roles from multiple enrollments with the same role', () => {
+    user.updateRolesFromEnrollments([
+      stubEnrollment('student'),
+      stubEnrollment('student'),
+      stubEnrollment('student'),
+    ]);
+
+    expect(user.roles).toEqual([UserRole.STUDENT]);
+  });
+
+  it('should fall back to uppercased role string for unknown Moodle roles', () => {
+    user.updateRolesFromEnrollments([stubEnrollment('coursecreator')]);
+
+    expect(user.roles).toEqual(['COURSECREATOR']);
+  });
+});

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -94,6 +94,10 @@ export class User extends CustomBaseEntity {
     enrollments: Enrollment[],
     institutionalRoles: UserInstitutionalRole[] = [],
   ) {
+    const protectedRoles = this.roles.filter(
+      (r) => r === UserRole.SUPER_ADMIN || r === UserRole.ADMIN,
+    );
+
     const enrollmentRoles = enrollments
       .filter((e) => e.isActive)
       .map(
@@ -108,8 +112,8 @@ export class User extends CustomBaseEntity {
         (ir.role.toUpperCase() as unknown as UserRole),
     );
 
-    this.roles = [...new Set([...enrollmentRoles, ...instRoles])].filter(
-      Boolean,
-    );
+    this.roles = [
+      ...new Set([...protectedRoles, ...enrollmentRoles, ...instRoles]),
+    ].filter(Boolean);
   }
 }

--- a/src/modules/admin/admin.controller.spec.ts
+++ b/src/modules/admin/admin.controller.spec.ts
@@ -21,6 +21,7 @@ describe('AdminController', () => {
           currentPage: 1,
         },
       }),
+      GetUserDetail: jest.fn().mockResolvedValue({}),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -39,6 +40,12 @@ describe('AdminController', () => {
       .compile();
 
     controller = module.get(AdminController);
+  });
+
+  it('should delegate user detail to the admin service', async () => {
+    await controller.GetUserDetail('user-1');
+
+    expect(adminService.GetUserDetail).toHaveBeenCalledWith('user-1');
   });
 
   it('should delegate user listing to the admin service', async () => {

--- a/src/modules/admin/admin.controller.ts
+++ b/src/modules/admin/admin.controller.ts
@@ -12,7 +12,9 @@ import { AdminService } from './services/admin.service';
 import { AssignInstitutionalRoleDto } from './dto/requests/assign-institutional-role.request.dto';
 import { RemoveInstitutionalRoleDto } from './dto/requests/remove-institutional-role.request.dto';
 import { ListUsersQueryDto } from './dto/requests/list-users-query.dto';
+import { DeanEligibleCategoriesQueryDto } from './dto/requests/dean-eligible-categories-query.dto';
 import { AdminUserListResponseDto } from './dto/responses/admin-user-list.response.dto';
+import { DeanEligibleCategoryResponseDto } from './dto/responses/dean-eligible-category.response.dto';
 
 @ApiTags('Admin')
 @Controller('admin')
@@ -84,6 +86,24 @@ export class AdminController {
     @Query() query: ListUsersQueryDto,
   ): Promise<AdminUserListResponseDto> {
     return this.adminService.ListUsers(query);
+  }
+
+  @Get('institutional-roles/dean-eligible-categories')
+  @ApiOperation({
+    summary: 'List eligible department categories for DEAN promotion',
+  })
+  @ApiQuery({
+    name: 'userId',
+    required: true,
+    type: String,
+    description: 'UUID of the user to check eligibility for',
+  })
+  @ApiResponse({ status: 200, type: [DeanEligibleCategoryResponseDto] })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  async GetDeanEligibleCategories(
+    @Query() query: DeanEligibleCategoriesQueryDto,
+  ): Promise<DeanEligibleCategoryResponseDto[]> {
+    return this.adminService.GetDeanEligibleCategories(query.userId);
   }
 
   @Post('institutional-roles')

--- a/src/modules/admin/admin.controller.ts
+++ b/src/modules/admin/admin.controller.ts
@@ -1,7 +1,17 @@
-import { Body, Controller, Delete, Get, Post, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Query,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOperation,
+  ApiParam,
   ApiQuery,
   ApiResponse,
   ApiTags,
@@ -13,6 +23,7 @@ import { AssignInstitutionalRoleDto } from './dto/requests/assign-institutional-
 import { RemoveInstitutionalRoleDto } from './dto/requests/remove-institutional-role.request.dto';
 import { ListUsersQueryDto } from './dto/requests/list-users-query.dto';
 import { DeanEligibleCategoriesQueryDto } from './dto/requests/dean-eligible-categories-query.dto';
+import { AdminUserDetailResponseDto } from './dto/responses/admin-user-detail.response.dto';
 import { AdminUserListResponseDto } from './dto/responses/admin-user-list.response.dto';
 import { DeanEligibleCategoryResponseDto } from './dto/responses/dean-eligible-category.response.dto';
 
@@ -86,6 +97,18 @@ export class AdminController {
     @Query() query: ListUsersQueryDto,
   ): Promise<AdminUserListResponseDto> {
     return this.adminService.ListUsers(query);
+  }
+
+  @Get('users/:id')
+  @ApiOperation({ summary: 'Get detailed information about a single user' })
+  @ApiParam({ name: 'id', type: String, description: 'User UUID' })
+  @ApiResponse({ status: 200, type: AdminUserDetailResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid UUID format' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  async GetUserDetail(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<AdminUserDetailResponseDto> {
+    return this.adminService.GetUserDetail(id);
   }
 
   @Get('institutional-roles/dean-eligible-categories')

--- a/src/modules/admin/admin.module.ts
+++ b/src/modules/admin/admin.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { Campus } from 'src/entities/campus.entity';
+import { Course } from 'src/entities/course.entity';
 import { Department } from 'src/entities/department.entity';
+import { Enrollment } from 'src/entities/enrollment.entity';
 import { MoodleCategory } from 'src/entities/moodle-category.entity';
 import { Program } from 'src/entities/program.entity';
 import { Semester } from 'src/entities/semester.entity';
@@ -16,7 +18,9 @@ import { AdminFiltersService } from './services/admin-filters.service';
   imports: [
     MikroOrmModule.forFeature([
       Campus,
+      Course,
       Department,
+      Enrollment,
       MoodleCategory,
       Program,
       Semester,

--- a/src/modules/admin/dto/requests/dean-eligible-categories-query.dto.ts
+++ b/src/modules/admin/dto/requests/dean-eligible-categories-query.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUUID } from 'class-validator';
+
+export class DeanEligibleCategoriesQueryDto {
+  @ApiProperty({
+    description: 'UUID of the user to check dean eligibility for',
+  })
+  @IsUUID()
+  userId: string;
+}

--- a/src/modules/admin/dto/responses/admin-user-detail.response.dto.ts
+++ b/src/modules/admin/dto/responses/admin-user-detail.response.dto.ts
@@ -1,0 +1,179 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Enrollment } from 'src/entities/enrollment.entity';
+import { UserInstitutionalRole } from 'src/entities/user-institutional-role.entity';
+import { User } from 'src/entities/user.entity';
+import { UserRole } from 'src/modules/auth/roles.enum';
+import { AdminUserScopedRelationDto } from './admin-user-item.response.dto';
+
+class AdminEnrollmentCourseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  shortname: string;
+
+  @ApiProperty()
+  fullname: string;
+}
+
+class AdminInstitutionalRoleCategoryDto {
+  @ApiProperty()
+  moodleCategoryId: number;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  depth: number;
+}
+
+export class AdminEnrollmentItemDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  role: string;
+
+  @ApiProperty()
+  isActive: boolean;
+
+  @ApiProperty({ type: AdminEnrollmentCourseDto })
+  course: AdminEnrollmentCourseDto;
+
+  static Map(enrollment: Enrollment): AdminEnrollmentItemDto {
+    return {
+      id: enrollment.id,
+      role: enrollment.role,
+      isActive: enrollment.isActive,
+      course: {
+        id: enrollment.course.id,
+        shortname: enrollment.course.shortname,
+        fullname: enrollment.course.fullname,
+      },
+    };
+  }
+}
+
+export class AdminInstitutionalRoleItemDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  role: string;
+
+  @ApiProperty()
+  source: string;
+
+  @ApiProperty({ type: AdminInstitutionalRoleCategoryDto })
+  category: AdminInstitutionalRoleCategoryDto;
+
+  static Map(ir: UserInstitutionalRole): AdminInstitutionalRoleItemDto | null {
+    if (!ir.moodleCategory) return null;
+
+    return {
+      id: ir.id,
+      role: ir.role,
+      source: ir.source,
+      category: {
+        moodleCategoryId: ir.moodleCategory.moodleCategoryId,
+        name: ir.moodleCategory.name,
+        depth: ir.moodleCategory.depth,
+      },
+    };
+  }
+}
+
+export class AdminUserDetailResponseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  userName: string;
+
+  @ApiProperty()
+  fullName: string;
+
+  @ApiProperty()
+  firstName: string;
+
+  @ApiProperty()
+  lastName: string;
+
+  @ApiPropertyOptional()
+  moodleUserId?: number;
+
+  @ApiProperty()
+  userProfilePicture: string;
+
+  @ApiProperty({ enum: UserRole, isArray: true })
+  roles: UserRole[];
+
+  @ApiProperty()
+  isActive: boolean;
+
+  @ApiProperty()
+  lastLoginAt: Date;
+
+  @ApiProperty()
+  createdAt: Date;
+
+  @ApiPropertyOptional({ type: AdminUserScopedRelationDto, nullable: true })
+  campus: AdminUserScopedRelationDto | null;
+
+  @ApiPropertyOptional({ type: AdminUserScopedRelationDto, nullable: true })
+  department: AdminUserScopedRelationDto | null;
+
+  @ApiPropertyOptional({ type: AdminUserScopedRelationDto, nullable: true })
+  program: AdminUserScopedRelationDto | null;
+
+  @ApiProperty({ type: [AdminEnrollmentItemDto] })
+  enrollments: AdminEnrollmentItemDto[];
+
+  @ApiProperty({ type: [AdminInstitutionalRoleItemDto] })
+  institutionalRoles: AdminInstitutionalRoleItemDto[];
+
+  static Map(
+    user: User,
+    enrollments: Enrollment[],
+    institutionalRoles: UserInstitutionalRole[],
+  ): AdminUserDetailResponseDto {
+    return {
+      id: user.id,
+      userName: user.userName,
+      fullName: user.fullName ?? `${user.firstName} ${user.lastName}`.trim(),
+      firstName: user.firstName,
+      lastName: user.lastName,
+      moodleUserId: user.moodleUserId,
+      userProfilePicture: user.userProfilePicture,
+      roles: user.roles,
+      isActive: user.isActive,
+      lastLoginAt: user.lastLoginAt,
+      createdAt: user.createdAt,
+      campus: user.campus
+        ? {
+            id: user.campus.id,
+            code: user.campus.code,
+            name: user.campus.name,
+          }
+        : null,
+      department: user.department
+        ? {
+            id: user.department.id,
+            code: user.department.code,
+            name: user.department.name,
+          }
+        : null,
+      program: user.program
+        ? {
+            id: user.program.id,
+            code: user.program.code,
+            name: user.program.name,
+          }
+        : null,
+      enrollments: enrollments.map((e) => AdminEnrollmentItemDto.Map(e)),
+      institutionalRoles: institutionalRoles
+        .map((ir) => AdminInstitutionalRoleItemDto.Map(ir))
+        .filter((dto): dto is AdminInstitutionalRoleItemDto => dto !== null),
+    };
+  }
+}

--- a/src/modules/admin/dto/responses/admin-user-item.response.dto.ts
+++ b/src/modules/admin/dto/responses/admin-user-item.response.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { User } from 'src/entities/user.entity';
 import { UserRole } from 'src/modules/auth/roles.enum';
 
-class AdminUserScopedRelationDto {
+export class AdminUserScopedRelationDto {
   @ApiProperty()
   id: string;
 

--- a/src/modules/admin/dto/responses/dean-eligible-category.response.dto.ts
+++ b/src/modules/admin/dto/responses/dean-eligible-category.response.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { MoodleCategory } from 'src/entities/moodle-category.entity';
+
+export class DeanEligibleCategoryResponseDto {
+  @ApiProperty({
+    description: 'Moodle category ID for the department',
+    example: 8,
+  })
+  moodleCategoryId: number;
+
+  @ApiProperty({ description: 'Department name', example: 'CCS' })
+  name: string;
+
+  static Map(category: MoodleCategory): DeanEligibleCategoryResponseDto {
+    return {
+      moodleCategoryId: category.moodleCategoryId,
+      name: category.name,
+    };
+  }
+}

--- a/src/modules/admin/services/admin.service.spec.ts
+++ b/src/modules/admin/services/admin.service.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { EntityManager } from '@mikro-orm/postgresql';
 import { Test, TestingModule } from '@nestjs/testing';
 import { User } from 'src/entities/user.entity';
@@ -305,6 +305,172 @@ describe('AdminService', () => {
         expect.objectContaining({ moodleCategory: programCategory }),
         expect.anything(),
       );
+    });
+  });
+
+  describe('GetDeanEligibleCategories', () => {
+    const mockUser = { id: 'user-1' } as User;
+
+    const deptCCS = {
+      moodleCategoryId: 8,
+      name: 'CCS',
+      depth: 3,
+      parentMoodleCategoryId: 6,
+    };
+
+    const deptCOE = {
+      moodleCategoryId: 12,
+      name: 'COE',
+      depth: 3,
+      parentMoodleCategoryId: 6,
+    };
+
+    const programBSCS = {
+      moodleCategoryId: 18,
+      name: 'BSCS',
+      depth: 4,
+      parentMoodleCategoryId: 8,
+    };
+
+    const programBSIT = {
+      moodleCategoryId: 19,
+      name: 'BSIT',
+      depth: 4,
+      parentMoodleCategoryId: 8,
+    };
+
+    const programBSCE = {
+      moodleCategoryId: 20,
+      name: 'BSCE',
+      depth: 4,
+      parentMoodleCategoryId: 12,
+    };
+
+    it('should resolve depth-4 CHAIRPERSON to parent depth-3 department', async () => {
+      em.findOneOrFail.mockResolvedValueOnce(mockUser);
+      em.find
+        .mockResolvedValueOnce([
+          { role: UserRole.CHAIRPERSON, moodleCategory: programBSCS },
+        ])
+        .mockResolvedValueOnce([deptCCS]);
+
+      const result = await service.GetDeanEligibleCategories('user-1');
+
+      expect(result).toEqual([{ moodleCategoryId: 8, name: 'CCS' }]);
+    });
+
+    it('should return depth-3 CHAIRPERSON directly (manual-assignment scenario)', async () => {
+      em.findOneOrFail.mockResolvedValueOnce(mockUser);
+      em.find.mockResolvedValueOnce([
+        { role: UserRole.CHAIRPERSON, moodleCategory: deptCCS },
+      ]);
+
+      const result = await service.GetDeanEligibleCategories('user-1');
+
+      expect(result).toEqual([{ moodleCategoryId: 8, name: 'CCS' }]);
+    });
+
+    it('should deduplicate when multiple depth-4 roles share the same parent department', async () => {
+      em.findOneOrFail.mockResolvedValueOnce(mockUser);
+      em.find
+        .mockResolvedValueOnce([
+          { role: UserRole.CHAIRPERSON, moodleCategory: programBSCS },
+          { role: UserRole.CHAIRPERSON, moodleCategory: programBSIT },
+        ])
+        .mockResolvedValueOnce([deptCCS]);
+
+      const result = await service.GetDeanEligibleCategories('user-1');
+
+      expect(result).toEqual([{ moodleCategoryId: 8, name: 'CCS' }]);
+    });
+
+    it('should exclude categories where user is already DEAN', async () => {
+      em.findOneOrFail.mockResolvedValueOnce(mockUser);
+      em.find
+        .mockResolvedValueOnce([
+          { role: UserRole.DEAN, moodleCategory: deptCCS },
+          { role: UserRole.CHAIRPERSON, moodleCategory: programBSCS },
+        ])
+        .mockResolvedValueOnce([deptCCS]);
+
+      const result = await service.GetDeanEligibleCategories('user-1');
+
+      expect(result).toEqual([]);
+    });
+
+    it('should throw NotFoundException for invalid userId', async () => {
+      em.findOneOrFail.mockImplementationOnce(
+        (
+          _entity: unknown,
+          _filter: unknown,
+          opts: { failHandler: () => Error },
+        ) => {
+          throw opts.failHandler();
+        },
+      );
+
+      await expect(
+        service.GetDeanEligibleCategories('nonexistent'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should return empty array when user has no institutional roles', async () => {
+      em.findOneOrFail.mockResolvedValueOnce(mockUser);
+      em.find.mockResolvedValueOnce([]);
+
+      const result = await service.GetDeanEligibleCategories('user-1');
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return only non-DEAN departments in mixed scenario', async () => {
+      em.findOneOrFail.mockResolvedValueOnce(mockUser);
+      em.find
+        .mockResolvedValueOnce([
+          { role: UserRole.DEAN, moodleCategory: deptCCS },
+          { role: UserRole.CHAIRPERSON, moodleCategory: programBSCS },
+          { role: UserRole.CHAIRPERSON, moodleCategory: programBSCE },
+        ])
+        .mockResolvedValueOnce([deptCCS, deptCOE]);
+
+      const result = await service.GetDeanEligibleCategories('user-1');
+
+      expect(result).toEqual([{ moodleCategoryId: 12, name: 'COE' }]);
+    });
+
+    it('should silently skip CHAIRPERSON roles at unexpected depths (not 3 or 4)', async () => {
+      const semesterCategory = {
+        moodleCategoryId: 6,
+        name: 'S22526',
+        depth: 2,
+        parentMoodleCategoryId: 1,
+      };
+
+      em.findOneOrFail.mockResolvedValueOnce(mockUser);
+      em.find.mockResolvedValueOnce([
+        { role: UserRole.CHAIRPERSON, moodleCategory: semesterCategory },
+      ]);
+
+      const result = await service.GetDeanEligibleCategories('user-1');
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return results sorted alphabetically by name', async () => {
+      em.findOneOrFail.mockResolvedValueOnce(mockUser);
+      em.find
+        .mockResolvedValueOnce([
+          { role: UserRole.CHAIRPERSON, moodleCategory: programBSCS },
+          { role: UserRole.CHAIRPERSON, moodleCategory: programBSCE },
+        ])
+        .mockResolvedValueOnce([deptCCS, deptCOE]);
+
+      const result = await service.GetDeanEligibleCategories('user-1');
+
+      expect(result).toEqual([
+        { moodleCategoryId: 8, name: 'CCS' },
+        { moodleCategoryId: 12, name: 'COE' },
+      ]);
     });
   });
 });

--- a/src/modules/admin/services/admin.service.spec.ts
+++ b/src/modules/admin/services/admin.service.spec.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { EntityManager } from '@mikro-orm/postgresql';
 import { Test, TestingModule } from '@nestjs/testing';
+import { Enrollment } from 'src/entities/enrollment.entity';
 import { User } from 'src/entities/user.entity';
 import { UserRole } from 'src/modules/auth/roles.enum';
 import { AdminService } from './admin.service';
@@ -198,6 +199,144 @@ describe('AdminService', () => {
         totalPages: 0,
         currentPage: 1,
       },
+    });
+  });
+
+  describe('GetUserDetail', () => {
+    const mockUser = {
+      id: 'user-1',
+      userName: 'jdoe',
+      fullName: 'John Doe',
+      firstName: 'John',
+      lastName: 'Doe',
+      moodleUserId: 123,
+      userProfilePicture: 'https://example.com/pic.jpg',
+      roles: [UserRole.FACULTY],
+      isActive: true,
+      lastLoginAt: new Date('2026-03-01'),
+      createdAt: new Date('2026-01-01'),
+      campus: { id: 'campus-1', code: 'UCMN', name: 'Main' },
+      department: { id: 'dept-1', code: 'CCS', name: 'Computer Studies' },
+      program: { id: 'prog-1', code: 'BSCS', name: 'Computer Science' },
+    } as unknown as User;
+
+    it('should return full user detail with enrollments and institutional roles', async () => {
+      const mockEnrollments = [
+        {
+          id: 'enr-1',
+          role: 'student',
+          isActive: true,
+          course: {
+            id: 'course-1',
+            shortname: 'CS101',
+            fullname: 'Intro to CS',
+          },
+        },
+      ];
+      const mockInstitutionalRoles = [
+        {
+          id: 'ir-1',
+          role: UserRole.DEAN,
+          source: 'manual',
+          moodleCategory: {
+            moodleCategoryId: 8,
+            name: 'CCS',
+            depth: 3,
+          },
+        },
+      ];
+
+      em.findOneOrFail.mockResolvedValueOnce(mockUser);
+      em.find
+        .mockResolvedValueOnce(mockEnrollments)
+        .mockResolvedValueOnce(mockInstitutionalRoles);
+
+      const result = await service.GetUserDetail('user-1');
+
+      expect(result.id).toBe('user-1');
+      expect(result.userName).toBe('jdoe');
+      expect(result.fullName).toBe('John Doe');
+      expect(result.enrollments).toHaveLength(1);
+      expect(result.enrollments[0]).toEqual({
+        id: 'enr-1',
+        role: 'student',
+        isActive: true,
+        course: {
+          id: 'course-1',
+          shortname: 'CS101',
+          fullname: 'Intro to CS',
+        },
+      });
+      expect(result.institutionalRoles).toHaveLength(1);
+      expect(result.institutionalRoles[0]).toEqual({
+        id: 'ir-1',
+        role: UserRole.DEAN,
+        source: 'manual',
+        category: {
+          moodleCategoryId: 8,
+          name: 'CCS',
+          depth: 3,
+        },
+      });
+    });
+
+    it('should use fullName fallback when fullName is null', async () => {
+      const userWithoutFullName = {
+        ...mockUser,
+        fullName: null,
+        firstName: 'Anna',
+        lastName: 'Smith',
+      } as unknown as User;
+
+      em.findOneOrFail.mockResolvedValueOnce(userWithoutFullName);
+      em.find.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      const result = await service.GetUserDetail('user-1');
+
+      expect(result.fullName).toBe('Anna Smith');
+    });
+
+    it('should return empty arrays when user has no enrollments or roles', async () => {
+      em.findOneOrFail.mockResolvedValueOnce(mockUser);
+      em.find.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      const result = await service.GetUserDetail('user-1');
+
+      expect(result.enrollments).toEqual([]);
+      expect(result.institutionalRoles).toEqual([]);
+      expect(result.id).toBe('user-1');
+    });
+
+    it('should throw NotFoundException when user does not exist', async () => {
+      em.findOneOrFail.mockImplementationOnce(
+        (
+          _entity: unknown,
+          _filter: unknown,
+          opts: { failHandler: () => Error },
+        ) => {
+          throw opts.failHandler();
+        },
+      );
+
+      await expect(service.GetUserDetail('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should filter enrollments by isActive and course.isActive', async () => {
+      em.findOneOrFail.mockResolvedValueOnce(mockUser);
+      em.find.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      await service.GetUserDetail('user-1');
+
+      expect(em.find).toHaveBeenCalledWith(
+        Enrollment,
+        { user: 'user-1', isActive: true, course: { isActive: true } },
+        expect.objectContaining({
+          populate: ['course'],
+          orderBy: { timeModified: 'DESC' },
+        }),
+      );
     });
   });
 

--- a/src/modules/admin/services/admin.service.ts
+++ b/src/modules/admin/services/admin.service.ts
@@ -18,6 +18,7 @@ import { RemoveInstitutionalRoleDto } from '../dto/requests/remove-institutional
 import { ListUsersQueryDto } from '../dto/requests/list-users-query.dto';
 import { AdminUserItemResponseDto } from '../dto/responses/admin-user-item.response.dto';
 import { AdminUserListResponseDto } from '../dto/responses/admin-user-list.response.dto';
+import { DeanEligibleCategoryResponseDto } from '../dto/responses/dean-eligible-category.response.dto';
 
 @Injectable()
 export class AdminService {
@@ -137,6 +138,71 @@ export class AdminService {
     return {
       message: `Removed ${dto.role} at category ${moodleCategory.name}`,
     };
+  }
+
+  async GetDeanEligibleCategories(
+    userId: string,
+  ): Promise<DeanEligibleCategoryResponseDto[]> {
+    await this.em.findOneOrFail(
+      User,
+      { id: userId },
+      {
+        failHandler: () => new NotFoundException('User not found'),
+      },
+    );
+
+    const roles = await this.em.find(
+      UserInstitutionalRole,
+      { user: userId },
+      { populate: ['moodleCategory'] },
+    );
+
+    // Build DEAN exclusion set
+    const deanCategoryIds = new Set(
+      roles
+        .filter(
+          (ir) => ir.role === (UserRole.DEAN as string) && ir.moodleCategory,
+        )
+        .map((ir) => ir.moodleCategory.moodleCategoryId),
+    );
+
+    // Filter explicit CHAIRPERSON candidates, skip null moodleCategory
+    const chairpersonRoles = roles.filter(
+      (ir) => ir.role === (UserRole.CHAIRPERSON as string) && ir.moodleCategory,
+    );
+
+    // Separate depth-3 (direct) and depth-4 (need parent resolution)
+    const candidates = new Map<number, MoodleCategory>();
+    const parentIdsToFetch = new Set<number>();
+
+    for (const ir of chairpersonRoles) {
+      const cat = ir.moodleCategory;
+      if (cat.depth === 3) {
+        candidates.set(cat.moodleCategoryId, cat);
+      } else if (cat.depth === 4) {
+        parentIdsToFetch.add(cat.parentMoodleCategoryId);
+      }
+    }
+
+    // Batch-fetch depth-4 parents, only accept depth-3 (department level)
+    if (parentIdsToFetch.size > 0) {
+      const parentCategories = await this.em.find(MoodleCategory, {
+        moodleCategoryId: { $in: [...parentIdsToFetch] },
+        depth: 3,
+      });
+      for (const parent of parentCategories) {
+        candidates.set(parent.moodleCategoryId, parent);
+      }
+    }
+
+    // Exclude categories where user is already DEAN
+    for (const deanCatId of deanCategoryIds) {
+      candidates.delete(deanCatId);
+    }
+
+    return [...candidates.values()]
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((cat) => DeanEligibleCategoryResponseDto.Map(cat));
   }
 
   private async refreshUserRoles(user: User) {

--- a/src/modules/admin/services/admin.service.ts
+++ b/src/modules/admin/services/admin.service.ts
@@ -17,6 +17,7 @@ import { AssignInstitutionalRoleDto } from '../dto/requests/assign-institutional
 import { RemoveInstitutionalRoleDto } from '../dto/requests/remove-institutional-role.request.dto';
 import { ListUsersQueryDto } from '../dto/requests/list-users-query.dto';
 import { AdminUserItemResponseDto } from '../dto/responses/admin-user-item.response.dto';
+import { AdminUserDetailResponseDto } from '../dto/responses/admin-user-detail.response.dto';
 import { AdminUserListResponseDto } from '../dto/responses/admin-user-list.response.dto';
 import { DeanEligibleCategoryResponseDto } from '../dto/responses/dean-eligible-category.response.dto';
 
@@ -50,6 +51,39 @@ export class AdminService {
         currentPage: page,
       },
     };
+  }
+
+  async GetUserDetail(userId: string): Promise<AdminUserDetailResponseDto> {
+    const user = await this.em.findOneOrFail(
+      User,
+      { id: userId },
+      {
+        populate: ['campus', 'department', 'program'],
+        failHandler: () => new NotFoundException('User not found'),
+      },
+    );
+
+    const [enrollments, institutionalRoles] = await Promise.all([
+      this.em.find(
+        Enrollment,
+        { user: userId, isActive: true, course: { isActive: true } },
+        {
+          populate: ['course'],
+          orderBy: { timeModified: 'DESC' },
+        },
+      ),
+      this.em.find(
+        UserInstitutionalRole,
+        { user: userId },
+        { populate: ['moodleCategory'] },
+      ),
+    ]);
+
+    return AdminUserDetailResponseDto.Map(
+      user,
+      enrollments,
+      institutionalRoles,
+    );
   }
 
   async AssignInstitutionalRole(dto: AssignInstitutionalRoleDto) {

--- a/src/modules/auth/dto/responses/me.response.dto.ts
+++ b/src/modules/auth/dto/responses/me.response.dto.ts
@@ -10,6 +10,8 @@ export class MeResponse {
   fullName: string;
   roles: string[];
   campus?: { id: string; name?: string; code: string };
+  program?: { id: string; name?: string; code: string };
+  department?: { id: string; name?: string; code: string };
 
   static Map(user: User): MeResponse {
     return {
@@ -23,6 +25,20 @@ export class MeResponse {
       roles: user.roles,
       campus: user.campus
         ? { id: user.campus.id, name: user.campus.name, code: user.campus.code }
+        : undefined,
+      program: user.program
+        ? {
+            id: user.program.id,
+            name: user.program.name,
+            code: user.program.code,
+          }
+        : undefined,
+      department: user.department
+        ? {
+            id: user.department.id,
+            name: user.department.name,
+            code: user.department.code,
+          }
         : undefined,
     };
   }

--- a/src/modules/common/data-loaders/user.loader.ts
+++ b/src/modules/common/data-loaders/user.loader.ts
@@ -15,7 +15,7 @@ export class UserLoader {
             id: { $in: [...userIds] },
           },
           {
-            populate: ['campus'],
+            populate: ['campus', 'program', 'department'],
           },
         );
 

--- a/src/modules/index.module.ts
+++ b/src/modules/index.module.ts
@@ -70,7 +70,10 @@ export const InfrastructureModules = [
     middleware: { mount: true },
   }),
   ScheduleModule.forRoot(),
-  BullModule.forRoot({ connection: { url: env.REDIS_URL } }),
+  BullModule.forRoot({
+    connection: { url: env.REDIS_URL },
+    prefix: `${env.REDIS_KEY_PREFIX}bull`,
+  }),
   ThrottlerModule.forRootAsync({
     useFactory: () => ({
       throttlers: [

--- a/src/modules/moodle/services/moodle-enrollment-sync.service.ts
+++ b/src/modules/moodle/services/moodle-enrollment-sync.service.ts
@@ -3,6 +3,8 @@ import { Injectable, Logger } from '@nestjs/common';
 import pLimit from 'p-limit';
 import { Course } from 'src/entities/course.entity';
 import { Section } from 'src/entities/section.entity';
+import { Campus } from 'src/entities/campus.entity';
+import { Program } from 'src/entities/program.entity';
 import { env } from 'src/configurations/env';
 import { Enrollment } from 'src/entities/enrollment.entity';
 import { User } from 'src/entities/user.entity';
@@ -80,6 +82,14 @@ export class EnrollmentSyncService {
           `Failed to sync enrollments for course ${course.moodleCourseId}: ${message}`,
         );
       }
+    }
+
+    // Phase 4: Backfill campus, program, department on users
+    try {
+      await this.backfillUserScopes(fetched);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Failed to backfill user scopes: ${message}`);
     }
 
     const inserted = Math.max(0, enrollmentUpserts - enrollmentCountBefore);
@@ -312,5 +322,116 @@ export class EnrollmentSyncService {
     }
 
     return sectionMap;
+  }
+
+  private async backfillUserScopes(
+    fetched: { course: Course; remoteUsers: MoodleEnrolledUser[] }[],
+  ) {
+    // 1. Build user → program mapping (most course enrollments wins)
+    const userProgramCounts = new Map<number, Map<string, number>>();
+
+    for (const { course, remoteUsers } of fetched) {
+      const programRef = course.program;
+      if (!programRef) continue;
+      const programId =
+        typeof programRef === 'object' ? programRef.id : String(programRef);
+
+      for (const remote of remoteUsers) {
+        if (remote.id == null || !remote.username) continue;
+        if (!userProgramCounts.has(remote.id)) {
+          userProgramCounts.set(remote.id, new Map());
+        }
+        const counts = userProgramCounts.get(remote.id)!;
+        counts.set(programId, (counts.get(programId) ?? 0) + 1);
+      }
+    }
+
+    // 2. Resolve primary program per user (most enrollments, alphabetical ID tiebreaker)
+    const userPrimaryProgram = new Map<number, string>();
+    for (const [moodleUserId, counts] of userProgramCounts) {
+      let maxCount = 0;
+      let primaryProgramId = '';
+      for (const [programId, count] of counts) {
+        if (
+          count > maxCount ||
+          (count === maxCount && programId < primaryProgramId)
+        ) {
+          maxCount = count;
+          primaryProgramId = programId;
+        }
+      }
+      if (primaryProgramId) {
+        userPrimaryProgram.set(moodleUserId, primaryProgramId);
+      }
+    }
+
+    if (userPrimaryProgram.size === 0) return;
+
+    // 3. Load programs with department → semester → campus chain
+    const programIds = [...new Set(userPrimaryProgram.values())];
+    const fork = this.em.fork();
+    const programs = await fork.find(
+      Program,
+      { id: { $in: programIds } },
+      {
+        populate: [
+          'department',
+          'department.semester',
+          'department.semester.campus',
+        ],
+      },
+    );
+    const programMap = new Map(programs.map((p) => [p.id, p]));
+
+    // 4. Load all campuses for username prefix lookup
+    const campuses = await fork.find(Campus, {});
+    const campusByCode = new Map(campuses.map((c) => [c.code, c]));
+
+    // 5. Load users and update scope fields
+    const moodleUserIds = [...userPrimaryProgram.keys()];
+    const users = await fork.find(User, {
+      moodleUserId: { $in: moodleUserIds },
+    });
+
+    let updated = 0;
+    for (const user of users) {
+      if (!user.moodleUserId) continue;
+
+      const programId = userPrimaryProgram.get(user.moodleUserId);
+      if (!programId) continue;
+
+      const program = programMap.get(programId);
+      if (!program) continue;
+
+      const changed =
+        user.program?.id !== program.id ||
+        user.department?.id !== program.department?.id;
+
+      user.program = program;
+
+      if (program.department) {
+        user.department = program.department;
+      }
+
+      // Campus: username prefix first, fallback to category hierarchy
+      const parts = user.userName.split('-');
+      const campusCode = parts.length > 1 ? parts[0].toUpperCase() : null;
+      const campus = campusCode ? campusByCode.get(campusCode) : undefined;
+      const resolvedCampus = campus ?? program.department?.semester?.campus;
+      const campusChanged = user.campus?.id !== resolvedCampus?.id;
+
+      if (resolvedCampus) {
+        user.campus = resolvedCampus;
+      }
+
+      if (changed || campusChanged) {
+        updated++;
+      }
+    }
+
+    if (updated > 0) {
+      await fork.flush();
+      this.logger.log(`Backfilled scope fields for ${updated} users`);
+    }
   }
 }

--- a/src/modules/moodle/services/moodle-enrollment-sync.service.ts
+++ b/src/modules/moodle/services/moodle-enrollment-sync.service.ts
@@ -8,6 +8,7 @@ import { Program } from 'src/entities/program.entity';
 import { env } from 'src/configurations/env';
 import { Enrollment } from 'src/entities/enrollment.entity';
 import { User } from 'src/entities/user.entity';
+import { UserInstitutionalRole } from 'src/entities/user-institutional-role.entity';
 import { MoodleEnrolledUser } from '../lib/moodle.types';
 import { MoodleService } from '../moodle.service';
 import UnitOfWork from 'src/modules/common/unit-of-work';
@@ -90,6 +91,14 @@ export class EnrollmentSyncService {
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       this.logger.error(`Failed to backfill user scopes: ${message}`);
+    }
+
+    // Phase 5: Derive user roles from enrollments + institutional roles
+    try {
+      await this.deriveUserRoles(fetched);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Failed to derive user roles: ${message}`);
     }
 
     const inserted = Math.max(0, enrollmentUpserts - enrollmentCountBefore);
@@ -432,6 +441,81 @@ export class EnrollmentSyncService {
     if (updated > 0) {
       await fork.flush();
       this.logger.log(`Backfilled scope fields for ${updated} users`);
+    }
+  }
+
+  private async deriveUserRoles(
+    fetched: { course: Course; remoteUsers: MoodleEnrolledUser[] }[],
+  ) {
+    // 1. Collect unique moodleUserIds from ALL remote users (no program filter)
+    const uniqueMoodleUserIds = new Set<number>();
+    for (const { remoteUsers } of fetched) {
+      for (const remote of remoteUsers) {
+        if (remote.id == null || !remote.username) continue;
+        uniqueMoodleUserIds.add(remote.id);
+      }
+    }
+
+    if (uniqueMoodleUserIds.size === 0) return;
+
+    const moodleUserIds = [...uniqueMoodleUserIds];
+    const fork = this.em.fork();
+
+    // 2. Batch-load users by Moodle ID
+    const users = await fork.find(User, {
+      moodleUserId: { $in: moodleUserIds },
+    });
+
+    if (users.length === 0) return;
+
+    // 3. Extract entity UUIDs for relational queries
+    const userUuids = users.map((u) => u.id);
+
+    // 4. Batch-load active enrollments and institutional roles
+    const [allEnrollments, allInstRoles] = await Promise.all([
+      fork.find(Enrollment, { user: { $in: userUuids }, isActive: true }),
+      fork.find(UserInstitutionalRole, { user: { $in: userUuids } }),
+    ]);
+
+    // 5. Group by user ID
+    const groupByUserId = <T extends { user: User | string }>(
+      items: T[],
+    ): Map<string, T[]> => {
+      const map = new Map<string, T[]>();
+      for (const item of items) {
+        const userId =
+          typeof item.user === 'object' ? item.user.id : String(item.user);
+        if (!map.has(userId)) {
+          map.set(userId, []);
+        }
+        map.get(userId)!.push(item);
+      }
+      return map;
+    };
+
+    const enrollmentsByUser = groupByUserId(allEnrollments);
+    const instRolesByUser = groupByUserId(allInstRoles);
+
+    // 6. Derive roles for each user
+    let updated = 0;
+    for (const user of users) {
+      const oldRoles = [...user.roles].sort();
+      const userEnrollments = enrollmentsByUser.get(user.id) ?? [];
+      const userInstRoles = instRolesByUser.get(user.id) ?? [];
+
+      user.updateRolesFromEnrollments(userEnrollments, userInstRoles);
+
+      const newRoles = [...user.roles].sort();
+      if (JSON.stringify(oldRoles) !== JSON.stringify(newRoles)) {
+        updated++;
+      }
+    }
+
+    // 7. Always flush — change counter is for logging only
+    await fork.flush();
+
+    if (updated > 0) {
+      this.logger.log(`Derived roles for ${updated} users`);
     }
   }
 }

--- a/src/modules/moodle/services/moodle-user-hydration.service.ts
+++ b/src/modules/moodle/services/moodle-user-hydration.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { User } from 'src/entities/user.entity';
 import { Program } from 'src/entities/program.entity';
+import { Campus } from 'src/entities/campus.entity';
 import { Course } from 'src/entities/course.entity';
 import { Enrollment } from 'src/entities/enrollment.entity';
 import { Section } from 'src/entities/section.entity';
@@ -249,6 +250,10 @@ export class MoodleUserHydrationService {
       const institutionalRoles = await tx.find(UserInstitutionalRole, { user });
 
       user.updateRolesFromEnrollments(activeEnrollments, institutionalRoles);
+
+      // Derive scope fields: program, department, campus
+      await this.deriveUserScopes(user, programCache, remoteCourses, tx);
+
       tx.persist(user);
     });
 
@@ -256,6 +261,69 @@ export class MoodleUserHydrationService {
     this.logger.log(
       `Finished hydrating courses for Moodle user ${moodleUserId} in ${duration}ms`,
     );
+  }
+
+  private async deriveUserScopes(
+    user: User,
+    programCache: Map<number, Program>,
+    remoteCourses: MoodleCourse[],
+    tx: EntityManager,
+  ) {
+    // Pick primary program: most course enrollments
+    const programCounts = new Map<
+      string,
+      { program: Program; count: number }
+    >();
+    for (const rc of remoteCourses) {
+      const program = programCache.get(rc.category);
+      if (!program) continue;
+      const entry = programCounts.get(program.id);
+      if (entry) {
+        entry.count++;
+      } else {
+        programCounts.set(program.id, { program, count: 1 });
+      }
+    }
+
+    let primaryProgram: Program | undefined;
+    let maxCount = 0;
+    for (const { program, count } of programCounts.values()) {
+      if (
+        count > maxCount ||
+        (count === maxCount &&
+          (!primaryProgram || program.id < primaryProgram.id))
+      ) {
+        maxCount = count;
+        primaryProgram = program;
+      }
+    }
+
+    if (!primaryProgram) return;
+
+    // Populate department → semester → campus chain
+    await tx.populate(primaryProgram, [
+      'department',
+      'department.semester',
+      'department.semester.campus',
+    ]);
+
+    user.program = primaryProgram;
+
+    if (primaryProgram.department) {
+      user.department = primaryProgram.department;
+    }
+
+    // Campus: username prefix first, fallback to category hierarchy
+    const parts = user.userName.split('-');
+    const campusCode = parts.length > 1 ? parts[0].toUpperCase() : null;
+    const campus = campusCode
+      ? await tx.findOne(Campus, { code: campusCode })
+      : null;
+    if (campus) {
+      user.campus = campus;
+    } else if (primaryProgram.department?.semester?.campus) {
+      user.campus = primaryProgram.department.semester.campus;
+    }
   }
 
   private async resolveInstitutionalRoles(

--- a/src/modules/questionnaires/dto/requests/create-version-from-template-request.dto.ts
+++ b/src/modules/questionnaires/dto/requests/create-version-from-template-request.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUUID } from 'class-validator';
+
+export class CreateVersionFromTemplateRequest {
+  @ApiProperty({ description: 'UUID of the version to copy the schema from' })
+  @IsUUID()
+  sourceVersionId!: string;
+}

--- a/src/modules/questionnaires/questionnaire.controller.spec.ts
+++ b/src/modules/questionnaires/questionnaire.controller.spec.ts
@@ -40,6 +40,7 @@ describe('QuestionnaireController - checkSubmission', () => {
             getVersionsByType: jest.fn(),
             createQuestionnaire: jest.fn(),
             CreateVersion: jest.fn(),
+            CreateVersionFromTemplate: jest.fn(),
             GetLatestActiveVersion: jest.fn(),
             PublishVersion: jest.fn(),
             DeprecateVersion: jest.fn(),
@@ -208,6 +209,7 @@ describe('QuestionnaireController - IngestCsv', () => {
             getVersionsByType: jest.fn(),
             createQuestionnaire: jest.fn(),
             CreateVersion: jest.fn(),
+            CreateVersionFromTemplate: jest.fn(),
             GetLatestActiveVersion: jest.fn(),
             PublishVersion: jest.fn(),
             DeprecateVersion: jest.fn(),
@@ -461,6 +463,7 @@ describe('QuestionnaireController - wipeSubmissions', () => {
             getVersionsByType: jest.fn(),
             createQuestionnaire: jest.fn(),
             CreateVersion: jest.fn(),
+            CreateVersionFromTemplate: jest.fn(),
             GetLatestActiveVersion: jest.fn(),
             PublishVersion: jest.fn(),
             DeprecateVersion: jest.fn(),
@@ -595,6 +598,7 @@ describe('QuestionnaireController - GetCsvTemplate', () => {
             getVersionsByType: jest.fn(),
             createQuestionnaire: jest.fn(),
             CreateVersion: jest.fn(),
+            CreateVersionFromTemplate: jest.fn(),
             GetLatestActiveVersion: jest.fn(),
             PublishVersion: jest.fn(),
             DeprecateVersion: jest.fn(),
@@ -773,6 +777,7 @@ describe('QuestionnaireController - mutation DTO mapping', () => {
             getVersionsByType: jest.fn(),
             createQuestionnaire: jest.fn(),
             CreateVersion: jest.fn(),
+            CreateVersionFromTemplate: jest.fn(),
             GetLatestActiveVersion: jest.fn(),
             PublishVersion: jest.fn(),
             DeprecateVersion: jest.fn(),
@@ -977,5 +982,35 @@ describe('QuestionnaireController - mutation DTO mapping', () => {
     expect(questionnaireService.ArchiveQuestionnaire).toHaveBeenCalledWith(
       'q-1',
     );
+  });
+
+  it('createVersionFromTemplate should call service and return QuestionnaireVersionDetailResponse', async () => {
+    questionnaireService.CreateVersionFromTemplate.mockResolvedValue(
+      mockVersion as any,
+    );
+
+    const result = await controller.createVersionFromTemplate('q-1', {
+      sourceVersionId: 'src-v1',
+    });
+
+    expect(questionnaireService.CreateVersionFromTemplate).toHaveBeenCalledWith(
+      'q-1',
+      'src-v1',
+    );
+    expect(result).toEqual({
+      id: 'v-1',
+      questionnaireId: 'q-1',
+      questionnaireTitle: 'Test Questionnaire',
+      questionnaireType: mockTypeEntity,
+      versionNumber: 1,
+      status: QuestionnaireStatus.DRAFT,
+      isActive: false,
+      schemaSnapshot: mockSchema,
+      publishedAt: undefined,
+      createdAt: mockVersion.createdAt,
+      updatedAt: mockVersion.updatedAt,
+    });
+    expect(result).not.toHaveProperty('deletedAt');
+    expect(result).not.toHaveProperty('questionnaire');
   });
 });

--- a/src/modules/questionnaires/questionnaire.controller.ts
+++ b/src/modules/questionnaires/questionnaire.controller.ts
@@ -26,6 +26,7 @@ import {
 import type { Response } from 'express';
 import { CreateQuestionnaireRequest } from './dto/requests/create-questionnaire-request.dto';
 import { CreateVersionRequest } from './dto/requests/create-version-request.dto';
+import { CreateVersionFromTemplateRequest } from './dto/requests/create-version-from-template-request.dto';
 import { UpdateVersionRequest } from './dto/requests/update-version-request.dto';
 import { UpdateQuestionnaireTitleRequest } from './dto/requests/update-questionnaire-title-request.dto';
 import { SubmitQuestionnaireRequest } from './dto/requests/submit-questionnaire-request.dto';
@@ -166,6 +167,40 @@ export class QuestionnaireController {
     const version = await this.questionnaireService.CreateVersion(
       id,
       data.schema,
+    );
+    return QuestionnaireVersionDetailResponse.Map(version);
+  }
+
+  @Post(':id/versions/from-template')
+  @UseJwtGuard(UserRole.SUPER_ADMIN, UserRole.ADMIN)
+  @ApiOperation({
+    summary: 'Create a new version from an existing version template',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Version created from template',
+    type: QuestionnaireVersionDetailResponse,
+  })
+  @ApiResponse({
+    status: 400,
+    description:
+      'Source version is a draft, archived questionnaire, or belongs to different questionnaire',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Questionnaire or source version not found',
+  })
+  @ApiResponse({
+    status: 409,
+    description: 'Draft version already exists',
+  })
+  async createVersionFromTemplate(
+    @Param('id') id: string,
+    @Body() data: CreateVersionFromTemplateRequest,
+  ): Promise<QuestionnaireVersionDetailResponse> {
+    const version = await this.questionnaireService.CreateVersionFromTemplate(
+      id,
+      data.sourceVersionId,
     );
     return QuestionnaireVersionDetailResponse.Map(version);
   }

--- a/src/modules/questionnaires/services/__tests__/questionnaire-types.spec.ts
+++ b/src/modules/questionnaires/services/__tests__/questionnaire-types.spec.ts
@@ -21,6 +21,7 @@ import { CacheService } from '../../../common/cache/cache.service';
 import { AnalysisService } from '../../../analysis/analysis.service';
 import { CurrentUserService } from '../../../common/cls/current-user.service';
 import { QuestionnaireStatus } from '../../lib/questionnaire.types';
+import UnitOfWork from '../../../common/unit-of-work';
 
 describe('QuestionnaireService - Types & Versions', () => {
   let service: QuestionnaireService;
@@ -121,6 +122,18 @@ describe('QuestionnaireService - Types & Versions', () => {
           provide: CurrentUserService,
           useValue: {
             getOrFail: jest.fn().mockReturnValue({ id: 'test-user' }),
+          },
+        },
+        {
+          provide: UnitOfWork,
+          useValue: {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+            runInTransaction: jest.fn().mockImplementation((cb) =>
+              cb({
+                findOne: jest.fn(),
+                create: jest.fn(),
+              }),
+            ),
           },
         },
         {

--- a/src/modules/questionnaires/services/__tests__/questionnaire-types.spec.ts
+++ b/src/modules/questionnaires/services/__tests__/questionnaire-types.spec.ts
@@ -127,13 +127,20 @@ describe('QuestionnaireService - Types & Versions', () => {
         {
           provide: UnitOfWork,
           useValue: {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-            runInTransaction: jest.fn().mockImplementation((cb) =>
-              cb({
-                findOne: jest.fn(),
-                create: jest.fn(),
-              }),
-            ),
+            runInTransaction: jest
+              .fn()
+              .mockImplementation(
+                (
+                  cb: (em: {
+                    findOne: jest.Mock;
+                    create: jest.Mock;
+                  }) => unknown,
+                ) =>
+                  cb({
+                    findOne: jest.fn(),
+                    create: jest.fn(),
+                  }),
+              ),
           },
         },
         {

--- a/src/modules/questionnaires/services/questionnaire.service.spec.ts
+++ b/src/modules/questionnaires/services/questionnaire.service.spec.ts
@@ -35,6 +35,7 @@ import {
   EnrollmentRole,
   QuestionnaireStatus,
 } from '../lib/questionnaire.types';
+import UnitOfWork from '../../common/unit-of-work';
 
 describe('QuestionnaireService', () => {
   let service: QuestionnaireService;
@@ -49,6 +50,7 @@ describe('QuestionnaireService', () => {
     invalidateNamespace: jest.Mock;
     invalidateNamespaces: jest.Mock;
   };
+  let mockTransactionalEm: { findOne: jest.Mock; create: jest.Mock };
 
   const RESPONDENT_ID = 'r1';
   const FACULTY_ID = 'f1';
@@ -73,6 +75,16 @@ describe('QuestionnaireService', () => {
       find: jest.fn(),
     };
     const enrollmentRepoMock = createMockRepo();
+
+    mockTransactionalEm = {
+      findOne: jest.fn(),
+      create: jest
+        .fn()
+        .mockImplementation((_: unknown, data: Record<string, unknown>) => ({
+          ...data,
+          id: 'new-version-id',
+        })),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -148,6 +160,15 @@ describe('QuestionnaireService', () => {
           provide: AnalysisService,
           useValue: {
             EnqueueJob: jest.fn().mockResolvedValue('mock-job-id'),
+          },
+        },
+        {
+          provide: UnitOfWork,
+          useValue: {
+            runInTransaction: jest
+              .fn()
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+              .mockImplementation((cb) => cb(mockTransactionalEm)),
           },
         },
         {
@@ -551,6 +572,184 @@ describe('QuestionnaireService', () => {
 
       expect(result.versionNumber).toBe(1);
       expect(result.status).toBe(QuestionnaireStatus.DRAFT);
+    });
+  });
+
+  describe('CreateVersionFromTemplate', () => {
+    const QUESTIONNAIRE_ID = 'q1';
+    const SOURCE_VERSION_ID = 'src-v1';
+
+    const mockQuestionnaire = {
+      id: QUESTIONNAIRE_ID,
+      status: QuestionnaireStatus.ACTIVE,
+      type: { id: 't1', name: 'Type 1', code: 'T1' },
+    };
+
+    const mockSourceVersion = {
+      id: SOURCE_VERSION_ID,
+      status: QuestionnaireStatus.ACTIVE,
+      questionnaire: { id: QUESTIONNAIRE_ID },
+      schemaSnapshot: {
+        meta: {
+          questionnaireType: 'FACULTY_IN_CLASSROOM',
+          scoringModel: 'SECTION_WEIGHTED',
+          version: 1,
+          maxScore: 5,
+        },
+        sections: [
+          {
+            id: 'sec1',
+            title: 'Section 1',
+            questions: [{ id: 'q1', text: 'How?', required: true }],
+          },
+        ],
+      },
+    };
+
+    const mockLatestVersion = { versionNumber: 2 };
+
+    it('should create a new draft version from template (happy path)', async () => {
+      mockTransactionalEm.findOne
+        .mockResolvedValueOnce(mockQuestionnaire) // questionnaire
+        .mockResolvedValueOnce(mockSourceVersion) // source version
+        .mockResolvedValueOnce(null) // no existing draft
+        .mockResolvedValueOnce(mockLatestVersion); // latest version
+
+      versionRepo.findOne.mockResolvedValue({
+        id: 'new-version-id',
+        versionNumber: 3,
+        status: QuestionnaireStatus.DRAFT,
+        questionnaire: mockQuestionnaire,
+      } as any);
+
+      const result = await service.CreateVersionFromTemplate(
+        QUESTIONNAIRE_ID,
+        SOURCE_VERSION_ID,
+      );
+
+      expect(result.id).toBe('new-version-id');
+      expect(mockTransactionalEm.create).toHaveBeenCalledWith(
+        QuestionnaireVersion,
+        expect.objectContaining({
+          questionnaire: mockQuestionnaire,
+          versionNumber: 3,
+          status: QuestionnaireStatus.DRAFT,
+          isActive: false,
+        }),
+      );
+
+      // Verify deep copy — schema should match but not be the same reference
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const createCall = mockTransactionalEm.create.mock.calls[0][1];
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(createCall.schemaSnapshot).toEqual(
+        mockSourceVersion.schemaSnapshot,
+      );
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(createCall.schemaSnapshot).not.toBe(
+        mockSourceVersion.schemaSnapshot,
+      );
+
+      // Verify cache invalidation
+      expect(cacheService.invalidateNamespace).toHaveBeenCalledWith(
+        CacheNamespace.QUESTIONNAIRE_VERSIONS,
+      );
+
+      // Verify post-commit re-fetch
+      expect(versionRepo.findOne).toHaveBeenCalledWith('new-version-id', {
+        populate: ['questionnaire.type'],
+      });
+    });
+
+    it('should throw NotFoundException if questionnaire not found', async () => {
+      mockTransactionalEm.findOne.mockResolvedValueOnce(null);
+
+      await expect(
+        service.CreateVersionFromTemplate(QUESTIONNAIRE_ID, SOURCE_VERSION_ID),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw BadRequestException if questionnaire is archived', async () => {
+      mockTransactionalEm.findOne.mockResolvedValueOnce({
+        ...mockQuestionnaire,
+        status: QuestionnaireStatus.ARCHIVED,
+      });
+
+      await expect(
+        service.CreateVersionFromTemplate(QUESTIONNAIRE_ID, SOURCE_VERSION_ID),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw NotFoundException if source version not found', async () => {
+      mockTransactionalEm.findOne
+        .mockResolvedValueOnce(mockQuestionnaire)
+        .mockResolvedValueOnce(null);
+
+      await expect(
+        service.CreateVersionFromTemplate(QUESTIONNAIRE_ID, SOURCE_VERSION_ID),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw BadRequestException if source belongs to different questionnaire', async () => {
+      mockTransactionalEm.findOne
+        .mockResolvedValueOnce(mockQuestionnaire)
+        .mockResolvedValueOnce({
+          ...mockSourceVersion,
+          questionnaire: { id: 'different-q' },
+        });
+
+      await expect(
+        service.CreateVersionFromTemplate(QUESTIONNAIRE_ID, SOURCE_VERSION_ID),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException if source is a DRAFT', async () => {
+      mockTransactionalEm.findOne
+        .mockResolvedValueOnce(mockQuestionnaire)
+        .mockResolvedValueOnce({
+          ...mockSourceVersion,
+          status: QuestionnaireStatus.DRAFT,
+        });
+
+      await expect(
+        service.CreateVersionFromTemplate(QUESTIONNAIRE_ID, SOURCE_VERSION_ID),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw ConflictException if draft already exists', async () => {
+      mockTransactionalEm.findOne
+        .mockResolvedValueOnce(mockQuestionnaire)
+        .mockResolvedValueOnce(mockSourceVersion)
+        .mockResolvedValueOnce({ id: 'existing-draft' }); // existing draft
+
+      await expect(
+        service.CreateVersionFromTemplate(QUESTIONNAIRE_ID, SOURCE_VERSION_ID),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('should use versionNumber 1 when no versions exist', async () => {
+      mockTransactionalEm.findOne
+        .mockResolvedValueOnce(mockQuestionnaire)
+        .mockResolvedValueOnce(mockSourceVersion)
+        .mockResolvedValueOnce(null) // no existing draft
+        .mockResolvedValueOnce(null); // no latest version
+
+      versionRepo.findOne.mockResolvedValue({
+        id: 'new-version-id',
+        versionNumber: 1,
+        status: QuestionnaireStatus.DRAFT,
+        questionnaire: mockQuestionnaire,
+      } as any);
+
+      await service.CreateVersionFromTemplate(
+        QUESTIONNAIRE_ID,
+        SOURCE_VERSION_ID,
+      );
+
+      expect(mockTransactionalEm.create).toHaveBeenCalledWith(
+        QuestionnaireVersion,
+        expect.objectContaining({ versionNumber: 1 }),
+      );
     });
   });
 

--- a/src/modules/questionnaires/services/questionnaire.service.ts
+++ b/src/modules/questionnaires/services/questionnaire.service.ts
@@ -51,6 +51,7 @@ import { QueueName } from 'src/configurations/common/queue-names';
 import { CurrentUserService } from '../../common/cls/current-user.service';
 import { env } from 'src/configurations/env';
 import { cleanText } from '../utils/clean-text';
+import UnitOfWork from '../../common/unit-of-work';
 
 @Injectable()
 export class QuestionnaireService {
@@ -75,6 +76,7 @@ export class QuestionnaireService {
     private readonly cacheService: CacheService,
     private readonly analysisService: AnalysisService,
     private readonly currentUserService: CurrentUserService,
+    private readonly unitOfWork: UnitOfWork,
   ) {}
 
   async getQuestionnaireTypes(): Promise<QuestionnaireTypeResponse[]> {
@@ -287,6 +289,106 @@ export class QuestionnaireService {
     await this.cacheService.invalidateNamespace(
       CacheNamespace.QUESTIONNAIRE_VERSIONS,
     );
+    return version;
+  }
+
+  async CreateVersionFromTemplate(
+    questionnaireId: string,
+    sourceVersionId: string,
+  ) {
+    const versionId = await this.unitOfWork.runInTransaction(async (em) => {
+      // 1. Fetch questionnaire
+      const questionnaire = await em.findOne(Questionnaire, questionnaireId, {
+        populate: ['type'],
+      });
+      if (!questionnaire) {
+        throw new NotFoundException(
+          `Questionnaire with ID ${questionnaireId} not found.`,
+        );
+      }
+
+      if (questionnaire.status === QuestionnaireStatus.ARCHIVED) {
+        throw new BadRequestException(
+          'Cannot create a version for an archived questionnaire.',
+        );
+      }
+
+      // 2. Fetch source version
+      const sourceVersion = await em.findOne(
+        QuestionnaireVersion,
+        sourceVersionId,
+        { populate: ['questionnaire'] },
+      );
+      if (!sourceVersion) {
+        throw new NotFoundException(
+          `Source version with ID ${sourceVersionId} not found.`,
+        );
+      }
+
+      // 3. Validate source belongs to same questionnaire
+      if (sourceVersion.questionnaire.id !== questionnaireId) {
+        throw new BadRequestException(
+          'Source version does not belong to this questionnaire.',
+        );
+      }
+
+      // 4. Validate source is not DRAFT
+      if (sourceVersion.status === QuestionnaireStatus.DRAFT) {
+        throw new BadRequestException(
+          'Cannot use a draft version as a template.',
+        );
+      }
+
+      // 5. Enforce single-draft rule
+      const existingDraft = await em.findOne(QuestionnaireVersion, {
+        questionnaire,
+        status: QuestionnaireStatus.DRAFT,
+      });
+      if (existingDraft) {
+        throw new ConflictException(
+          'A draft version already exists for this questionnaire.',
+        );
+      }
+
+      // 6. Determine next version number
+      const latestVersion = await em.findOne(
+        QuestionnaireVersion,
+        { questionnaire },
+        { orderBy: { versionNumber: 'DESC' } },
+      );
+      const nextVersionNumber = latestVersion
+        ? latestVersion.versionNumber + 1
+        : 1;
+
+      // 7. Deep-copy schema
+      const schema = structuredClone(sourceVersion.schemaSnapshot);
+
+      // 8. Create new version
+      const version = em.create(QuestionnaireVersion, {
+        questionnaire,
+        versionNumber: nextVersionNumber,
+        schemaSnapshot: schema,
+        status: QuestionnaireStatus.DRAFT,
+        isActive: false,
+      });
+
+      return version.id;
+    });
+
+    // Cache invalidation AFTER transaction commits
+    await this.cacheService.invalidateNamespace(
+      CacheNamespace.QUESTIONNAIRE_VERSIONS,
+    );
+
+    // Re-fetch with full populate for the response mapper
+    const version = await this.versionRepo.findOne(versionId, {
+      populate: ['questionnaire.type'],
+    });
+    if (!version) {
+      throw new NotFoundException(
+        `Version ${versionId} not found after creation.`,
+      );
+    }
     return version;
   }
 


### PR DESCRIPTION
## Summary
- fix: docker url binding (#245, #246) — `a7a33c4`
- **FAC-107** fix: populate campus, program, and department on users during sync and login (#251, #252) — `34ea155`
- **FAC-108** fix: BullMQ queue prefix isolation (#254, #255) — `8b96bef`
- **FAC-109** feat: streamline dean promotion flow (#256, #257) — `f7e894d`
- **FAC-110** feat: admin endpoint for detailed info about a single user (#258, #259) — `d3a6bde`
- **FAC-111** feat: questionnaire version templating (#261, #262) — `f1d1597`
- **FAC-112** feat: derive user roles during Moodle sync (#265, #266) — `7175375`

## Commits
Cherry-picked from `staging` (7 commits)

## Test plan
- [x] Run `npm run test` — all unit tests pass
- [x] Run `npm run test:e2e` — E2E tests pass
- [x] Apply pending migrations (`npx mikro-orm migration:up`)
- [x] Smoke-test Moodle sync — verify users get roles, campus, program, and department populated
- [x] Verify dean promotion endpoint works end-to-end
- [x] Confirm questionnaire versioning creates new versions correctly
- [x] Validate BullMQ queues use environment-specific prefixes