### PR TITLE
FAC-122.2 fix: explicitly type CustomBaseEntity.deletedAt to fix varchar(255) reflection

### DIFF
--- a/src/entities/base.entity.ts
+++ b/src/entities/base.entity.ts
@@ -11,7 +11,7 @@ export abstract class CustomBaseEntity {
   @Property()
   updatedAt: Date & Opt = new Date();
 
-  @Property({ nullable: true })
+  @Property({ type: 'datetime', nullable: true })
   deletedAt?: Date & Opt;
 
   SoftDelete() {

--- a/src/migrations/Migration20260412153923_fix-deleted-at-type.ts
+++ b/src/migrations/Migration20260412153923_fix-deleted-at-type.ts
@@ -1,0 +1,87 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260412153923 extends Migration {
+
+  override async up(): Promise<void> {
+    // Fix CustomBaseEntity.deletedAt reflection bug (issue #306)
+    // TypeScript's emitDecoratorMetadata can't reflect optional Date types cleanly,
+    // causing MikroORM to fall back to varchar(255). All tables extending CustomBaseEntity
+    // (except report_job, which was created with timestamptz) have deleted_at as varchar(255).
+    // This migration converts them to timestamptz to match the corrected entity metadata.
+
+    const tables = [
+      'analysis_pipeline',
+      'campus',
+      'course',
+      'department',
+      'dimension',
+      'enrollment',
+      'moodle_category',
+      'moodle_token',
+      'program',
+      'questionnaire',
+      'questionnaire_answer',
+      'questionnaire_draft',
+      'questionnaire_submission',
+      'questionnaire_type',
+      'questionnaire_version',
+      'recommendation_run',
+      'recommended_action',
+      'refresh_token',
+      'section',
+      'semester',
+      'sentiment_result',
+      'sentiment_run',
+      'submission_embedding',
+      'system_config',
+      'topic',
+      'topic_assignment',
+      'topic_model_run',
+      'user',
+      'user_institutional_role',
+    ];
+
+    for (const table of tables) {
+      this.addSql(`alter table "${table}" alter column "deleted_at" type timestamptz using ("deleted_at"::timestamptz);`);
+    }
+  }
+
+  override async down(): Promise<void> {
+    const tables = [
+      'analysis_pipeline',
+      'campus',
+      'course',
+      'department',
+      'dimension',
+      'enrollment',
+      'moodle_category',
+      'moodle_token',
+      'program',
+      'questionnaire',
+      'questionnaire_answer',
+      'questionnaire_draft',
+      'questionnaire_submission',
+      'questionnaire_type',
+      'questionnaire_version',
+      'recommendation_run',
+      'recommended_action',
+      'refresh_token',
+      'section',
+      'semester',
+      'sentiment_result',
+      'sentiment_run',
+      'submission_embedding',
+      'system_config',
+      'topic',
+      'topic_assignment',
+      'topic_model_run',
+      'user',
+      'user_institutional_role',
+    ];
+
+    for (const table of tables) {
+      this.addSql(`alter table "${table}" alter column "deleted_at" type varchar(255) using ("deleted_at"::varchar(255));`);
+    }
+  }
+
+}


### PR DESCRIPTION
## Summary

- Adds explicit `type: 'datetime'` to `CustomBaseEntity.deletedAt` decorator to fix TypeScript reflection fallback
- Creates migration to convert 29 tables from `varchar(255)` to `timestamptz`
- Excludes `report_job` which already has the correct type

## Context

TypeScript's `emitDecoratorMetadata` can't reflect optional Date types without initializers, causing MikroORM to fall back to `varchar(255)`. This was causing `schema:update --dump` to emit a downgrade for `report_job.deleted_at` from `timestamptz` to `varchar(255)`.

## Verification

- `schema:update --dump` no longer shows `report_job.deleted_at` downgrade
- All 885 tests passing
- Lint clean (0 errors)

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run test` — 885/885 passing
- [x] `npx mikro-orm schema:update --dump` — no `report_job.deleted_at` downgrade
- [ ] Run migration on staging first before production

Closes #306