### PR TITLE
[STAGING] FAC-133 feat: add faculty enrollments by id endpoint

### DIFF
--- a/src/modules/faculty/dto/requests/get-faculty-enrollments-query.dto.ts
+++ b/src/modules/faculty/dto/requests/get-faculty-enrollments-query.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsUUID } from 'class-validator';
+import { PaginationQueryDto } from 'src/modules/common/dto/pagination-query.dto';
+
+export class GetFacultyEnrollmentsQueryDto extends PaginationQueryDto {
+  @ApiProperty({ description: 'Semester UUID to scope faculty enrollments' })
+  @IsUUID()
+  @IsNotEmpty()
+  semesterId!: string;
+}

--- a/src/modules/faculty/dto/responses/faculty-enrollments.response.dto.ts
+++ b/src/modules/faculty/dto/responses/faculty-enrollments.response.dto.ts
@@ -1,0 +1,1 @@
+export { MyEnrollmentsResponseDto as FacultyEnrollmentsResponseDto } from 'src/modules/enrollments/dto/responses/my-enrollments.response.dto';

--- a/src/modules/faculty/faculty.controller.ts
+++ b/src/modules/faculty/faculty.controller.ts
@@ -15,6 +15,8 @@ import { ListFacultyQueryDto } from './dto/requests/list-faculty-query.dto';
 import { FacultyListResponseDto } from './dto/responses/faculty-list.response.dto';
 import { GetSubmissionCountQueryDto } from './dto/requests/get-submission-count-query.dto';
 import { SubmissionCountResponseDto } from './dto/responses/submission-count.response.dto';
+import { GetFacultyEnrollmentsQueryDto } from './dto/requests/get-faculty-enrollments-query.dto';
+import { FacultyEnrollmentsResponseDto } from './dto/responses/faculty-enrollments.response.dto';
 
 @ApiTags('Faculty')
 @Controller('faculty')
