### PR TITLE
FAC-122 fix: harden sentiment pipeline against hallucinated submission IDs

### DIFF
--- a/src/modules/analysis/processors/sentiment.processor.spec.ts
+++ b/src/modules/analysis/processors/sentiment.processor.spec.ts
@@ -206,6 +206,78 @@ describe('SentimentProcessor', () => {
       );
     });
 
+    it('should drop unknown submissionId and persist valid majority', async () => {
+      const mockRun = { id: 'r1', status: RunStatus.PENDING };
+      mockFork.findOneOrFail.mockResolvedValue(mockRun);
+      const warnSpy = jest
+        .spyOn(processor['logger'], 'warn')
+        .mockImplementation();
+
+      const job = createMockBatchJob();
+      const result: BatchAnalysisResultMessage = {
+        jobId: '550e8400-e29b-41d4-a716-446655440000',
+        version: '1.0',
+        status: 'completed',
+        results: [
+          { submissionId: 's1', positive: 0.8, neutral: 0.1, negative: 0.1 },
+          { submissionId: 's2', positive: 0.1, neutral: 0.1, negative: 0.8 },
+          {
+            submissionId: 'unknown-id',
+            positive: 0.5,
+            neutral: 0.3,
+            negative: 0.2,
+          },
+        ],
+        completedAt: '2026-03-12T00:01:00.000Z',
+      };
+
+      await processor.Persist(job, result);
+
+      expect(mockFork.create).toHaveBeenCalledTimes(2);
+      expect(mockOrchestrator.OnSentimentComplete).toHaveBeenCalledWith('p1');
+      expect(mockOrchestrator.OnStageFailed).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Dropped 1 of 3'),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('r1'));
+    });
+
+    it('should call OnStageFailed and skip fork when all submissionIds are unknown', async () => {
+      const job = createMockBatchJob();
+      const result: BatchAnalysisResultMessage = {
+        jobId: '550e8400-e29b-41d4-a716-446655440000',
+        version: '1.0',
+        status: 'completed',
+        results: [
+          {
+            submissionId: 'bad-id-1',
+            positive: 0.8,
+            neutral: 0.1,
+            negative: 0.1,
+          },
+          {
+            submissionId: 'bad-id-2',
+            positive: 0.1,
+            neutral: 0.1,
+            negative: 0.8,
+          },
+        ],
+        completedAt: '2026-03-12T00:01:00.000Z',
+      };
+
+      await processor.Persist(job, result);
+
+      expect(mockOrchestrator.OnStageFailed).toHaveBeenCalledWith(
+        'p1',
+        'sentiment_analysis',
+        expect.stringContaining('All sentiment results were dropped'),
+      );
+      expect(mockFork.create).not.toHaveBeenCalled();
+      expect(mockOrchestrator.OnSentimentComplete).not.toHaveBeenCalled();
+      expect(mockFork.findOneOrFail).not.toHaveBeenCalled();
+    });
+
     it('should skip invalid result items and continue', async () => {
       const mockRun = { id: 'r1', status: RunStatus.PENDING };
       mockFork.findOneOrFail.mockResolvedValue(mockRun);

--- a/src/modules/analysis/processors/sentiment.processor.ts
+++ b/src/modules/analysis/processors/sentiment.processor.ts
@@ -61,10 +61,31 @@ export class SentimentProcessor extends RunPodBatchProcessor {
       return;
     }
 
+    const dispatchedIds = new Set(job.data.items.map((i) => i.submissionId));
+    const validResults = result.results.filter((raw) => {
+      if (typeof raw !== 'object' || raw === null) return false;
+      const id = (raw as { submissionId?: unknown }).submissionId;
+      return typeof id === 'string' && dispatchedIds.has(id);
+    });
+    const droppedCount = result.results.length - validResults.length;
+    if (droppedCount > 0) {
+      this.logger.warn(
+        `Dropped ${droppedCount} of ${result.results.length} sentiment results for run ${runId} (unknown submissionIds)`,
+      );
+    }
+    if (validResults.length === 0) {
+      await this.orchestrator.OnStageFailed(
+        pipelineId,
+        'sentiment_analysis',
+        'All sentiment results were dropped (no valid submissionIds)',
+      );
+      return;
+    }
+
     const fork = this.em.fork();
     const run = await fork.findOneOrFail(SentimentRun, runId);
 
-    for (const raw of result.results) {
+    for (const raw of validResults) {
       const parsed = sentimentResultItemSchema.safeParse(raw);
       if (!parsed.success) {
         this.logger.error(


### PR DESCRIPTION
Closes #292

## Summary

- Adds a defensive ID filter in `SentimentProcessor.Persist` that validates worker results against the dispatched `job.data.items` set before any DB work begins
- Drops results with unknown `submissionIds`, emits a single warn with the dropped count, and fails the stage only when the entire batch was dropped
- The `em.fork()` call is never reached when all results are invalid — no orphaned DB state
- Root cause: GPT-4o-mini drifted one nibble in a UUID (`a970160c-…` → `a970160b-…`), which sailed through `fork.getReference()` (lazy ref, no existence check) and triggered a Postgres FK violation at flush time, rolling back the entire 189-row batch

## Test plan

- [x] `npx jest sentiment.processor` — 8 tests passing (2 new: single-drop majority, all-unknown fail-stage)
- [x] Existing happy-path test unchanged and green
- [x] No regressions in other processor tests