### PR TITLE
FAC-122.1 chore: add @Index expression metadata for soft-delete partial indexes

### DIFF
--- a/src/entities/questionnaire-type.entity.ts
+++ b/src/entities/questionnaire-type.entity.ts
@@ -2,6 +2,11 @@ import { Entity, Property, Index } from '@mikro-orm/core';
 import { CustomBaseEntity } from './base.entity';
 import { QuestionnaireTypeRepository } from '../repositories/questionnaire-type.repository';
 
+@Index({
+  name: 'questionnaire_type_code_unique',
+  expression:
+    'create unique index "questionnaire_type_code_unique" on "questionnaire_type" ("code") where "deleted_at" is null',
+})
 @Entity({ repository: () => QuestionnaireTypeRepository })
 export class QuestionnaireType extends CustomBaseEntity {
   @Property()

--- a/src/entities/report-job.entity.ts
+++ b/src/entities/report-job.entity.ts
@@ -10,6 +10,19 @@ export type ReportJobStatus =
   | 'failed'
   | 'skipped';
 
+@Index({
+  name: 'uq_report_job_pending',
+  expression: `create unique index "uq_report_job_pending" on "report_job" ("faculty_id", "semester_id", "questionnaire_type_code", "report_type") where status in ('waiting', 'active') and deleted_at is null`,
+})
+@Index({
+  name: 'report_job_batch_id_index',
+  expression:
+    'create index "report_job_batch_id_index" on "report_job" ("batch_id") where batch_id is not null',
+})
+@Index({
+  name: 'report_job_status_completed_at_index',
+  properties: ['status', 'completedAt'],
+})
 @Entity({ repository: () => ReportJobRepository })
 export class ReportJob extends CustomBaseEntity {
   @Property()
@@ -36,7 +49,7 @@ export class ReportJob extends CustomBaseEntity {
   questionnaireTypeCode: string;
 
   @Property({ nullable: true })
-  @Index()
+  // Indexed via class-level @Index (name: 'report_job_batch_id_index') — see top of file
   batchId?: string;
 
   @Property({ nullable: true })

--- a/src/entities/sentiment-result.entity.ts
+++ b/src/entities/sentiment-result.entity.ts
@@ -4,6 +4,16 @@ import { SentimentResultRepository } from '../repositories/sentiment-result.repo
 import { SentimentRun } from './sentiment-run.entity';
 import { QuestionnaireSubmission } from './questionnaire-submission.entity';
 
+@Index({
+  name: 'idx_sr_submission_processed',
+  expression:
+    'create index "idx_sr_submission_processed" on "sentiment_result" ("submission_id", "processed_at" desc) where "deleted_at" is null',
+})
+@Index({
+  name: 'sentiment_result_run_id_submission_id_unique',
+  expression:
+    'create unique index "sentiment_result_run_id_submission_id_unique" on "sentiment_result" ("run_id", "submission_id") where "deleted_at" is null',
+})
 @Entity({ repository: () => SentimentResultRepository })
 @Index({ properties: ['run'] })
 @Index({ properties: ['submission'] })

--- a/src/entities/submission-embedding.entity.ts
+++ b/src/entities/submission-embedding.entity.ts
@@ -4,6 +4,11 @@ import { CustomBaseEntity } from './base.entity';
 import { QuestionnaireSubmission } from './questionnaire-submission.entity';
 import { SubmissionEmbeddingRepository } from '../repositories/submission-embedding.repository';
 
+@Index({
+  name: 'submission_embedding_submission_id_unique',
+  expression:
+    'create unique index "submission_embedding_submission_id_unique" on "submission_embedding" ("submission_id") where "deleted_at" is null',
+})
 @Entity({ repository: () => SubmissionEmbeddingRepository })
 @Index({ properties: ['submission'] })
 export class SubmissionEmbedding extends CustomBaseEntity {

--- a/src/entities/topic-assignment.entity.ts
+++ b/src/entities/topic-assignment.entity.ts
@@ -4,6 +4,11 @@ import { TopicAssignmentRepository } from '../repositories/topic-assignment.repo
 import { Topic } from './topic.entity';
 import { QuestionnaireSubmission } from './questionnaire-submission.entity';
 
+@Index({
+  name: 'topic_assignment_topic_id_submission_id_unique',
+  expression:
+    'create unique index "topic_assignment_topic_id_submission_id_unique" on "topic_assignment" ("topic_id", "submission_id") where "deleted_at" is null',
+})
 @Entity({ repository: () => TopicAssignmentRepository })
 @Index({ properties: ['topic'] })
 @Index({ properties: ['submission'] })


### PR DESCRIPTION
## Summary

Adds class-level `@Index` expression metadata for 7 partial indexes + 1 composite index that were invisible to MikroORM's schema comparator. Stops phantom `DROP INDEX` statements in future `migration:create` runs, unblocks FAC-123/124/125, and protects the load-bearing `uq_report_job_pending` constraint that `reports.service.ts:92` catches via `UniqueConstraintViolationException`.

## Notes

**8th index (`report_job_batch_id_index`)** — not explicitly in issue #305's "7 indexes" framing. Surfaced during spec investigation as same-family drift (same migration file, same fix shape) and included to keep the fix atomic. Empirically it was already structurally matched via the property-level `@Index()` on `batchId` (did not appear in the pre-edit drift), but the class-level partial decorator is added anyway for explicit documentation and future-proofing.

**`report_job_status_completed_at_index`** — issue #305 body lists this under "partial"; it isn't. No `WHERE` clause in the original migration. Uses `properties: ['status', 'completedAt']` form (structural comparator), not `expression:` form.

**Property-level `@Index()` removal** — removed from `batchId?: string;` in `report-job.entity.ts` to resolve a `keyName` collision with the new class-level partial decorator. A one-line cross-reference comment replaces it. See Technical Decision #5 in `_bmad-output/implementation-artifacts/tech-spec-fac-122-1-partial-index-metadata.md`.

**Architectural foundation** — MikroORM's `SchemaComparator.diffIndex` (`node_modules/@mikro-orm/knex/schema/SchemaComparator.js:468-472`) compares by `keyName` only when either side has `expression` set. That means the `name:` field is what stops phantom drops; the `expression:` SQL is only used as a fallback for codegen during `migration:create --initial`. No byte-equality required, no Postgres-version coupling.

## Verification

<details>
<summary>Pre-edit baseline (<code>schema:update --dump</code>) — 7 of 8 expected index drops present</summary>

```sql
drop index "questionnaire_type_code_unique";
drop index "report_job_status_completed_at_index";
drop index "uq_report_job_pending";
drop index "submission_embedding_submission_id_unique";
drop index "topic_assignment_topic_id_submission_id_unique";
drop index "idx_sr_submission_processed";
drop index "sentiment_result_run_id_submission_id_unique";
```

Plus unrelated noise from issues #306 (`deleted_at`/`occurred_at` type drift) and #307 (`recommended_action`/`action_category`) and two CHECK constraint enum diffs. `report_job_batch_id_index` was NOT in the baseline — already structurally matched via property-level decorator.
</details>

<details>
<summary>Post-edit (<code>schema:update --dump</code>) — zero mention of any of the 8 keynames</summary>

```sql
set names 'utf8';
alter table "questionnaire_version" drop constraint if exists "questionnaire_version_status_check";
alter table "questionnaire_submission" drop constraint if exists "questionnaire_submission_respondent_role_check";
alter table "audit_log" alter column "occurred_at" drop default;
alter table "audit_log" alter column "occurred_at" type timestamptz using ("occurred_at"::timestamptz);
alter table "questionnaire_version" add constraint "questionnaire_version_status_check" check("status" in ('DRAFT', 'ACTIVE', 'DEPRECATED', 'ARCHIVED'));
alter table "report_job" alter column "deleted_at" type varchar(255) using ("deleted_at"::varchar(255));
alter table "questionnaire_submission" add constraint "questionnaire_submission_respondent_role_check" check("respondent_role" in ('STUDENT', 'DEAN', 'CHAIRPERSON'));
alter table "submission_embedding" alter column "embedding" type vector using ("embedding"::vector);
alter table "recommended_action" alter column "category" type text using ("category"::text);
alter table "recommended_action" alter column "description" drop default;
alter table "recommended_action" alter column "description" type text using ("description"::text);
alter table "recommended_action" alter column "action_plan" drop default;
alter table "recommended_action" alter column "action_plan" type text using ("action_plan"::text);
alter table "recommended_action" add constraint "recommended_action_category_check" check("category" in ('STRENGTH', 'IMPROVEMENT'));
drop type "action_category";
```

`migration:check` exit code: `1` (unchanged — residual noise from #306/#307 + CHECK constraint enum drift keeps it non-zero). AC1 satisfied modulo unrelated drift captured in the baseline.
</details>

## Test plan

- [x] `schema:update --dump` no longer mentions any of the 8 fixed keynames
- [x] `npm run lint` — 0 errors (9 pre-existing warnings in unrelated Moodle test files)
- [x] `npm run build` — green
- [x] `npm run test` — 885/885 passing across 77 suites
- [x] `git diff --stat` — exactly 5 entity files modified, no snapshot, no migrations

## Scope

5 entity files. No migrations, no snapshot, no repositories, no services, no tests. Entity-metadata-only change.

Closes #305.