@@ -64,5 +66,34 @@ export class FacultyController {
     @Query() query: GetSubmissionCountQueryDto,
   ): Promise<SubmissionCountResponseDto> {
     return this.facultyService.GetSubmissionCount(facultyId, query.semesterId);
+  }
+
+  @Get(':facultyId/enrollments')
+  @UseJwtGuard(
+    UserRole.SUPER_ADMIN,
+    UserRole.DEAN,
+    UserRole.CHAIRPERSON,
+    UserRole.CAMPUS_HEAD,
+    UserRole.FACULTY,
+  )
+  @ApiOperation({
+    summary:
+      'Get active teaching enrollments for a faculty member in a semester',
+  })
+  @ApiResponse({ status: 200, type: FacultyEnrollmentsResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid UUID format' })
+  @ApiResponse({
+    status: 403,
+    description: 'You do not have access to this faculty member',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Faculty or semester not found',
+  })
+  async getFacultyEnrollments(
+    @Param('facultyId', ParseUUIDPipe) facultyId: string,
+    @Query() query: GetFacultyEnrollmentsQueryDto,
+  ): Promise<FacultyEnrollmentsResponseDto> {
+    return this.facultyService.GetFacultyEnrollments(facultyId, query);
   }
 }

--- a/src/modules/faculty/services/faculty.service.spec.ts
+++ b/src/modules/faculty/services/faculty.service.spec.ts
@@ -7,10 +7,13 @@ import {
 import { EntityManager } from '@mikro-orm/postgresql';
 import { QueryOrder } from '@mikro-orm/core';
 import { FacultyService } from './faculty.service';
+import { CurrentUserService } from 'src/modules/common/cls/current-user.service';
 import { ScopeResolverService } from 'src/modules/common/services/scope-resolver.service';
 import { User } from 'src/entities/user.entity';
 import { Enrollment } from 'src/entities/enrollment.entity';
 import { UserRole } from 'src/modules/auth/roles.enum';
+import { EnrollmentRole } from 'src/modules/questionnaires/lib/questionnaire.types';
+import { GetFacultyEnrollmentsQueryDto } from '../dto/requests/get-faculty-enrollments-query.dto';
 import { ListFacultyQueryDto } from '../dto/requests/list-faculty-query.dto';
 
 describe('FacultyService', () => {
@@ -23,6 +26,7 @@ describe('FacultyService', () => {
     getConnection: jest.Mock;
   };
   let scopeResolver: { ResolveDepartmentIds: jest.Mock };
+  let currentUserService: { getOrFail: jest.Mock };
   let executeMock: jest.Mock;
 
   const semesterId = 'semester-1';
@@ -34,6 +38,12 @@ describe('FacultyService', () => {
     semesterId,
     page: 1,
     limit: 20,
+  };
+
+  const baseEnrollmentsQuery: GetFacultyEnrollmentsQueryDto = {
+    semesterId,
+    page: 1,
+    limit: 10,
   };
 
   const mockUser = (
@@ -71,11 +81,19 @@ describe('FacultyService', () => {
       ResolveDepartmentIds: jest.fn(),
     };
 
+    currentUserService = {
+      getOrFail: jest.fn().mockReturnValue({
+        id: 'dean-user',
+        roles: [UserRole.DEAN],
+      }),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         FacultyService,
         { provide: EntityManager, useValue: em },
         { provide: ScopeResolverService, useValue: scopeResolver },
+        { provide: CurrentUserService, useValue: currentUserService },
       ],
     }).compile();
 
@@ -801,6 +819,201 @@ describe('FacultyService', () => {
         faculty: facultyId,
         semester: semesterId,
       });
+    });
+  });
+
+  describe('GetFacultyEnrollments', () => {
+    const facultyId = 'faculty-1';
+
+    beforeEach(() => {
+      currentUserService.getOrFail.mockReturnValue({
+        id: 'dean-user',
+        roles: [UserRole.DEAN],
+      });
+    });
+
+    it('returns paginated teaching enrollments for an in-scope faculty', async () => {
+      em.findOne
+        .mockResolvedValueOnce({ id: semesterId })
+        .mockResolvedValueOnce({
+          id: facultyId,
+          isActive: true,
+          roles: [UserRole.FACULTY],
+          department: { id: deptId },
+          fullName: 'Prof. Ada Lovelace',
+          firstName: 'Ada',
+          lastName: 'Lovelace',
+          userName: 'EMP001',
+          userProfilePicture: 'https://example.com/ada.jpg',
+        });
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
+      em.findAndCount.mockResolvedValueOnce([
+        [
+          {
+            id: 'enrollment-1',
+            role: EnrollmentRole.EDITING_TEACHER,
+            course: {
+              id: 'course-1',
+              moodleCourseId: 101,
+              shortname: 'CS101',
+              fullname: 'Intro to CS',
+              courseImage: null,
+              program: {
+                department: {
+                  semester: {
+                    id: semesterId,
+                    code: 'S12526',
+                    label: '1st Semester',
+                    academicYear: '2025-2026',
+                  },
+                },
+              },
+            },
+            section: { id: 'section-1', name: 'A' },
+          },
+        ],
+        1,
+      ]);
+
+      const result = await service.GetFacultyEnrollments(
+        facultyId,
+        baseEnrollmentsQuery,
+      );
+
+      expect(result.meta).toEqual({
+        totalItems: 1,
+        itemCount: 1,
+        itemsPerPage: 10,
+        totalPages: 1,
+        currentPage: 1,
+      });
+      expect(result.data[0]).toEqual({
+        id: 'enrollment-1',
+        role: EnrollmentRole.EDITING_TEACHER,
+        course: {
+          id: 'course-1',
+          moodleCourseId: 101,
+          shortname: 'CS101',
+          fullname: 'Intro to CS',
+          courseImage: undefined,
+        },
+        faculty: {
+          id: facultyId,
+          fullName: 'Prof. Ada Lovelace',
+          employeeNumber: 'EMP001',
+          profilePicture: 'https://example.com/ada.jpg',
+        },
+        semester: {
+          id: semesterId,
+          code: 'S12526',
+          label: '1st Semester',
+          academicYear: '2025-2026',
+        },
+        section: { id: 'section-1', name: 'A' },
+        submission: { submitted: false },
+      });
+
+      expect(em.findAndCount).toHaveBeenCalledWith(
+        Enrollment,
+        {
+          user: facultyId,
+          role: {
+            $in: [EnrollmentRole.EDITING_TEACHER, EnrollmentRole.TEACHER],
+          },
+          isActive: true,
+          course: {
+            isActive: true,
+            program: { department: { semester: semesterId } },
+          },
+        },
+        expect.objectContaining({
+          populate: ['course.program.department.semester', 'section'],
+          limit: 10,
+          offset: 0,
+          orderBy: { timeModified: QueryOrder.DESC },
+        }),
+      );
+    });
+
+    it('allows faculty to fetch their own enrollments', async () => {
+      currentUserService.getOrFail.mockReturnValue({
+        id: facultyId,
+        roles: [UserRole.FACULTY],
+      });
+      em.findOne
+        .mockResolvedValueOnce({ id: semesterId })
+        .mockResolvedValueOnce({
+          id: facultyId,
+          isActive: true,
+          roles: [UserRole.FACULTY],
+          department: { id: deptId },
+          firstName: 'Ada',
+          lastName: 'Lovelace',
+          userName: 'EMP001',
+          userProfilePicture: '',
+        });
+      em.findAndCount.mockResolvedValueOnce([[], 0]);
+
+      const result = await service.GetFacultyEnrollments(
+        facultyId,
+        baseEnrollmentsQuery,
+      );
+
+      expect(result.data).toEqual([]);
+      expect(scopeResolver.ResolveDepartmentIds).not.toHaveBeenCalled();
+    });
+
+    it('forbids faculty from fetching another faculty member', async () => {
+      currentUserService.getOrFail.mockReturnValue({
+        id: 'other-faculty',
+        roles: [UserRole.FACULTY],
+      });
+      em.findOne
+        .mockResolvedValueOnce({ id: semesterId })
+        .mockResolvedValueOnce({
+          id: facultyId,
+          isActive: true,
+          roles: [UserRole.FACULTY],
+          department: { id: deptId },
+        });
+
+      await expect(
+        service.GetFacultyEnrollments(facultyId, baseEnrollmentsQuery),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('forbids dean when faculty is outside scope', async () => {
+      em.findOne
+        .mockResolvedValueOnce({ id: semesterId })
+        .mockResolvedValueOnce({
+          id: facultyId,
+          isActive: true,
+          roles: [UserRole.FACULTY],
+          department: { id: deptId2 },
+        });
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
+
+      await expect(
+        service.GetFacultyEnrollments(facultyId, baseEnrollmentsQuery),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('throws NotFoundException when semester does not exist', async () => {
+      em.findOne.mockResolvedValueOnce(null);
+
+      await expect(
+        service.GetFacultyEnrollments(facultyId, baseEnrollmentsQuery),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException when faculty does not exist', async () => {
+      em.findOne
+        .mockResolvedValueOnce({ id: semesterId })
+        .mockResolvedValueOnce(null);
+
+      await expect(
+        service.GetFacultyEnrollments(facultyId, baseEnrollmentsQuery),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/src/modules/faculty/services/faculty.service.ts
+++ b/src/modules/faculty/services/faculty.service.ts
@@ -10,7 +10,11 @@ import { Enrollment } from 'src/entities/enrollment.entity';
 import { Program } from 'src/entities/program.entity';
 import { Semester } from 'src/entities/semester.entity';
 import { QuestionnaireSubmission } from 'src/entities/questionnaire-submission.entity';
+import { CurrentUserService } from 'src/modules/common/cls/current-user.service';
 import { ScopeResolverService } from 'src/modules/common/services/scope-resolver.service';
+import { MyEnrollmentsResponseDto } from 'src/modules/enrollments/dto/responses/my-enrollments.response.dto';
+import { FacultyShortResponseDto } from 'src/modules/enrollments/dto/responses/faculty-short.response.dto';
+import { GetFacultyEnrollmentsQueryDto } from '../dto/requests/get-faculty-enrollments-query.dto';
 import { ListFacultyQueryDto } from '../dto/requests/list-faculty-query.dto';
 import { FacultyListResponseDto } from '../dto/responses/faculty-list.response.dto';
 import { FacultyCardResponseDto } from '../dto/responses/faculty-card.response.dto';
@@ -25,6 +29,7 @@ export class FacultyService {
   constructor(
     private readonly em: EntityManager,
     private readonly scopeResolverService: ScopeResolverService,
+    private readonly currentUserService: CurrentUserService,
   ) {}
 
   async ListFaculty(
@@ -341,6 +346,105 @@ export class FacultyService {
     return { count };
   }
 
+  async GetFacultyEnrollments(
+    facultyId: string,
+    query: GetFacultyEnrollmentsQueryDto,
+  ): Promise<MyEnrollmentsResponseDto> {
+    const semester = await this.em.findOne(Semester, { id: query.semesterId });
+    if (!semester) {
+      throw new NotFoundException(
+        `Semester with id '${query.semesterId}' not found.`,
+      );
+    }
+
+    const faculty = await this.em.findOne(
+      User,
+      { id: facultyId, isActive: true },
+      { populate: ['department'] },
+    );
+    if (!faculty || !faculty.roles.includes(UserRole.FACULTY)) {
+      throw new NotFoundException(`Faculty with id '${facultyId}' not found.`);
+    }
+
+    await this.AssertFacultyAccess(faculty, query.semesterId);
+
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 10;
+    const offset = (page - 1) * limit;
+
+    const [enrollments, totalItems] = await this.em.findAndCount(
+      Enrollment,
+      {
+        user: facultyId,
+        role: {
+          $in: [EnrollmentRole.EDITING_TEACHER, EnrollmentRole.TEACHER],
+        },
+        isActive: true,
+        course: {
+          isActive: true,
+          program: { department: { semester: query.semesterId } },
+        },
+      },
+      {
+        populate: ['course.program.department.semester', 'section'],
+        limit,
+        offset,
+        orderBy: { timeModified: QueryOrder.DESC },
+      },
+    );
+
+    const facultyDto: FacultyShortResponseDto = {
+      id: faculty.id,
+      fullName: faculty.fullName ?? `${faculty.firstName} ${faculty.lastName}`,
+      employeeNumber: faculty.userName,
+      profilePicture: faculty.userProfilePicture || undefined,
+    };
+
+    return {
+      data: enrollments.map((enrollment) => {
+        const enrollmentSemester =
+          enrollment.course.program?.department?.semester;
+
+        return {
+          id: enrollment.id,
+          role: enrollment.role,
+          course: {
+            id: enrollment.course.id,
+            moodleCourseId: enrollment.course.moodleCourseId,
+            shortname: enrollment.course.shortname,
+            fullname: enrollment.course.fullname,
+            courseImage: enrollment.course.courseImage ?? undefined,
+          },
+          faculty: facultyDto,
+          semester: enrollmentSemester
+            ? {
+                id: enrollmentSemester.id,
+                code: enrollmentSemester.code,
+                label: enrollmentSemester.label,
+                academicYear: enrollmentSemester.academicYear,
+              }
+            : null,
+          section: enrollment.section
+            ? {
+                id: enrollment.section.id,
+                name: enrollment.section.name,
+              }
+            : null,
+          submission: {
+            submitted: false,
+          },
+        };
+      }),
+      meta: {
+        totalItems,
+        itemCount: enrollments.length,
+        itemsPerPage: limit,
+        totalPages: Math.ceil(totalItems / limit),
+        currentPage: page,
+      },
+    };
+  }
+
   private BuildUserFilter(
     query: ListFacultyQueryDto,
     departmentIds: string[] | null,
@@ -517,6 +621,54 @@ export class FacultyService {
       .replace(/\\/g, '\\\\')
       .replace(/%/g, '\\%')
       .replace(/_/g, '\\_');
+  }
+
+  private async AssertFacultyAccess(
+    faculty: User,
+    semesterId: string,
+  ): Promise<void> {
+    const currentUser = this.currentUserService.getOrFail();
+
+    if (currentUser.roles.includes(UserRole.SUPER_ADMIN)) {
+      return;
+    }
+
+    if (
+      currentUser.roles.some((role) =>
+        [UserRole.DEAN, UserRole.CHAIRPERSON, UserRole.CAMPUS_HEAD].includes(
+          role,
+        ),
+      )
+    ) {
+      const departmentIds =
+        await this.scopeResolverService.ResolveDepartmentIds(semesterId);
+
+      if (departmentIds === null) {
+        return;
+      }
+
+      if (
+        !faculty.department?.id ||
+        !departmentIds.includes(faculty.department.id)
+      ) {
+        throw new ForbiddenException(
+          'You do not have access to this faculty member',
+        );
+      }
+
+      return;
+    }
+
+    if (
+      currentUser.roles.includes(UserRole.FACULTY) &&
+      currentUser.id === faculty.id
+    ) {
+      return;
+    }
+
+    throw new ForbiddenException(
+      'You do not have access to this faculty member',
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- add `GET /api/v1/faculty/:facultyId/enrollments` for semester-scoped teaching enrollments
- enforce scoped access for dean/chairperson/campus head/super admin and self-only access for faculty
- reuse the existing enrollments response shape so frontend course filtering can consume the endpoint directly

## Why
The dean faculty analysis flow needs a backend source for the selected faculty member's current courses so the report UI can filter by course using `facultyId` and `semesterId`.

## What Changed
- added a new faculty query DTO for `semesterId` plus pagination
- added a new faculty controller route for `:facultyId/enrollments`
- implemented `FacultyService.GetFacultyEnrollments(...)`
- added access checks tied to current user role and scoped department visibility
- added service tests for in-scope dean access, faculty self-access, and forbidden/out-of-scope cases

## Validation
- [x] `npm test -- faculty.service.spec.ts`
- [x] `npm run build`

## Notes
- the endpoint returns active teaching enrollments only (`teacher`, `editingteacher`)
- `src/migrations/.snapshot-neondb.json` was left out of this PR because it was unrelated to the endpoint change
