### PR TITLE
FAC-113 feat: scoped program filters for analytics attention endpoint

### DIFF
--- a/src/modules/analytics/analytics.controller.spec.ts
+++ b/src/modules/analytics/analytics.controller.spec.ts
@@ -77,7 +77,7 @@ describe('AnalyticsController', () => {
   });
 
   describe('GetAttentionList', () => {
-    it('should delegate to AnalyticsService with semesterId', async () => {
+    it('should delegate to AnalyticsService with semesterId and query', async () => {
       const query = {
         semesterId: '550e8400-e29b-41d4-a716-446655440000',
       };
@@ -91,6 +91,27 @@ describe('AnalyticsController', () => {
 
       expect(mockAnalyticsService.GetAttentionList).toHaveBeenCalledWith(
         query.semesterId,
+        query,
+      );
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('should pass programCode to service', async () => {
+      const query = {
+        semesterId: '550e8400-e29b-41d4-a716-446655440000',
+        programCode: 'BSCS',
+      };
+      const expectedResult = {
+        items: [],
+        lastRefreshedAt: null,
+      };
+      mockAnalyticsService.GetAttentionList.mockResolvedValue(expectedResult);
+
+      const result = await controller.GetAttentionList(query);
+
+      expect(mockAnalyticsService.GetAttentionList).toHaveBeenCalledWith(
+        query.semesterId,
+        query,
       );
       expect(result).toEqual(expectedResult);
     });

--- a/src/modules/analytics/analytics.controller.ts
+++ b/src/modules/analytics/analytics.controller.ts
@@ -47,11 +47,12 @@ export class AnalyticsController {
     summary: 'Get attention list — faculty flagged for review',
   })
   @ApiQuery({ name: 'semesterId', required: true, type: String })
+  @ApiQuery({ name: 'programCode', required: false, type: String })
   @ApiResponse({ status: 200, type: AttentionListResponseDto })
   async GetAttentionList(
     @Query() query: AttentionListQueryDto,
   ): Promise<AttentionListResponseDto> {
-    return this.analyticsService.GetAttentionList(query.semesterId);
+    return this.analyticsService.GetAttentionList(query.semesterId, query);
   }
 
   @Get('trends')

--- a/src/modules/analytics/analytics.service.spec.ts
+++ b/src/modules/analytics/analytics.service.spec.ts
@@ -8,7 +8,10 @@ import { QuestionnaireSchemaSnapshot } from 'src/modules/questionnaires/lib/ques
 describe('AnalyticsService', () => {
   let service: AnalyticsService;
   let mockExecute: jest.Mock;
-  let mockScopeResolver: { ResolveDepartmentIds: jest.Mock };
+  let mockScopeResolver: {
+    ResolveDepartmentIds: jest.Mock;
+    ResolveProgramCodes: jest.Mock;
+  };
 
   beforeEach(async () => {
     mockExecute = jest.fn().mockResolvedValue([]);
@@ -20,6 +23,7 @@ describe('AnalyticsService', () => {
 
     mockScopeResolver = {
       ResolveDepartmentIds: jest.fn().mockResolvedValue(null),
+      ResolveProgramCodes: jest.fn().mockResolvedValue(null),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -183,7 +187,9 @@ describe('AnalyticsService', () => {
         // GetLastRefreshedAt
         .mockResolvedValueOnce([]);
 
-      const result = await service.GetAttentionList(semesterId);
+      const result = await service.GetAttentionList(semesterId, {
+        semesterId,
+      });
 
       expect(result.items).toHaveLength(1);
       expect(result.items[0].flags).toHaveLength(1);
@@ -211,7 +217,9 @@ describe('AnalyticsService', () => {
         // GetLastRefreshedAt
         .mockResolvedValueOnce([]);
 
-      const result = await service.GetAttentionList(semesterId);
+      const result = await service.GetAttentionList(semesterId, {
+        semesterId,
+      });
 
       expect(result.items).toHaveLength(1);
       expect(result.items[0].flags[0].type).toBe('quant_qual_gap');
@@ -236,7 +244,9 @@ describe('AnalyticsService', () => {
         // GetLastRefreshedAt
         .mockResolvedValueOnce([]);
 
-      const result = await service.GetAttentionList(semesterId);
+      const result = await service.GetAttentionList(semesterId, {
+        semesterId,
+      });
 
       expect(result.items).toHaveLength(1);
       expect(result.items[0].flags[0].type).toBe('low_coverage');
@@ -274,7 +284,9 @@ describe('AnalyticsService', () => {
         // GetLastRefreshedAt
         .mockResolvedValueOnce([]);
 
-      const result = await service.GetAttentionList(semesterId);
+      const result = await service.GetAttentionList(semesterId, {
+        semesterId,
+      });
 
       // Same faculty should be deduplicated into one item with 2 flags
       expect(result.items).toHaveLength(1);
@@ -295,12 +307,164 @@ describe('AnalyticsService', () => {
         // GetLastRefreshedAt
         .mockResolvedValueOnce([]);
 
-      const result = await service.GetAttentionList(semesterId);
+      const result = await service.GetAttentionList(semesterId, {
+        semesterId,
+      });
 
       expect(result.items).toHaveLength(0);
       expect(mockScopeResolver.ResolveDepartmentIds).toHaveBeenCalledWith(
         semesterId,
       );
+    });
+
+    it('should filter attention by programCode on quant-qual gap and low coverage', async () => {
+      // Super admin: no dept scope call
+      mockExecute
+        // Declining trends
+        .mockResolvedValueOnce([])
+        // Quant-qual gap
+        .mockResolvedValueOnce([
+          {
+            faculty_id: 'f1',
+            faculty_name: 'Dr. Smith',
+            department_code: 'CCS',
+            avg_normalized_score: 90,
+            positive_count: 5,
+            analyzed_count: 20,
+            divergence: 0.65,
+          },
+        ])
+        // Low coverage
+        .mockResolvedValueOnce([])
+        // GetLastRefreshedAt
+        .mockResolvedValueOnce([]);
+
+      await service.GetAttentionList(semesterId, {
+        semesterId,
+        programCode: 'BSCS',
+      });
+
+      // Quant-qual gap (call[1]) should include program_code_snapshot filter
+      const qqCall = mockExecute.mock.calls[1] as [string, unknown[]];
+      expect(qqCall[0]).toContain('program_code_snapshot = ?');
+      expect(qqCall[1]).toContain('BSCS');
+
+      // Low coverage (call[2]) should include program_code_snapshot filter
+      const lcCall = mockExecute.mock.calls[2] as [string, unknown[]];
+      expect(lcCall[0]).toContain('program_code_snapshot = ?');
+      expect(lcCall[1]).toContain('BSCS');
+    });
+
+    it('should join-back declining trends to stats MV when programCode provided', async () => {
+      mockExecute
+        // Declining trends (with join)
+        .mockResolvedValueOnce([])
+        // Quant-qual gap
+        .mockResolvedValueOnce([])
+        // Low coverage
+        .mockResolvedValueOnce([])
+        // GetLastRefreshedAt
+        .mockResolvedValueOnce([]);
+
+      await service.GetAttentionList(semesterId, {
+        semesterId,
+        programCode: 'BSCS',
+      });
+
+      // Declining trends (call[0]) should JOIN mv_faculty_semester_stats
+      const dtCall = mockExecute.mock.calls[0] as [string, unknown[]];
+      expect(dtCall[0]).toContain('JOIN mv_faculty_semester_stats');
+      expect(dtCall[0]).toContain('s.semester_id = ?');
+      expect(dtCall[0]).toContain('s.program_code_snapshot = ?');
+    });
+
+    it('should correctly expand params when both programCode and deptCodes are present', async () => {
+      mockScopeResolver.ResolveDepartmentIds.mockResolvedValue(['dept-uuid-1']);
+      // ResolveDepartmentCodes
+      mockExecute
+        .mockResolvedValueOnce([{ code: 'CCS' }])
+        // Declining trends
+        .mockResolvedValueOnce([])
+        // Quant-qual gap
+        .mockResolvedValueOnce([])
+        // Low coverage
+        .mockResolvedValueOnce([])
+        // GetLastRefreshedAt
+        .mockResolvedValueOnce([]);
+
+      await service.GetAttentionList(semesterId, {
+        semesterId,
+        programCode: 'BSCS',
+      });
+
+      // Declining trends (call[1]): params should be
+      // [minSemesters, minR2, minR2, semesterId, programCode, deptCodes]
+      const dtCall = mockExecute.mock.calls[1] as [string, unknown[]];
+      expect(dtCall[0]).toContain('JOIN mv_faculty_semester_stats');
+      expect(dtCall[0]).toContain('t.department_code_snapshot = ANY(?)');
+      expect(dtCall[1]).toEqual([3, 0.5, 0.5, semesterId, 'BSCS', '{CCS}']);
+    });
+
+    it('should return empty when programCode is out of scope for chairperson', async () => {
+      mockScopeResolver.ResolveProgramCodes.mockResolvedValue(['BSCS']);
+      mockScopeResolver.ResolveDepartmentIds.mockResolvedValue(['dept-1']);
+      // ResolveDepartmentCodes
+      mockExecute.mockResolvedValueOnce([{ code: 'CCS' }]);
+      // GetLastRefreshedAt
+      mockExecute.mockResolvedValueOnce([
+        { value: '2026-03-22T10:00:00.000Z' },
+      ]);
+
+      const result = await service.GetAttentionList(semesterId, {
+        semesterId,
+        programCode: 'BSIT',
+      });
+
+      expect(result.items).toEqual([]);
+      expect(result.lastRefreshedAt).toBe('2026-03-22T10:00:00.000Z');
+    });
+
+    it('should allow any programCode for super admin (unrestricted)', async () => {
+      mockScopeResolver.ResolveProgramCodes.mockResolvedValue(null);
+      mockExecute
+        // Declining trends
+        .mockResolvedValueOnce([])
+        // Quant-qual gap
+        .mockResolvedValueOnce([])
+        // Low coverage
+        .mockResolvedValueOnce([])
+        // GetLastRefreshedAt
+        .mockResolvedValueOnce([]);
+
+      const result = await service.GetAttentionList(semesterId, {
+        semesterId,
+        programCode: 'ANY_CODE',
+      });
+
+      // All 3 sub-queries should have been called (4 total with GetLastRefreshedAt)
+      expect(mockExecute).toHaveBeenCalledTimes(4);
+      expect(result.items).toHaveLength(0);
+    });
+  });
+
+  describe('GetDepartmentOverview — scope validation', () => {
+    const semesterId = '550e8400-e29b-41d4-a716-446655440000';
+
+    it('should return empty overview when programCode is out of scope', async () => {
+      mockScopeResolver.ResolveProgramCodes.mockResolvedValue(['BSCS']);
+      // GetLastRefreshedAt
+      mockExecute.mockResolvedValueOnce([
+        { value: '2026-03-22T10:00:00.000Z' },
+      ]);
+
+      const result = await service.GetDepartmentOverview(semesterId, {
+        semesterId,
+        programCode: 'BSIT',
+      });
+
+      expect(result.summary.totalFaculty).toBe(0);
+      expect(result.faculty).toEqual([]);
+      expect(result.lastRefreshedAt).toBe('2026-03-22T10:00:00.000Z');
     });
   });
 

--- a/src/modules/analytics/analytics.service.ts
+++ b/src/modules/analytics/analytics.service.ts
@@ -12,6 +12,7 @@ import {
 import { getInterpretation } from './lib/interpretation.util';
 import {
   DepartmentOverviewQueryDto,
+  AttentionListQueryDto,
   FacultyTrendsQueryDto,
   FacultyReportQueryDto,
   FacultyReportCommentsQueryDto,
@@ -75,6 +76,22 @@ export class AnalyticsService {
     query: DepartmentOverviewQueryDto,
   ): Promise<DepartmentOverviewResponseDto> {
     const deptCodes = await this.ResolveDepartmentCodes(semesterId);
+
+    if (!(await this.IsProgramCodeInScope(semesterId, query.programCode))) {
+      const lastRefreshedAt = await this.GetLastRefreshedAt();
+      return {
+        summary: {
+          totalFaculty: 0,
+          totalSubmissions: 0,
+          totalAnalyzed: 0,
+          positiveCount: 0,
+          negativeCount: 0,
+          neutralCount: 0,
+        },
+        faculty: [],
+        lastRefreshedAt,
+      };
+    }
 
     const prevSemRows: { id: string }[] = await this.em.execute(
       `SELECT s2.id FROM semester s2
@@ -171,8 +188,15 @@ export class AnalyticsService {
 
   async GetAttentionList(
     semesterId: string,
+    query: AttentionListQueryDto,
   ): Promise<AttentionListResponseDto> {
+    const { programCode } = query;
     const deptCodes = await this.ResolveDepartmentCodes(semesterId);
+
+    if (!(await this.IsProgramCodeInScope(semesterId, programCode))) {
+      const lastRefreshedAt = await this.GetLastRefreshedAt();
+      return { items: [], lastRefreshedAt };
+    }
 
     const flagMap = new Map<
       string,
@@ -211,25 +235,49 @@ export class AnalyticsService {
         ATTENTION_THRESHOLDS.MIN_R2_FOR_TREND,
       ];
 
+      let fromClause: string;
+      let colPrefix: string;
+      let deptPrefix: string;
+      let extraFilters = '';
+
+      if (programCode) {
+        fromClause = `FROM mv_faculty_trends t
+          JOIN mv_faculty_semester_stats s
+            ON s.faculty_id = t.faculty_id
+            AND s.department_code_snapshot = t.department_code_snapshot`;
+        colPrefix = 't.';
+        deptPrefix = 't.';
+        extraFilters = ` AND s.semester_id = ? AND s.program_code_snapshot = ?`;
+        params.push(semesterId, programCode);
+      } else {
+        fromClause = 'FROM mv_faculty_trends';
+        colPrefix = '';
+        deptPrefix = '';
+      }
+
       let deptFilter = '';
       if (deptCodes !== null) {
-        deptFilter = ` AND department_code_snapshot = ANY(?)`;
+        deptFilter = ` AND ${deptPrefix}department_code_snapshot = ANY(?)`;
         params.push(pgArray(deptCodes));
       }
 
       const sql = `
-        SELECT faculty_id, faculty_name_snapshot AS faculty_name,
-               department_code_snapshot AS department_code,
-               score_slope, score_r2, sentiment_slope, sentiment_r2
-        FROM mv_faculty_trends
-        WHERE semester_count >= ?
+        SELECT ${colPrefix}faculty_id,
+               ${colPrefix}faculty_name_snapshot AS faculty_name,
+               ${colPrefix}department_code_snapshot AS department_code,
+               ${colPrefix}score_slope, ${colPrefix}score_r2,
+               ${colPrefix}sentiment_slope, ${colPrefix}sentiment_r2
+        ${fromClause}
+        WHERE ${colPrefix}semester_count >= ?
           AND (
-            (score_slope < 0 AND score_r2 >= ?)
-            OR (sentiment_slope < 0 AND sentiment_r2 >= ?)
-          )${deptFilter}
+            (${colPrefix}score_slope < 0 AND ${colPrefix}score_r2 >= ?)
+            OR (${colPrefix}sentiment_slope < 0 AND ${colPrefix}sentiment_r2 >= ?)
+          )${extraFilters}${deptFilter}
       `;
 
-      // The R2 threshold is used twice in the SQL
+      // PARAM CONTRACT: params[0] = minSemesters, params[1] = minR2 (used twice in SQL).
+      // params[2..] = optional filters pushed conditionally: [semesterId?, programCode?, deptCodes?].
+      // Expansion duplicates minR2 for the two R2 comparisons, then appends the rest.
       const sqlParams = [params[0], params[1], params[1], ...params.slice(2)];
       const rows = await this.em.execute(sql, sqlParams);
 
@@ -287,6 +335,12 @@ export class AnalyticsService {
         params.push(pgArray(deptCodes));
       }
 
+      let programFilter = '';
+      if (programCode) {
+        programFilter = ` AND program_code_snapshot = ?`;
+        params.push(programCode);
+      }
+
       const sql = `
         SELECT faculty_id, faculty_name_snapshot AS faculty_name,
                department_code_snapshot AS department_code,
@@ -295,7 +349,7 @@ export class AnalyticsService {
         FROM mv_faculty_semester_stats
         WHERE semester_id = ?
           AND analyzed_count >= ?
-          AND ABS((avg_normalized_score / 100.0) - (positive_count::float / analyzed_count)) > ?${deptFilter}
+          AND ABS((avg_normalized_score / 100.0) - (positive_count::float / analyzed_count)) > ?${deptFilter}${programFilter}
       `;
 
       const rows = await this.em.execute(sql, params);
@@ -333,6 +387,12 @@ export class AnalyticsService {
         params.push(pgArray(deptCodes));
       }
 
+      let programFilter = '';
+      if (programCode) {
+        programFilter = ` AND program_code_snapshot = ?`;
+        params.push(programCode);
+      }
+
       const sql = `
         SELECT faculty_id, faculty_name_snapshot AS faculty_name,
                department_code_snapshot AS department_code,
@@ -340,7 +400,7 @@ export class AnalyticsService {
         FROM mv_faculty_semester_stats
         WHERE semester_id = ?
           AND submission_count > 0
-          AND (analyzed_count::float / submission_count) < 0.5${deptFilter}
+          AND (analyzed_count::float / submission_count) < 0.5${deptFilter}${programFilter}
       `;
 
       const rows = await this.em.execute(sql, params);
@@ -996,6 +1056,17 @@ export class AnalyticsService {
     );
 
     return rows[0]?.value ?? null;
+  }
+
+  private async IsProgramCodeInScope(
+    semesterId: string,
+    programCode?: string,
+  ): Promise<boolean> {
+    if (!programCode) return true;
+    const allowedCodes =
+      await this.scopeResolver.ResolveProgramCodes(semesterId);
+    if (allowedCodes === null) return true;
+    return allowedCodes.includes(programCode);
   }
 
   private async ResolveDepartmentCodes(

--- a/src/modules/analytics/dto/analytics-query.dto.ts
+++ b/src/modules/analytics/dto/analytics-query.dto.ts
@@ -8,8 +8,9 @@ import {
   IsInt,
   Min,
   Max,
+  MaxLength,
 } from 'class-validator';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 
 export class DepartmentOverviewQueryDto {
   @ApiProperty({ description: 'Semester UUID to query analytics for' })
@@ -19,7 +20,12 @@ export class DepartmentOverviewQueryDto {
   @ApiPropertyOptional({
     description: 'Optional program code filter',
   })
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? value.trim() : value,
+  )
   @IsString()
+  @IsNotEmpty()
+  @MaxLength(20)
   @IsOptional()
   programCode?: string;
 }
@@ -28,6 +34,16 @@ export class AttentionListQueryDto {
   @ApiProperty({ description: 'Semester UUID to query analytics for' })
   @IsUUID()
   semesterId!: string;
+
+  @ApiPropertyOptional({ description: 'Optional program code filter' })
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? value.trim() : value,
+  )
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(20)
+  @IsOptional()
+  programCode?: string;
 }
 
 export class FacultyTrendsQueryDto {

--- a/src/modules/common/services/scope-resolver.service.spec.ts
+++ b/src/modules/common/services/scope-resolver.service.spec.ts
@@ -192,4 +192,78 @@ describe('ScopeResolverService', () => {
     expect(result).toBeNull();
     expect(em.find).not.toHaveBeenCalled();
   });
+
+  // ─── ResolveProgramCodes ─────────────────────────────────────────
+
+  describe('ResolveProgramCodes', () => {
+    it('should return null for SUPER_ADMIN', async () => {
+      const user = createUser([UserRole.SUPER_ADMIN]);
+      currentUserService.getOrFail.mockReturnValue(user);
+
+      const result = await service.ResolveProgramCodes(semesterId);
+
+      expect(result).toBeNull();
+      expect(em.find).not.toHaveBeenCalled();
+    });
+
+    it('should return null for DEAN', async () => {
+      const user = createUser([UserRole.DEAN]);
+      currentUserService.getOrFail.mockReturnValue(user);
+
+      const result = await service.ResolveProgramCodes(semesterId);
+
+      expect(result).toBeNull();
+      expect(em.find).not.toHaveBeenCalled();
+    });
+
+    it('should return specific codes for CHAIRPERSON', async () => {
+      const user = createUser([UserRole.CHAIRPERSON]);
+      currentUserService.getOrFail.mockReturnValue(user);
+
+      em.find
+        .mockResolvedValueOnce([{ moodleCategory: { name: 'BSCS' } }])
+        .mockResolvedValueOnce([{ id: 'prog-1', code: 'BSCS' }]);
+
+      const result = await service.ResolveProgramCodes(semesterId);
+
+      expect(result).toEqual(['BSCS']);
+    });
+
+    it('should return empty array when chairperson has no institutional roles', async () => {
+      const user = createUser([UserRole.CHAIRPERSON]);
+      currentUserService.getOrFail.mockReturnValue(user);
+
+      em.find.mockResolvedValueOnce([]);
+
+      const result = await service.ResolveProgramCodes(semesterId);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should throw ForbiddenException for unsupported roles', async () => {
+      const user = createUser([UserRole.STUDENT]);
+      currentUserService.getOrFail.mockReturnValue(user);
+
+      await expect(service.ResolveProgramCodes(semesterId)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+  });
+
+  // ─── ResolveProgramIds (regression after refactor) ───────────────
+
+  describe('ResolveProgramIds', () => {
+    it('should still return UUIDs after refactor', async () => {
+      const user = createUser([UserRole.CHAIRPERSON]);
+      currentUserService.getOrFail.mockReturnValue(user);
+
+      em.find
+        .mockResolvedValueOnce([{ moodleCategory: { name: 'BSCS' } }])
+        .mockResolvedValueOnce([{ id: 'prog-uuid-1', code: 'BSCS' }]);
+
+      const result = await service.ResolveProgramIds(semesterId);
+
+      expect(result).toEqual(['prog-uuid-1']);
+    });
+  });
 });

--- a/src/modules/common/services/scope-resolver.service.ts
+++ b/src/modules/common/services/scope-resolver.service.ts
@@ -54,31 +54,66 @@ export class ScopeResolverService {
     }
 
     if (user.roles.includes(UserRole.CHAIRPERSON)) {
-      const institutionalRoles = await this.em.find(
-        UserInstitutionalRole,
-        { user: user.id, role: UserRole.CHAIRPERSON },
-        { populate: ['moodleCategory'] },
+      const programs = await this.resolveChairpersonPrograms(
+        user.id,
+        semesterId,
       );
-
-      const programCodes = institutionalRoles
-        .filter((ir) => ir.moodleCategory?.name != null)
-        .map((ir) => ir.moodleCategory.name);
-
-      if (programCodes.length === 0) {
-        return [];
-      }
-
-      const programs = await this.em.find(Program, {
-        code: { $in: programCodes },
-        department: { semester: semesterId },
-      });
-
       return programs.map((p) => p.id);
     }
 
     throw new ForbiddenException(
       'User does not have a role with scope access.',
     );
+  }
+
+  /**
+   * Resolves program codes the user is allowed to access for a given semester.
+   * Returns `null` for unrestricted access (super admin, dean), or `string[]` of program codes.
+   */
+  async ResolveProgramCodes(semesterId: string): Promise<string[] | null> {
+    const user = this.currentUserService.getOrFail();
+
+    if (user.roles.includes(UserRole.SUPER_ADMIN)) {
+      return null;
+    }
+
+    if (user.roles.includes(UserRole.DEAN)) {
+      return null;
+    }
+
+    if (user.roles.includes(UserRole.CHAIRPERSON)) {
+      const programs = await this.resolveChairpersonPrograms(
+        user.id,
+        semesterId,
+      );
+      return programs.map((p) => p.code);
+    }
+
+    throw new ForbiddenException(
+      'User does not have a role with scope access.',
+    );
+  }
+
+  private async resolveChairpersonPrograms(
+    userId: string,
+    semesterId: string,
+  ): Promise<Program[]> {
+    const institutionalRoles = await this.em.find(
+      UserInstitutionalRole,
+      { user: userId, role: UserRole.CHAIRPERSON },
+      { populate: ['moodleCategory'] },
+    );
+
+    const programCodes = institutionalRoles
+      .filter((ir) => ir.moodleCategory?.name != null)
+      .map((ir) => ir.moodleCategory.name);
+
+    if (programCodes.length === 0) return [];
+
+    return this.em.find(Program, {
+      code: { $in: programCodes },
+      department: { semester: semesterId },
+    });
   }
 
   private async resolveDeanDepartments(

--- a/src/modules/curriculum/services/curriculum.service.spec.ts
+++ b/src/modules/curriculum/services/curriculum.service.spec.ts
@@ -11,7 +11,10 @@ import { ScopeResolverService } from 'src/modules/common/services/scope-resolver
 describe('CurriculumService', () => {
   let service: CurriculumService;
   let em: { findOne: jest.Mock; findAndCount: jest.Mock };
-  let scopeResolver: { ResolveDepartmentIds: jest.Mock };
+  let scopeResolver: {
+    ResolveDepartmentIds: jest.Mock;
+    ResolveProgramIds: jest.Mock;
+  };
 
   const semesterId = 'semester-1';
   const deptId = 'dept-1';
@@ -27,6 +30,7 @@ describe('CurriculumService', () => {
 
     scopeResolver = {
       ResolveDepartmentIds: jest.fn(),
+      ResolveProgramIds: jest.fn().mockResolvedValue(null),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -407,9 +411,58 @@ describe('CurriculumService', () => {
         expect.objectContaining({ limit: 15, offset: 15 }),
       );
     });
+
+    it('should narrow programs for chairperson to assigned programs only', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
+      scopeResolver.ResolveProgramIds.mockResolvedValue([programId]);
+      em.findAndCount.mockResolvedValue([
+        [
+          {
+            id: programId,
+            code: 'BSCS',
+            name: 'BS Computer Science',
+            department: { id: deptId },
+          },
+        ],
+        1,
+      ]);
+
+      const result = await service.ListPrograms({ semesterId });
+
+      expect(result.data).toHaveLength(1);
+      const findCall = em.findAndCount.mock.calls[0] as unknown[];
+      expect(findCall[1]).toEqual(
+        expect.objectContaining({ id: { $in: [programId] } }),
+      );
+    });
+
+    it('should not narrow programs for dean (unrestricted)', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
+      scopeResolver.ResolveProgramIds.mockResolvedValue(null);
+      em.findAndCount.mockResolvedValue([[], 0]);
+
+      await service.ListPrograms({ semesterId });
+
+      const findCall = em.findAndCount.mock.calls[0] as unknown[];
+      expect(findCall[1]).not.toHaveProperty('id');
+    });
+
+    it('should return empty page when chairperson has no assigned programs', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
+      scopeResolver.ResolveProgramIds.mockResolvedValue([]);
+
+      const result = await service.ListPrograms({ semesterId });
+
+      expect(result.data).toEqual([]);
+      expect(result.meta).toEqual(emptyMeta());
+      expect(em.findAndCount).not.toHaveBeenCalled();
+    });
   });
 
-  // ─── ListCourses ──────────────────────────────────────────────────
+  // ─── ListCourses ─────────────────────────────��────────────────────
 
   describe('ListCourses', () => {
     it('should throw 400 when neither programId nor departmentId is provided', async () => {

--- a/src/modules/curriculum/services/curriculum.service.ts
+++ b/src/modules/curriculum/services/curriculum.service.ts
@@ -114,6 +114,16 @@ export class CurriculumService {
       department: departmentFilter,
     };
 
+    const programIds = await this.scopeResolverService.ResolveProgramIds(
+      query.semesterId,
+    );
+    if (programIds !== null) {
+      if (programIds.length === 0) {
+        return this.BuildEmptyPage(page, limit);
+      }
+      filter.id = { $in: programIds };
+    }
+
     this.ApplySearchFilter(filter, query.search, ['code', 'name']);
 
     const [programs, totalItems] = await this.em.findAndCount(Program, filter, {


### PR DESCRIPTION
## Summary

- Add optional `programCode` query param to `GET /analytics/attention`, filtering all 3 attention sub-queries (declining trends via join-back, quant-qual gap, low coverage)
- Add `ResolveProgramCodes()` to `ScopeResolverService` with shared `resolveChairpersonPrograms()` helper
- Add scope validation for `programCode` on both `GET /analytics/overview` and `GET /analytics/attention`
- Fix chairperson program-level scoping in `GET /curriculum/programs` (was returning all department programs instead of only assigned ones)
- Harden `programCode` DTO validation (`@IsNotEmpty()`, `@MaxLength(20)`, `@Transform(trim)`)

## Test plan

- [x] 103 unit tests passing (13 new)
- [ ] As dean: `GET /analytics/attention?semesterId=X&programCode=BSCS` returns filtered results
- [ ] As dean: `GET /analytics/attention?semesterId=X` returns unfiltered results (no regression)
- [ ] As chairperson (BSCS only): `GET /analytics/attention?semesterId=X&programCode=BSIT` returns empty
- [ ] As chairperson: `GET /curriculum/programs?semesterId=X` returns only assigned programs
- [ ] Any role: `GET /analytics/attention?semesterId=X&programCode=` returns 400

Closes #268