### PR TITLE
FAC-124 refactor: stop deriving user scope fields from enrollment counts

### DIFF
--- a/docs/workflows/auth-hydration.md
+++ b/docs/workflows/auth-hydration.md
@@ -65,9 +65,6 @@ sequenceDiagram
 
     Note over MoodleUserHydrationService: Upsert Sections + assign to Enrollments
 
-    Note over MoodleUserHydrationService: Derive user scope (campus, program, department) from primary program
-    Note over MoodleUserHydrationService: Username prefix → Campus.code; fallback to program→department→semester→campus chain
-
     Note over MoodleUserHydrationService: Resolve Institutional Roles (Chairperson auto-detection)
     MoodleUserHydrationService->>MoodleService: GetUsersWithCapability(withcapability=moodle/category:manage)
     Note over MoodleUserHydrationService: Capability at program (depth 4) → CHAIRPERSON (source=auto)
@@ -127,15 +124,12 @@ Manual roles (`source=manual`) are never modified by the hydration process. They
 
 After institutional role resolution, the user's `roles` array is derived from both enrollment roles (via `MoodleRoleMapping`) and institutional roles. A user can have multiple roles (e.g., `[FACULTY, DEAN]` or `[FACULTY, CHAIRPERSON]`).
 
-Manually-granted `SUPER_ADMIN` and `ADMIN` roles are **never** dropped by hydration or by the batch role-derivation phase in institutional sync. `User.updateRolesFromEnrollments()` snapshots them before recomputing and merges them back in — hydration can promote a user (add FACULTY/CHAIRPERSON) but cannot revoke out-of-band admin roles. See [Institutional Sync — Phase 5](./institutional-sync.md#phase-5-user-role-derivation).
+Manually-granted `SUPER_ADMIN` and `ADMIN` roles are **never** dropped by hydration or by the batch role-derivation phase in institutional sync. `User.updateRolesFromEnrollments()` snapshots them before recomputing and merges them back in — hydration can promote a user (add FACULTY/CHAIRPERSON) but cannot revoke out-of-band admin roles. See [Institutional Sync — Phase 4](./institutional-sync.md#phase-4-user-role-derivation).
 
-## User Scope Derivation
+## User Scope Fields (Frozen)
 
-The same login flow also derives `user.campus`, `user.program`, and `user.department` from the user's primary program (the program with the most active enrollments; ties broken by lowest program UUID). Campus is resolved via username prefix first (`userName.split('-')[0]` → `Campus.code`), falling back to the `program → department → semester → campus` chain.
+The fields `user.campus`, `user.program`, and `user.department` are no longer derived during login. Existing values remain frozen as of FAC-124.
 
-These three fields are populated by both code paths:
+> **Historical context:** These fields were previously derived from the user's "primary program" (most enrollments). This represented teaching load rather than institutional belonging. FAC-125 will introduce `home_department_id` populated from Moodle profile custom fields as the authoritative source.
 
-- **Login hydration** — `MoodleUserHydrationService.deriveUserScopes()` runs inside the hydration transaction on every Moodle login.
-- **Sync Phase 4** — `MoodleEnrollmentSyncService.backfillUserScopes()` covers users who were synced but have not yet logged in.
-
-`MeResponse` exposes `campus`, `program`, and `department` so clients can display the user's institutional context without additional lookups.
+`MeResponse` still exposes `campus`, `program`, and `department` for clients that rely on them, but values will not change until FAC-125's backfill completes.

--- a/docs/workflows/dean-promotion.md
+++ b/docs/workflows/dean-promotion.md
@@ -42,6 +42,6 @@ Returns `AdminUserDetailResponseDto`:
 | `enrollments[]`                     | `{ id, role, isActive, course: { id, shortname, fullname } }` — filtered by `isActive: true AND course.isActive: true`, ordered `timeModified DESC` |
 | `institutionalRoles[]`              | `{ id, role, source, category: { moodleCategoryId, name, depth } }` — rows whose `moodleCategory` is null are filtered out                          |
 
-Enrollments and institutional roles are loaded in parallel via `Promise.all`. User load populates `['campus', 'department', 'program']` so the scope fields populated in [Phase 4 of institutional sync](./institutional-sync.md#phase-4-user-scope-backfill) / [auth hydration](./auth-hydration.md) are returned without extra queries.
+Enrollments and institutional roles are loaded in parallel via `Promise.all`. User load populates `['campus', 'department', 'program']` so the scope fields are returned without extra queries.
 
 The admin console pairs this endpoint with the dean-eligibility lookup above to drive the full "inspect user → promote to dean" flow from a single details panel.

--- a/docs/workflows/institutional-sync.md
+++ b/docs/workflows/institutional-sync.md
@@ -31,8 +31,7 @@ flowchart TD
     Courses --> CourseOK{Success?}
     CourseOK -->|Yes| Enrollments[Phase 3: Enrollment Sync]
     CourseOK -->|No| Abort2([Abort — skip enrollments])
-    Enrollments --> Scopes[Phase 4: User Scope Backfill]
-    Scopes --> Roles[Phase 5: User Role Derivation]
+    Enrollments --> Roles[Phase 4: User Role Derivation]
     Roles --> Cache[Invalidate ENROLLMENTS_ME cache]
     Cache --> Done([Complete])
 ```
@@ -60,24 +59,13 @@ Uses a 3-phase architecture to avoid deadlocks from overlapping user rows:
 
 No additional Moodle API calls are needed for sections — group data is already returned by the enrolled users endpoint.
 
-### Phase 4: User Scope Backfill
+### Phase 4: User Role Derivation
 
-After enrollments land, `backfillUserScopes()` loads each synced user, picks their "primary program" (the one they have the most active enrollments in; ties broken by lowest program UUID), and persists `campus`, `program`, and `department` onto the `User` row.
-
-Campus is resolved with a two-tier strategy:
-
-1. **Username prefix lookup** — split `userName` on `-`, uppercase the prefix, match against `Campus.code`. Handles the common `UCMN-jdoe` convention.
-2. **Category hierarchy fallback** — walk `program → department → semester → campus` when the prefix is missing or unmatched.
-
-The phase is wrapped in try/catch — a backfill failure logs a warning but does not fail the overall sync. These scope fields are consumed by `UserLoader` (populated alongside `campus` as `['campus', 'program', 'department']`) so scoped queries and the `MeResponse` DTO can return the full chain without extra round-trips.
-
-The same algorithm runs inline during login hydration via `MoodleUserHydrationService.deriveUserScopes()`, keeping the scope fields in sync from the user's very first login. See [Auth Hydration](./auth-hydration.md) for the full login flow.
-
-### Phase 5: User Role Derivation
-
-After scope backfill, `deriveUserRoles()` batch-loads each synced user's active `Enrollment` rows and `UserInstitutionalRole` rows in parallel, groups them per user, and calls `User.updateRolesFromEnrollments()` to recompute the `roles` array. Without this phase, freshly synced users had empty role arrays until their first login.
+After enrollments land, `deriveUserRoles()` batch-loads each synced user's active `Enrollment` rows and `UserInstitutionalRole` rows in parallel, groups them per user, and calls `User.updateRolesFromEnrollments()` to recompute the `roles` array.
 
 `updateRolesFromEnrollments()` snapshots existing `SUPER_ADMIN` and `ADMIN` roles and merges them back after recomputing. Those two roles are manually granted outside Moodle — the snapshot prevents a sync from ever revoking a role it never granted. The phase is non-fatal (try/catch); role drift is preferred over a broken sync run.
+
+> **Note:** Prior to FAC-124, a Phase 4 "User Scope Backfill" derived `user.campus`, `user.program`, and `user.department` from enrollment counts. This was removed because these fields represented teaching load rather than institutional belonging. FAC-125 will introduce the replacement `home_department_id` mechanism.
 
 ## Observability — SyncLog
 

--- a/src/modules/moodle/services/moodle-enrollment-sync.service.ts
+++ b/src/modules/moodle/services/moodle-enrollment-sync.service.ts
@@ -3,8 +3,6 @@ import { Injectable, Logger } from '@nestjs/common';
 import pLimit from 'p-limit';
 import { Course } from 'src/entities/course.entity';
 import { Section } from 'src/entities/section.entity';
-import { Campus } from 'src/entities/campus.entity';
-import { Program } from 'src/entities/program.entity';
 import { env } from 'src/configurations/env';
 import { Enrollment } from 'src/entities/enrollment.entity';
 import { User } from 'src/entities/user.entity';
@@ -85,15 +83,7 @@ export class EnrollmentSyncService {
       }
     }
 
-    // Phase 4: Backfill campus, program, department on users
-    try {
-      await this.backfillUserScopes(fetched);
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      this.logger.error(`Failed to backfill user scopes: ${message}`);
-    }
-
-    // Phase 5: Derive user roles from enrollments + institutional roles
+    // Phase 4: Derive user roles from enrollments + institutional roles
     try {
       await this.deriveUserRoles(fetched);
     } catch (error: unknown) {
@@ -331,117 +321,6 @@ export class EnrollmentSyncService {
     }
 
     return sectionMap;
-  }
-
-  private async backfillUserScopes(
-    fetched: { course: Course; remoteUsers: MoodleEnrolledUser[] }[],
-  ) {
-    // 1. Build user → program mapping (most course enrollments wins)
-    const userProgramCounts = new Map<number, Map<string, number>>();
-
-    for (const { course, remoteUsers } of fetched) {
-      const programRef = course.program;
-      if (!programRef) continue;
-      const programId =
-        typeof programRef === 'object' ? programRef.id : String(programRef);
-
-      for (const remote of remoteUsers) {
-        if (remote.id == null || !remote.username) continue;
-        if (!userProgramCounts.has(remote.id)) {
-          userProgramCounts.set(remote.id, new Map());
-        }
-        const counts = userProgramCounts.get(remote.id)!;
-        counts.set(programId, (counts.get(programId) ?? 0) + 1);
-      }
-    }
-
-    // 2. Resolve primary program per user (most enrollments, alphabetical ID tiebreaker)
-    const userPrimaryProgram = new Map<number, string>();
-    for (const [moodleUserId, counts] of userProgramCounts) {
-      let maxCount = 0;
-      let primaryProgramId = '';
-      for (const [programId, count] of counts) {
-        if (
-          count > maxCount ||
-          (count === maxCount && programId < primaryProgramId)
-        ) {
-          maxCount = count;
-          primaryProgramId = programId;
-        }
-      }
-      if (primaryProgramId) {
-        userPrimaryProgram.set(moodleUserId, primaryProgramId);
-      }
-    }
-
-    if (userPrimaryProgram.size === 0) return;
-
-    // 3. Load programs with department → semester → campus chain
-    const programIds = [...new Set(userPrimaryProgram.values())];
-    const fork = this.em.fork();
-    const programs = await fork.find(
-      Program,
-      { id: { $in: programIds } },
-      {
-        populate: [
-          'department',
-          'department.semester',
-          'department.semester.campus',
-        ],
-      },
-    );
-    const programMap = new Map(programs.map((p) => [p.id, p]));
-
-    // 4. Load all campuses for username prefix lookup
-    const campuses = await fork.find(Campus, {});
-    const campusByCode = new Map(campuses.map((c) => [c.code, c]));
-
-    // 5. Load users and update scope fields
-    const moodleUserIds = [...userPrimaryProgram.keys()];
-    const users = await fork.find(User, {
-      moodleUserId: { $in: moodleUserIds },
-    });
-
-    let updated = 0;
-    for (const user of users) {
-      if (!user.moodleUserId) continue;
-
-      const programId = userPrimaryProgram.get(user.moodleUserId);
-      if (!programId) continue;
-
-      const program = programMap.get(programId);
-      if (!program) continue;
-
-      const changed =
-        user.program?.id !== program.id ||
-        user.department?.id !== program.department?.id;
-
-      user.program = program;
-
-      if (program.department) {
-        user.department = program.department;
-      }
-
-      // Campus: username prefix first, fallback to category hierarchy
-      const parts = user.userName.split('-');
-      const campusCode = parts.length > 1 ? parts[0].toUpperCase() : null;
-      const campus = campusCode ? campusByCode.get(campusCode) : undefined;
-      const resolvedCampus = campus ?? program.department?.semester?.campus;
-      const campusChanged = user.campus?.id !== resolvedCampus?.id;
-
-      if (resolvedCampus) {
-        user.campus = resolvedCampus;
-      }
-
-      if (changed || campusChanged) {
-        updated++;
-      }
-    }
-
-    if (updated > 0) {
-      await fork.flush();
-      this.logger.log(`Backfilled scope fields for ${updated} users`);
-    }
   }
 
   private async deriveUserRoles(

--- a/src/modules/moodle/services/moodle-user-hydration.service.ts
+++ b/src/modules/moodle/services/moodle-user-hydration.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { User } from 'src/entities/user.entity';
 import { Program } from 'src/entities/program.entity';
-import { Campus } from 'src/entities/campus.entity';
 import { Course } from 'src/entities/course.entity';
 import { Enrollment } from 'src/entities/enrollment.entity';
 import { Section } from 'src/entities/section.entity';
@@ -251,9 +250,6 @@ export class MoodleUserHydrationService {
 
       user.updateRolesFromEnrollments(activeEnrollments, institutionalRoles);
 
-      // Derive scope fields: program, department, campus
-      await this.deriveUserScopes(user, programCache, remoteCourses, tx);
-
       tx.persist(user);
     });
 
@@ -261,69 +257,6 @@ export class MoodleUserHydrationService {
     this.logger.log(
       `Finished hydrating courses for Moodle user ${moodleUserId} in ${duration}ms`,
     );
-  }
-
-  private async deriveUserScopes(
-    user: User,
-    programCache: Map<number, Program>,
-    remoteCourses: MoodleCourse[],
-    tx: EntityManager,
-  ) {
-    // Pick primary program: most course enrollments
-    const programCounts = new Map<
-      string,
-      { program: Program; count: number }
-    >();
-    for (const rc of remoteCourses) {
-      const program = programCache.get(rc.category);
-      if (!program) continue;
-      const entry = programCounts.get(program.id);
-      if (entry) {
-        entry.count++;
-      } else {
-        programCounts.set(program.id, { program, count: 1 });
-      }
-    }
-
-    let primaryProgram: Program | undefined;
-    let maxCount = 0;
-    for (const { program, count } of programCounts.values()) {
-      if (
-        count > maxCount ||
-        (count === maxCount &&
-          (!primaryProgram || program.id < primaryProgram.id))
-      ) {
-        maxCount = count;
-        primaryProgram = program;
-      }
-    }
-
-    if (!primaryProgram) return;
-
-    // Populate department → semester → campus chain
-    await tx.populate(primaryProgram, [
-      'department',
-      'department.semester',
-      'department.semester.campus',
-    ]);
-
-    user.program = primaryProgram;
-
-    if (primaryProgram.department) {
-      user.department = primaryProgram.department;
-    }
-
-    // Campus: username prefix first, fallback to category hierarchy
-    const parts = user.userName.split('-');
-    const campusCode = parts.length > 1 ? parts[0].toUpperCase() : null;
-    const campus = campusCode
-      ? await tx.findOne(Campus, { code: campusCode })
-      : null;
-    if (campus) {
-      user.campus = campus;
-    } else if (primaryProgram.department?.semester?.campus) {
-      user.campus = primaryProgram.department.semester.campus;
-    }
   }
 
   private async resolveInstitutionalRoles(


### PR DESCRIPTION
## Summary

- Remove `backfillUserScopes` from `EnrollmentSyncService` (was Phase 4)
- Remove `deriveUserScopes` from `MoodleUserHydrationService`
- Update Phase numbering (Phase 5 → Phase 4) in code and documentation
- Freeze existing `user.campus`, `user.program`, and `user.department` values as fallback seed data for FAC-125

## Context

The removed methods derived scope fields based on "primary program wins" logic — the program with the most course enrollments became the user's department. This represented teaching load rather than institutional belonging. FAC-125 will introduce `home_department_id` populated from Moodle profile custom fields as the authoritative source.

## Test plan

- [x] All 885 unit tests pass
- [x] Lint passes with no new warnings
- [ ] Manual: Verify user's `department_id` remains unchanged after enrollment sync
- [ ] Manual: Verify user's `department_id` remains unchanged after Moodle login