### PR TITLE
FAC-132 feat: role-aware analysis pipeline triggering and output surfacing

### DIFF
--- a/_bmad-output/implementation-artifacts/tech-spec-fac-132-analysis-pipeline-interaction.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-fac-132-analysis-pipeline-interaction.md
@@ -1,0 +1,824 @@
+---
+title: 'FAC-132 feat: role-aware analysis pipeline triggering and output surfacing'
+slug: 'fac-132-analysis-pipeline-interaction'
+created: '2026-04-14'
+status: 'implementation-complete'
+stepsCompleted: [1, 2, 3, 4, 5, 6]
+tech_stack:
+  - 'NestJS 11 (TypeScript 5)'
+  - 'MikroORM 6 (PostgreSQL)'
+  - 'Passport JWT + RolesGuard'
+  - 'Zod + class-validator DTOs'
+  - 'BullMQ/Redis (existing pipeline infra, no changes)'
+  - 'OpenAI SDK (existing recommendation/topic-label services, no changes)'
+  - 'Jest 30 (backend tests)'
+  - 'Next.js 16 + React 19 (app.faculytics)'
+  - 'TanStack Query v5 + Axios'
+  - 'Zustand (auth store)'
+  - 'shadcn/ui + Tailwind 4'
+  - 'Bun (app.faculytics package manager)'
+files_to_modify:
+  # Backend — api.faculytics
+  - 'api.faculytics/src/modules/analysis/analysis.controller.ts (modify — class-level @UseJwtGuard(DEAN,CHAIRPERSON,CAMPUS_HEAD,SUPER_ADMIN) + @UseInterceptors(CurrentUserInterceptor); method-level widening for FACULTY on GETs; add GET /pipelines list endpoint)'
+  - 'api.faculytics/src/modules/analysis/services/pipeline-orchestrator.service.ts (modify — inject ScopeResolverService + CurrentUserService; add assertCanCreatePipeline + assertCanAccessPipeline; add ListPipelines method; call scope checks from Create/Confirm/Cancel/GetPipelineStatus/GetRecommendations; catch UniqueConstraintViolationException in CreatePipeline)'
+  - 'api.faculytics/src/modules/analysis/dto/list-pipelines.dto.ts (create — Zod + class-validator query schema for list endpoint)'
+  - 'api.faculytics/src/modules/analysis/dto/responses/pipeline-summary.response.dto.ts (create — { id, status, scope, coverage, warnings, createdAt, updatedAt, completedAt })'
+  - 'api.faculytics/src/modules/analysis/dto/pipeline-status.dto.ts (modify — extend scope shape to return BOTH IDs and display values; scope: { semesterId, semesterCode, departmentId, departmentCode, facultyId, facultyName, programId, programCode, campusId, campusCode, courseId, courseShortname, questionnaireVersionId })'
+  - 'api.faculytics/src/modules/common/services/scope-resolver.service.ts (modify — add ResolveCampusIds(semesterId) helper if missing; pipeline-specific logic stays in orchestrator)'
+  - 'api.faculytics/src/migrations/<timestamp>_fac-132-pipeline-scope-unique-index.ts (create — partial unique index on (semester_id, coalesced scope fields) WHERE status NOT IN active terminal statuses AND deleted_at IS NULL; enforces TD-8 one-canonical-pipeline invariant)'
+  - 'api.faculytics/src/modules/analysis/analysis.controller.spec.ts (modify — extend existing auditTestProviders() + overrideAuditInterceptors() harness; DO NOT copy from analytics.controller.spec.ts; add list-endpoint delegation test; add audit-on-403-reject test)'
+  - 'api.faculytics/src/modules/analysis/services/pipeline-orchestrator.service.spec.ts (modify — scope authorization matrix: SUPER_ADMIN unrestricted + reads-any, DEAN/CAMPUS_HEAD/CHAIRPERSON in/out of scope, FACULTY read-own/foreign/dept-scoped, FACULTY list auto-override, FACULTY service-layer create 403 (belt-and-braces), STUDENT 403, UniqueConstraintViolation race handling)'
+  - 'api.faculytics/docs/workflows/analysis-pipeline.md (modify — add Access Control section with per-endpoint allowlist + scope matrix + FACULTY auto-override + 404>403 rule)'
+  - 'api.faculytics/docs/architecture/scope-resolution.md (modify — add Pipeline-scope authorization addendum)'
+  # Frontend — app.faculytics
+  - 'app.faculytics/network/endpoints.ts (modify — add 6 analysis pipeline endpoint entries: list, create, confirm, cancel, status, recommendations)'
+  - 'app.faculytics/features/faculty-analytics/api/analysis-pipeline.requests.ts (create — thin Axios wrappers: listPipelines, createPipeline, confirmPipeline, cancelPipeline, fetchPipelineStatus, fetchPipelineRecommendations)'
+  - 'app.faculytics/features/faculty-analytics/types/index.ts (modify — add PipelineStatus const-union (UPPERCASE members matching backend enum), RunStatus const-union, PipelineScopeIds (for CreatePipelineRequest/ListPipelinesQuery), PipelineScopeDisplay (for PipelineStatusResponse.scope — codes/names/ids both), PipelineCoverage, PipelineStageStatus, PipelineStatusResponse, PipelineSummary (with warnings: string[]), CreatePipelineRequest, ListPipelinesQuery, TopicSource, DimensionScoresSource, SupportingEvidence, RecommendedActionDto, RecommendationsResponse (status typed as RunStatus))'
+  - 'app.faculytics/features/faculty-analytics/hooks/use-latest-pipeline-for-scope.ts (create — useQuery wrapping listPipelines; returns first/null)'
+  - 'app.faculytics/features/faculty-analytics/hooks/use-pipeline-status.ts (create — useQuery with refetchInterval that stops on terminal status)'
+  - 'app.faculytics/features/faculty-analytics/hooks/use-pipeline-recommendations.ts (create — useQuery enabled only when status === completed)'
+  - 'app.faculytics/features/faculty-analytics/hooks/use-create-pipeline.ts (create — useMutation + invalidate list query)'
+  - 'app.faculytics/features/faculty-analytics/hooks/use-confirm-pipeline.ts (create — useMutation + invalidate status query)'
+  - 'app.faculytics/features/faculty-analytics/hooks/use-cancel-pipeline.ts (create — useMutation + invalidate status + list)'
+  - 'app.faculytics/features/faculty-analytics/lib/pipeline-themes.ts (create — pure fn aggregateThemes(actions) returning ranked topic list with commentCount + weighted sentiment breakdown + sampleQuotes)'
+  - 'app.faculytics/features/faculty-analytics/components/pipeline-status-badge.tsx (create — maps PipelineStatus to badge variant + label)'
+  - 'app.faculytics/features/faculty-analytics/components/pipeline-trigger-card.tsx (create — Run/Confirm/Cancel/Re-run buttons with AlertDialog coverage warnings; role-gated via useActiveRole; FACULTY sees status badge only)'
+  - 'app.faculytics/features/faculty-analytics/components/themes-chip-list.tsx (create — compact chips for faculty report)'
+  - 'app.faculytics/features/faculty-analytics/components/themes-ranked-list.tsx (create — ranked list with count + sentiment bar for scoped dashboard)'
+  - 'app.faculytics/features/faculty-analytics/components/recommendations-card.tsx (create — Strengths/Improvements tabs with expandable evidence accordion)'
+  - 'app.faculytics/features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx (modify — compose PipelineTriggerCard row + conditional ThemesRankedList + RecommendationsCard row)'
+  - 'app.faculytics/features/faculty-analytics/components/faculty-report-screen.tsx (modify — conditional PipelineStatusBadge inline with header + ThemesChipList + RecommendationsCard in slot between summary cards and section performance)'
+  - 'app.faculytics/features/faculty-analytics/index.ts (modify — extend barrel exports)'
+code_patterns:
+  # Backend
+  - '@UseJwtGuard(UserRole.DEAN, UserRole.CHAIRPERSON, UserRole.CAMPUS_HEAD, UserRole.SUPER_ADMIN) at controller level; method-level guards can narrow/widen'
+  - '@UseInterceptors(CurrentUserInterceptor) on controller class — populates CLS with full User'
+  - '@Audited({ action: AuditAction.X, resource: ... }) + @UseInterceptors(MetaDataInterceptor, AuditInterceptor) for write ops'
+  - 'ScopeResolverService.ResolveDepartmentIds(semesterId) returns string[] | null — null = unrestricted, [] = 403, string[] = filter set'
+  - 'Service methods PascalCase (CreatePipeline, ConfirmPipeline, ...)'
+  - 'Zod + class-validator DTOs for requests; Zod response schemas'
+  - 'EntityManager.fork() for isolated DB context within async methods'
+  - 'Nullable scope fields on AnalysisPipeline — pipeline can be department-only / program-only / faculty-only / etc.'
+  # Frontend
+  - 'Feature-sliced: features/<feature>/{api,hooks,components,types,lib,index.ts} — FAC-132 does NOT use schemas/ or store/ subfolders'
+  - 'Thin Axios requests in api/*.requests.ts that return response.data'
+  - 'TanStack Query hooks in hooks/use-*.ts with queryKey + enabled: Boolean(token) gating'
+  - 'Query keys MUST NOT include the auth token — token is an Axios interceptor header, not cache identity (prior `use-report-status.ts` included it; new FAC-132 hooks deliberately diverge for consistent invalidation)'
+  - 'Pipeline status values are UPPERCASE strings matching the backend PipelineStatus enum: AWAITING_CONFIRMATION | EMBEDDING_CHECK | SENTIMENT_ANALYSIS | SENTIMENT_GATE | TOPIC_MODELING | GENERATING_RECOMMENDATIONS | COMPLETED | FAILED | CANCELLED'
+  - 'useActiveRole() from @/features/auth/hooks/use-active-role for role branching; APP_ROLES constants from @/constants/roles'
+  - 'Composition-based screens: header → metrics → charts → new pipeline row → attention/faculty-list'
+  - 'No server state duplicated into Zustand — React Query is the source of truth'
+test_patterns:
+  # Backend
+  - 'NestJS Test.createTestingModule with controllers + useValue mocks'
+  - '.overrideGuard(AuthGuard("jwt")).useValue({ canActivate: () => true }) for JWT bypass in controller specs'
+  - '.overrideGuard(RolesGuard).useValue({ canActivate: () => true }) for role bypass in controller specs (behavior verified separately in roles.guard.spec.ts — not re-tested here)'
+  - '.overrideInterceptor(CurrentUserInterceptor).useValue({ intercept: (_ctx, next) => next.handle() }) to no-op the interceptor'
+  - 'Service specs mock ScopeResolverService with jest.fn() returning null / [] / [ids] to exercise scope branches'
+  - 'Tests co-located as *.spec.ts alongside the source'
+  # Frontend
+  - 'NO test framework established in app.faculytics as of 2026-04-14 — document gap; rely on manual E2E verification for this ticket; do NOT introduce Vitest/RTL in this spec (separate convention-setting ticket)'
+---
+
+# Tech-Spec: FAC-132 feat: role-aware analysis pipeline triggering and output surfacing
+
+**Created:** 2026-04-14
+
+**Source Issue:** https://github.com/CtrlAltElite-Devs/api.faculytics/issues/319
+
+## Overview
+
+### Problem Statement
+
+The analysis pipeline is fully built on the backend but **disconnected from the product**:
+
+1. **No role guards on triggering.** `POST /analysis/pipelines`, `/:id/confirm`, and `/:id/cancel` are protected by `@UseJwtGuard()` with no role restrictions. Any authenticated user — including a STUDENT — can trigger a pipeline for any scope.
+2. **Zero frontend consumers.** There are no callers of the pipeline trigger/status endpoints in either `app.faculytics` or `admin.faculytics`. The pipeline is ungrafted from the UI.
+3. **Pipeline output is invisible to stakeholders.** The `/analytics/*` endpoints that Dean / Campus Head / Chairperson dashboards consume read only the stats-oriented materialized views (`mv_faculty_semester_stats`, `mv_faculty_trends`). They do not surface topic themes, LLM-generated recommendations, or sentiment distributions that the pipeline produces.
+4. **Net effect.** The pipeline produces signal (topics, strengths, improvements, sentiment gate outcomes) that never reaches the Faculty / Dean / Campus Head / Chairperson who would act on it. #319 calls this out as the core gap: "we need to enhance the analysis pipeline interaction, how to seamlessly integrate it with app.faculytics."
+
+### Solution
+
+A single integration slice delivered as one PR covering both backend guards and frontend surfacing:
+
+1. **Backend role + scope guards** on pipeline trigger endpoints. SUPER_ADMIN (any scope). DEAN / CAMPUS_HEAD / CHAIRPERSON (their institutional scope only, validated against `UserInstitutionalRole` assignments). FACULTY (read-only on their own pipelines — no triggering). STUDENT (blocked entirely from `/analysis/*`). One canonical `AnalysisPipeline` per `(semester, scope)` tuple — role determines the view filter, not the computation. This is what the current entity design already implies (scope-keyed pipelines with nullable scope fields) and what the orchestrator's duplicate-check logic already enforces.
+2. **Live reads, no new MVs.** Query `topic_assignment` and `recommended_action` directly by `pipelineId`. Defer materialization until read latency at dean/campus-head scope is demonstrated to need it.
+3. **Frontend surfacing in `app.faculytics`** (`features/faculty-analytics/` feature slice):
+   - **Faculty report page**: topic-theme chips + faculty-level LLM recommendation card on the existing `faculty-report-screen.tsx`.
+   - **Dean / Campus Head / Chairperson dashboard** (`scoped-analytics-dashboard-screen.tsx`): trigger-pipeline button (scope-aware), status poller reusing the FAC polling contract, ranked department-level topic themes, and a recommendations list filtered/grouped from faculty-level records.
+
+### Scope
+
+**In Scope:**
+
+- Role + scope guards on `POST /analysis/pipelines`, `POST /analysis/pipelines/:id/confirm`, `POST /analysis/pipelines/:id/cancel` (backend).
+- Read access to `GET /analysis/pipelines/:id/status` and `GET /analysis/pipelines/:id/recommendations` gated per role (a faculty member can read their own pipeline, a dean can read pipelines within their scope, etc.).
+- Any new or extended backend read endpoint required to surface topic themes keyed by `pipelineId` (e.g., `GET /analysis/pipelines/:id/topics`) if the existing endpoints do not already cover it.
+- Scope-validation helper that checks a user's `UserInstitutionalRole` assignments against the requested pipeline scope.
+- Frontend trigger-pipeline UI (button + confirmation dialog + coverage warnings) for DEAN / CAMPUS_HEAD / CHAIRPERSON / SUPER_ADMIN on the scoped analytics dashboard.
+- Frontend pipeline-status polling hook (React Query `refetchInterval`) that reuses the polling DTO contract established by the `frontend-pipeline-polling` spec.
+- Shared topic-themes component rendered in two framings: a chip list on the faculty report and a ranked/frequency-ordered list on the scoped dashboard.
+- Shared recommendations card (faculty-level records surfaced on the faculty report; grouped/filtered on the scoped dashboard).
+- Unit + integration tests for guard logic (NestJS `Test.createTestingModule` with mocked role/scope providers).
+- Frontend automated tests are NOT in scope — see TD-6 (no test framework established in `app.faculytics`); verification is manual E2E.
+
+**Out of Scope:**
+
+- Aggregate (department / program / campus-level) LLM recommendation prompts and evidence assembly — tracked as a follow-up ticket.
+- New materialized views for topics or recommendations — deferred until live-query latency is demonstrated to need them.
+- Auto-triggering pipelines on semester close — tracked as a follow-up ticket.
+- WebSocket / SSE live updates — polling is sufficient given the current pipeline duration profile.
+- Admin console (`admin.faculytics`) pipeline triggers — the issue scopes integration to `app.faculytics` only.
+- Student-facing surfaces — students do not interact with pipeline output in this slice.
+- Backfilling role/scope guards onto historical pipelines (existing pipelines continue to be readable under the new guard logic, but their triggerer is not retroactively validated).
+- Changes to pipeline execution, sentiment gate, topic-model prompts, or recommendation LLM prompts — this ticket surfaces existing output; it does not change how output is computed.
+
+## Context for Development
+
+### Technical Preferences & Constraints
+
+- **Single PR, two repos.** Delivered as one atomic integration slice per yander's decision during spec discovery (2026-04-14). Acknowledges larger review surface in exchange for end-to-end shipability and single rollback boundary.
+- **No new MVs.** Team synthesis (Winston/Mary): query live tables by `pipelineId`. Revisit only if dean-scope reads are measurably slow.
+- **One canonical pipeline per scope.** Role = view filter, not compute boundary. Aligns with existing `AnalysisPipeline` entity design and the orchestrator's active-duplicate check.
+- **Faculty do not trigger.** Consumer-only role. Avoids concurrency chaos and matches the UX mental model (faculty read their feedback; deans orchestrate the computation).
+- **Reuse before build.** Frontend reuses the polling DTO contract, the existing `scoped-analytics-dashboard-screen.tsx`, the existing `faculty-report-screen.tsx`, and the existing React Query patterns in `features/faculty-analytics/`. Topic + recommendations components are shared across faculty and scoped dashboard surfaces with different framings.
+- **Boring-tech defaults.** React Query `refetchInterval` for polling (no WebSockets). Live SQL queries (no new MVs). Standard NestJS guard composition (no custom auth middleware).
+
+### Scope Resolution Reference
+
+This ticket builds on the scope-resolution philosophy finalized in FAC-125, FAC-127, FAC-128, FAC-129, FAC-130, and FAC-131:
+
+- FAC-128 snapshot faculty home-department onto submissions.
+- FAC-129 filtered dean faculty listing by home department.
+- FAC-130 rewired `mv_faculty_semester_stats` to aggregate by faculty home department.
+- FAC-131 introduced the CAMPUS_HEAD role.
+
+The institutional-role resolution logic (`UserInstitutionalRole`, scope codes, etc.) established by this prior work is the substrate for the scope-validation helper this ticket adds.
+
+### Codebase Patterns
+
+**Backend guard composition (copy exactly):**
+
+The `@UseJwtGuard(...roles: UserRole[])` decorator at `api.faculytics/src/security/decorators/index.ts:12-25` applies `AuthGuard('jwt')` + `RolesGuard` when roles are passed. `RolesGuard` at `src/security/guards/roles.guard.ts:19-54` reads `ROLES_KEY` metadata and intersects with `user.roles`. Applied per method or class.
+
+The reference pattern for a scoped controller is `AnalyticsController` (`src/modules/analytics/analytics.controller.ts:29-36`):
+
+```typescript
+@UseJwtGuard(UserRole.DEAN, UserRole.CHAIRPERSON, UserRole.CAMPUS_HEAD, UserRole.SUPER_ADMIN)
+@UseInterceptors(CurrentUserInterceptor)
+export class AnalyticsController { ... }
+```
+
+`AnalysisController` copies this shape, then applies **method-level narrowing** for read-only endpoints where FACULTY should be allowed to read their own pipeline (see Technical Decisions → TD-1).
+
+**Scope resolution (reuse, do not reinvent):**
+
+`ScopeResolverService` at `src/modules/common/services/scope-resolver.service.ts` exposes three result-typed helpers: `ResolveDepartmentIds(semesterId)`, `ResolveProgramIds(semesterId)`, `ResolveProgramCodes(semesterId)`. All return `string[] | null` where `null` = unrestricted (SUPER_ADMIN), `[]` = no access (throw 403), `string[]` = allowed IDs/codes. The service internally resolves the caller via `CurrentUserService.getOrFail()` which reads CLS context populated by `CurrentUserInterceptor`.
+
+For pipeline scope validation, the orchestrator's `CreatePipeline` / `ConfirmPipeline` / `CancelPipeline` / `GetPipelineStatus` / `GetRecommendations` methods must add a call to the scope resolver **before** any DB work. The exact validation matrix is in Technical Decisions → TD-2.
+
+**Frontend feature-slice (non-negotiable):**
+
+Every new file for this ticket lives inside `app.faculytics/features/faculty-analytics/`. Placement rules from `app.faculytics/docs/ARCHITECTURE.md` §2 and §8:
+
+| Artifact                | Goes in                                        |
+| ----------------------- | ---------------------------------------------- |
+| Axios request functions | `features/faculty-analytics/api/*.requests.ts` |
+| TanStack Query hooks    | `features/faculty-analytics/hooks/use-*.ts`    |
+| TS types (request/resp) | `features/faculty-analytics/types/index.ts`    |
+| Pure helpers            | `features/faculty-analytics/lib/*.ts`          |
+| React components        | `features/faculty-analytics/components/*.tsx`  |
+| Public exports          | `features/faculty-analytics/index.ts`          |
+
+Forbidden: reintroducing root `hooks/<feature>/`, `network/requests/*`, or `types/<feature>/` folders; importing feature requests into shared shell components; duplicating server state in Zustand.
+
+**React Query + Axios pattern (template for pipeline hooks):**
+
+```typescript
+// api/analysis-pipeline.requests.ts
+export async function fetchPipelineStatus(pipelineId: string) {
+  const response = await apiClient.get<PipelineStatusResponse>(
+    Endpoints.analysisPipelinesStatus.replace(':id', pipelineId),
+  );
+  return response.data;
+}
+
+// hooks/use-pipeline-status.ts
+const TERMINAL_STATUSES: ReadonlySet<PipelineStatus> = new Set([
+  'COMPLETED',
+  'FAILED',
+  'CANCELLED',
+]);
+
+export function usePipelineStatus(
+  pipelineId: string | null,
+  options?: { enabled?: boolean },
+) {
+  const token = useAuthStore((state) => state.token);
+  return useQuery({
+    queryKey: ['analysis', 'pipeline-status', pipelineId], // NOTE: no token in queryKey
+    enabled:
+      Boolean(token) && Boolean(pipelineId) && (options?.enabled ?? true),
+    queryFn: () => fetchPipelineStatus(pipelineId!),
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status && TERMINAL_STATUSES.has(status) ? false : 3000;
+    },
+  });
+}
+```
+
+Note the divergences from `use-report-status.ts`: (1) terminal-status values are **UPPERCASE** to match the backend `PipelineStatus` enum (`'COMPLETED' | 'FAILED' | 'CANCELLED'`), (2) the auth token is NOT part of `queryKey` (token goes through Axios headers), (3) uses a `ReadonlySet` for membership clarity. These apply to ALL new pipeline hooks in this ticket.
+
+**Topic data is embedded in recommendations (no separate topics endpoint):**
+
+`RecommendedAction.supportingEvidence` is a JSONB field whose Zod schema at `src/modules/analysis/dto/recommendations.dto.ts:1-47` contains `sources: (TopicSource | DimensionScoresSource)[]` where `TopicSource` = `{ type: 'topic', topicLabel, commentCount, sentimentBreakdown: {positive,neutral,negative}, sampleQuotes: string[].max(3) }`. This is sufficient to render theme chips (faculty report) and a ranked theme list (scoped dashboard) without any new backend endpoint. See Technical Decisions → TD-3.
+
+**Scope shape in `GetPipelineStatus` — IDs + display values side by side:**
+
+The current `GetPipelineStatus` response at `pipeline-orchestrator.service.ts:550-561` emits `scope` as display values (`semester.code`, `department.code`, `faculty.fullName`, `course.shortname`). This is ambiguous for frontend consumers that need UUIDs for lookups/invalidation. **This ticket extends the shape to emit both IDs and display values side by side** — e.g., `scope: { semesterId, semesterCode, departmentId, departmentCode, facultyId, facultyName, programId, programCode, campusId, campusCode, courseId, courseShortname, questionnaireVersionId }`. Existing display fields remain for backwards-compat. See TD-9.
+
+**Tests (backend only — no frontend test framework):**
+
+Controller specs: `.overrideGuard(AuthGuard('jwt')).useValue({ canActivate: () => true })` + same for `RolesGuard`. **`AnalysisController` already has its own test harness** (`auditTestProviders() + overrideAuditInterceptors(builder)`) — extend that, do NOT copy the simpler `analytics.controller.spec.ts` pattern. Add `.overrideInterceptor(CurrentUserInterceptor).useValue({ intercept: (_ctx, next) => next.handle() })` on top of the existing audit harness.
+
+Service specs: mock `ScopeResolverService` methods with `jest.fn()` returning `null` / `[]` / `['id-1']` per scenario. Mock `CurrentUserService.getOrFail()` to return the user under test. Pattern at `src/modules/analytics/analytics.service.spec.ts:24-27, 40-99`.
+
+Frontend: `app.faculytics` has **no established test framework or tests** as of 2026-04-14. Introducing one is explicitly out of scope for this ticket; verification happens via manual E2E against a running dev stack.
+
+### Files to Reference
+
+| File                                                                                                    | Purpose                                                                                                                                                                                                              |
+| ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `api.faculytics/src/security/decorators/index.ts:12-25`                                                 | `@UseJwtGuard` decorator signature — copy role-args style to analysis controller                                                                                                                                     |
+| `api.faculytics/src/security/guards/roles.guard.ts:19-54`                                               | Reads `ROLES_KEY` metadata; throws `ForbiddenException` on role mismatch                                                                                                                                             |
+| `api.faculytics/src/modules/auth/roles.enum.ts`                                                         | `UserRole` enum — `SUPER_ADMIN`, `DEAN`, `CHAIRPERSON`, `CAMPUS_HEAD`, `FACULTY`, `STUDENT`                                                                                                                          |
+| `api.faculytics/src/modules/analytics/analytics.controller.ts:29-36`                                    | Canonical scoped-controller pattern: `@UseJwtGuard(...roles)` + `@UseInterceptors(CurrentUserInterceptor)`                                                                                                           |
+| `api.faculytics/src/modules/analytics/analytics.service.ts:74-94, 1061-1090`                            | Scope-filter application: `ResolveDepartmentIds`, `ResolveDepartmentCodes`, `IsProgramCodeInScope` — reuse the pattern inside `PipelineOrchestratorService`                                                          |
+| `api.faculytics/src/modules/common/services/scope-resolver.service.ts:22-215`                           | `ResolveDepartmentIds`, `ResolveProgramIds`, `ResolveProgramCodes`, `resolveCampusHeadDepartmentIds` — the scope authorization substrate                                                                             |
+| `api.faculytics/src/modules/common/cls/current-user.service.ts`                                         | CLS-backed `getOrFail()` — how scope resolver reads the caller                                                                                                                                                       |
+| `api.faculytics/src/modules/common/interceptors/current-user.interceptor.ts:12-28`                      | Populates CLS with the full `User` entity on every request                                                                                                                                                           |
+| `api.faculytics/src/entities/user-institutional-role.entity.ts`                                         | `UserInstitutionalRole` — how DEAN/CHAIRPERSON/CAMPUS_HEAD scope is stored (user + role + moodleCategory depth determines scope)                                                                                     |
+| `api.faculytics/src/entities/analysis-pipeline.entity.ts`                                               | Already has nullable scope FKs (faculty, department, program, campus, course, questionnaireVersion) + `triggeredBy` FK. No entity change needed                                                                      |
+| `api.faculytics/src/modules/analysis/analysis.controller.ts`                                            | 5 endpoints currently using bare `@UseJwtGuard()` — target of role-guard work                                                                                                                                        |
+| `api.faculytics/src/modules/analysis/services/pipeline-orchestrator.service.ts:88-242`                  | `CreatePipeline` / `ConfirmPipeline` — no ownership validation today; add scope checks                                                                                                                               |
+| `api.faculytics/src/modules/analysis/dto/pipeline-status.dto.ts`                                        | Polling DTO — already includes `scope` object with semester/department/faculty/program/campus/course; frontend consumes as-is                                                                                        |
+| `api.faculytics/src/modules/analysis/dto/responses/recommendations.response.dto.ts`                     | Recommendations response — includes `actions[].supportingEvidence` with topic sources                                                                                                                                |
+| `api.faculytics/src/modules/analysis/dto/recommendations.dto.ts:1-47`                                   | Zod schema for `supportingEvidence`: topic sources + dimension sources + confidence level                                                                                                                            |
+| `api.faculytics/src/modules/analysis/services/recommendation-generation.service.ts`                     | Existing topic-source aggregation (label + sentiment + quotes). This is the data the frontend will render — no new backend work to expose topics separately                                                          |
+| `api.faculytics/docs/workflows/analysis-pipeline.md`                                                    | Pipeline lifecycle reference — must gain an "Access Control" section                                                                                                                                                 |
+| `api.faculytics/docs/architecture/scope-resolution.md`                                                  | Scope rules — must gain a pipeline-scope addendum                                                                                                                                                                    |
+| `api.faculytics/_bmad-output/implementation-artifacts/tech-spec-fac-131-campus-head-role.md`            | Template for role addition: controllers touched, scope-resolver branch added                                                                                                                                         |
+| `api.faculytics/_bmad-output/implementation-artifacts/tech-spec-fac-127-admin-manual-scope-override.md` | Scope-assignment flow primer (not directly modified here; informs how scope is provisioned)                                                                                                                          |
+| `api.faculytics/_bmad-output/implementation-artifacts/tech-spec-frontend-pipeline-polling.md`           | Polling DTO contract already established; frontend consumes it as-is                                                                                                                                                 |
+| `api.faculytics/_bmad-output/implementation-artifacts/tech-spec-recommendation-engine-faculty-level.md` | Recommendation engine shape + supporting-evidence schema (faculty-level only; aggregate scope is out-of-scope for FAC-132)                                                                                           |
+| `api.faculytics/src/modules/analytics/analytics.controller.spec.ts:33-41`                               | Guard-override test pattern — copy into analysis controller spec                                                                                                                                                     |
+| `api.faculytics/src/modules/analytics/analytics.service.spec.ts:24-27, 40-99`                           | Scope-resolver mock pattern for service tests                                                                                                                                                                        |
+| `app.faculytics/docs/ARCHITECTURE.md`                                                                   | Feature-slice rules (§2, §8, §11) — hard constraints for every frontend file added                                                                                                                                   |
+| `app.faculytics/features/faculty-analytics/api/faculty-analytics.requests.ts`                           | Existing analytics requests — reference only; FAC-132 creates a SEPARATE `api/analysis-pipeline.requests.ts` file (do not extend this one)                                                                           |
+| `app.faculytics/features/faculty-analytics/hooks/use-faculty-report.ts`                                 | useQuery + auth-token gating + queryKey template — copy the structure, but new FAC-132 hooks OMIT the token from `queryKey` (see Codebase Patterns)                                                                  |
+| `app.faculytics/features/faculty-analytics/hooks/use-report-status.ts`                                  | `refetchInterval` polling template — structure only; FAC-132 diverges on UPPERCASE terminal-status values and tokenless queryKey                                                                                     |
+| `app.faculytics/features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx:1-87`       | Host screen currently mounted only at `/dean/dashboard` and `/campus-head/dashboard` — compose pipeline trigger + themes + recs here. CHAIRPERSON/SUPER_ADMIN dashboard mounting is deferred (see Known Limitations) |
+| `app.faculytics/features/faculty-analytics/components/faculty-report-screen.tsx:1-134`                  | Host screen for faculty view; compose theme chips + recs card here                                                                                                                                                   |
+| `app.faculytics/features/auth/hooks/use-active-role.ts:1-42`                                            | `useActiveRole()` — current user's active role for component-level gating                                                                                                                                            |
+| `app.faculytics/constants/roles.ts:1-13`                                                                | `APP_ROLES` enum — imports for role branching                                                                                                                                                                        |
+| `app.faculytics/network/endpoints.ts`                                                                   | Endpoint enum — add 6 pipeline entries (list, create, confirm, cancel, status, recommendations)                                                                                                                      |
+| `api.faculytics/src/modules/analysis/enums/pipeline-status.enum.ts`                                     | **Source of truth for `PipelineStatus` string values** (UPPERCASE). Frontend types MUST mirror verbatim                                                                                                              |
+| `api.faculytics/src/modules/analysis/dto/recommendations.dto.ts:15`                                     | `sampleQuotes: z.array(z.string()).max(3)` — pipeline-themes helper must respect this ceiling (not "up to 5" as earlier draft claimed)                                                                               |
+
+### Technical Decisions
+
+**TD-1 — Guard granularity: controller-level allowlist with method-level narrowing.**
+
+Apply `@UseJwtGuard(UserRole.DEAN, UserRole.CHAIRPERSON, UserRole.CAMPUS_HEAD, UserRole.SUPER_ADMIN)` at the class level for write operations (create/confirm/cancel). For read endpoints (`GET /:id/status`, `GET /:id/recommendations`), widen with a method-level `@UseJwtGuard(...scopedRoles, UserRole.FACULTY)` so a faculty member can read their own pipeline. STUDENT is implicitly blocked because they never appear in any guard's allowlist. Service-layer scope validation still enforces that a FACULTY can only read pipelines whose `faculty` FK matches their userId.
+
+**TD-2 — Pipeline-scope authorization matrix (enforced in the orchestrator service).** Create rules differ from List rules.
+
+**Create / Confirm / Cancel / Read-by-id (requires explicit scope):**
+
+| Role        | Create                                                                                                                    | Confirm/Cancel                                       | Read Status/Recs                                |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | ----------------------------------------------- |
+| SUPER_ADMIN | Any scope (incl. `semesterId` only)                                                                                       | Any pipeline                                         | Any pipeline                                    |
+| DEAN        | Explicit `departmentId` required; must ∈ `ResolveDepartmentIds(semesterId)`                                               | Pipeline's `department` ∈ resolved set               | Same as Create                                  |
+| CHAIRPERSON | Explicit `programId` required; must ∈ `ResolveProgramIds(semesterId)`                                                     | Pipeline's `program` ∈ resolved set                  | Same as Create                                  |
+| CAMPUS_HEAD | Explicit `campusId` or `departmentId` required; campus must ∈ `ResolveCampusIds(semesterId)`, or dept ∈ campus's dept set | Pipeline's `campus`/`department` within their campus | Same as Create                                  |
+| FACULTY     | _(blocked at guard — 403)_                                                                                                | _(blocked at guard — 403)_                           | Pipeline whose `faculty` FK equals their userId |
+| STUDENT     | _(blocked at guard — 403)_                                                                                                | _(blocked at guard — 403)_                           | _(blocked at guard — 403)_                      |
+
+Absence of the required explicit scope filter → `BadRequestException` with message `"scope filter required for your role"`. Scope provided but outside resolved set → `ForbiddenException`.
+
+**List (`GET /analysis/pipelines`) — defaults to the caller's resolved scope:**
+
+| Role        | Behavior                                                                                                                                                |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SUPER_ADMIN | Returns all pipelines matching the query (unfiltered)                                                                                                   |
+| DEAN        | If query omits `departmentId`, service fills with `ResolveDepartmentIds(semesterId)`. If query provides `departmentId`, verify ∈ resolved set else 403. |
+| CHAIRPERSON | Same with `programId` and `ResolveProgramIds(semesterId)`                                                                                               |
+| CAMPUS_HEAD | Same with `campusId` and `ResolveCampusIds(semesterId)`                                                                                                 |
+| FACULTY     | Service forces `facultyId = currentUser.id` (any `facultyId` in the query is silently overridden)                                                       |
+| STUDENT     | _(blocked at guard — 403)_                                                                                                                              |
+
+List returns `PipelineSummaryResponseDto[]` ordered by `createdAt DESC`, limit 10. This difference lets a DEAN's dashboard call `listPipelines({ semesterId })` without first needing to enumerate department IDs on the client — solving the "frontend has no `departmentId`" gap.
+
+**TD-3 — No new `/analysis/pipelines/:id/topics` endpoint. Themes derived on the frontend from recommendations evidence.**
+
+The existing `GET /analysis/pipelines/:id/recommendations` response embeds topic sources inside `actions[].supportingEvidence.sources`. A pure-function helper `lib/pipeline-themes.ts::aggregateThemes(actions)` on the frontend deduplicates + ranks topics by aggregate `commentCount` and blends `sentimentBreakdown` weights. The helper caps `sampleQuotes` at **3 per topic** (matching the backend schema's `z.array(z.string()).max(3)`). Dedup rule: first occurrence wins (preserves the order LLM emitted). Avoids a new backend endpoint, a new service method, and a new round-trip.
+
+**TD-4 — Faculty see only their own recommendations.**
+
+When a FACULTY calls `GET /analysis/pipelines/:id/recommendations` or `/status`, the orchestrator populates `pipeline.faculty` explicitly (`findOne(..., { populate: ['faculty'] })`) and verifies `pipeline.faculty?.id === currentUser.id`. If the pipeline is department-scoped (null faculty FK), the faculty cannot read it — they only see pipelines created _for them_. Frontend discovers a faculty's current pipeline via `GET /analysis/pipelines?semesterId=X&facultyId=<self>` (list endpoint silently coerces `facultyId` to currentUser).
+
+**TD-5 — Discovery via `GET /analysis/pipelines?semesterId=&...`.**
+
+Query params: `semesterId` (required), `facultyId`, `departmentId`, `programId`, `campusId`, `courseId`, `questionnaireVersionId` (all optional). Returns `PipelineSummaryResponseDto[]`. Scope-filling behavior per TD-2 "List" table above. The frontend uses this to find "the latest pipeline for my scope" so status + recommendations hooks can key off the discovered id.
+
+**TD-6 — Frontend tests deliberately deferred.**
+
+`app.faculytics` has no test framework established. Introducing one (Vitest + React Testing Library, most likely) is a separate convention-setting ticket. This ticket verifies frontend work via manual E2E against a running dev stack (API on :5200, app on :3000).
+
+**TD-7 — Documentation updates are part of this PR.**
+
+`docs/workflows/analysis-pipeline.md` gains an "Access Control" section. `docs/architecture/scope-resolution.md` gains a one-paragraph pipeline addendum. Without these, the access-control rules become tribal knowledge.
+
+**TD-8 — Partial unique index enforces one-canonical-pipeline-per-scope.**
+
+The orchestrator's current `findOne → create` dedup check at `pipeline-orchestrator.service.ts:100-118` is a TOCTOU race. Ship a partial unique index (MikroORM raw-SQL migration):
+
+```sql
+CREATE UNIQUE INDEX uq_analysis_pipeline_active_scope
+  ON analysis_pipeline (
+    semester_id,
+    COALESCE(faculty_id, 'NONE'),
+    COALESCE(department_id, 'NONE'),
+    COALESCE(program_id, 'NONE'),
+    COALESCE(campus_id, 'NONE'),
+    COALESCE(course_id, 'NONE'),
+    COALESCE(questionnaire_version_id, 'NONE')
+  )
+  WHERE status NOT IN ('COMPLETED','FAILED','CANCELLED') AND deleted_at IS NULL;
+```
+
+**Column-type note (verified 2026-04-14 against `Migration20260313170918.ts:13`):** `analysis_pipeline` FK columns are `varchar(255)`, not `uuid` — so the sentinel is the text literal `'NONE'` (no cast). Do NOT write `::uuid` casts in this index; they will fail to compile against the current column types.
+
+The orchestrator's `CreatePipeline` wraps the `findOne → create → flush` sequence in a try/catch for `UniqueConstraintViolationException` (imported from `@mikro-orm/core`); on catch it re-fetches the existing active pipeline and returns it (idempotent). Matches the project's `Anti-Pattern (Unique Constraint)` rule from CLAUDE.md (partial indexes for nullable/soft-delete-aware uniqueness). The sentinel-text trick is used because Postgres unique constraints treat NULL as distinct by default — replacing each nullable column with a stable sentinel value inside the index expression fixes this.
+
+**TD-9 — `GetPipelineStatus` scope response shape is REPLACED with an IDs + display paired shape. This is a contract change, not an additive extension.**
+
+Current response emits `scope: { semester, department, faculty, program, campus, course }` as display values only (codes, names, shortnames). Replace with:
+
+```typescript
+scope: {
+  semesterId: string;
+  semesterCode: string;
+  departmentId: string | null;
+  departmentCode: string | null;
+  facultyId: string | null;
+  facultyName: string | null;
+  programId: string | null;
+  programCode: string | null;
+  campusId: string | null;
+  campusCode: string | null;
+  courseId: string | null;
+  courseShortname: string | null;
+  questionnaireVersionId: string | null; // no display field; the id IS the stable identity today
+}
+```
+
+IDs are what the frontend uses for `queryClient.invalidateQueries`, scope comparisons, and lookups. Display values coexist for UI rendering.
+
+**Why this is safe despite breaking the old shape:**
+
+The `frontend-pipeline-polling` spec (referenced under Dependencies) declared the DTO contract but has **zero frontend consumers** as of 2026-04-14 (verified by the Step 1/2 investigation — no `/analysis/pipelines/:id/status` callers exist in `app.faculytics` or `admin.faculytics`). Replacing the shape now costs nothing in live-user impact. The backend-side `pipelineStatusSchema` Zod definition AND the corresponding spec (`pipeline-orchestrator.service.spec.ts`) both need updating as part of Task 9 — the `scope` assertions in existing tests will fail otherwise. Capture that rewrite as an explicit sub-task.
+
+**Type structure on the frontend:**
+
+- `PipelineScopeIds` — UUIDs only, used for `CreatePipelineRequest` and `ListPipelinesQuery` inputs (what the client sends).
+- `PipelineScopeDisplay` — IDs + display paired, used for `PipelineStatusResponse.scope` (what the server returns).
+
+**If a historical consumer ever surfaces** (unlikely — backend-only contract today), write a compat mapper in the consuming module. No mapper shipped in FAC-132 because no consumer exists.
+
+## Implementation Plan
+
+Tasks are ordered by dependency: backend module wiring → backend service scope logic → backend controller guards → backend tests → backend docs → frontend types/endpoints → frontend requests → frontend hooks (queries/mutations) → frontend lib helpers → frontend leaf components → frontend screen integration → barrel exports → manual E2E verification.
+
+**Resolved open questions from Step 2 (+ adversarial-review revisions):**
+
+- **TD-2 — split Create vs List rules.** Create/Confirm/Cancel/Read-by-id require explicit scope for non-SUPER_ADMIN and 400 if absent. List (`GET /analysis/pipelines`) fills in the caller's resolved scope when the query omits it, so a DEAN can call `listPipelines({ semesterId })` without needing a client-side `departmentId`. See TD-2 table.
+- **TD-5 resolution (pipeline discovery).** Add `GET /analysis/pipelines` with query params `semesterId` (required), `facultyId`, `departmentId`, `programId`, `campusId`, `courseId`, `questionnaireVersionId` (all optional). Returns `PipelineSummaryResponseDto[]`. List semantics per TD-2.
+- **TD-8 — partial unique index** on active-pipeline scope tuple, enforced at DB level. Replaces the weaker `findOne → create` TOCTOU dedup. Orchestrator catches `UniqueConstraintViolationException` and re-fetches for idempotence.
+- **TD-9 — `GetPipelineStatus.scope` returns IDs + display values side by side.** Frontend `PipelineScopeIds` (UUIDs, used for lookups) and `PipelineScopeDisplay` (codes/names + ids, used for UI) are split types.
+
+### Tasks
+
+#### Backend — `api.faculytics`
+
+- [x] **Task 1: Verify `AnalysisModule` already exposes `ScopeResolverService` + `CurrentUserService` through `CommonModule`.**
+  - File: `src/modules/analysis/analysis.module.ts` (read-only)
+  - Action: Confirm `CommonModule` is already in `imports` (it is, at L47 per verification 2026-04-14). Confirm `CommonModule` exports `ScopeResolverService` (it does, `common.module.ts:18`) and re-exports `AppClsModule` which provides `CurrentUserService` (it does, `cls.module.ts:6-7`). **No code change required.** If `CommonModule` is for any reason missing, add it and move on. This task exists only because the adversarial review flagged the assumption; keep it so future readers see the verification.
+  - Notes: Do NOT add redundant providers. Verified 2026-04-14 against `common.module.ts` lines 7/12/18.
+
+- [x] **Task 2: Add `ListPipelinesQueryDto` + `PipelineSummaryResponseDto` (with `warnings`).**
+  - Files (new): `src/modules/analysis/dto/list-pipelines.dto.ts`, `src/modules/analysis/dto/responses/pipeline-summary.response.dto.ts`
+  - Action: Zod schema `listPipelinesQuerySchema` mirroring `createPipelineSchema` (semesterId required, rest optional). `PipelineSummaryResponseDto.Map(pipeline)` producing `{ id, status, scope: <TD-9 shape>, coverage, warnings: string[], createdAt, updatedAt, completedAt }`. Warnings are included because the trigger-card confirmation dialog (AC-19) consumes them without a second roundtrip to `/status`.
+  - Notes: Copy DTO shape conventions from `create-pipeline.dto.ts` (class-validator + Zod + Swagger). Scope sub-shape per TD-9 — include both IDs and display values.
+
+- [x] **Task 3: Add scope-authorization helpers to `PipelineOrchestratorService`.**
+  - File: `src/modules/analysis/services/pipeline-orchestrator.service.ts`
+  - Action: Inject `ScopeResolverService` and `CurrentUserService`. Add three private async methods:
+    - `assertCanCreatePipeline(input: CreatePipelineInput): Promise<void>` — resolves caller, routes on role per TD-2 "Create" table. SUPER_ADMIN: return. FACULTY/STUDENT: throw `ForbiddenException` (belt-and-braces; guard should have blocked). DEAN/CHAIRPERSON/CAMPUS_HEAD: require at least one scope filter beyond `semesterId` (else `BadRequestException('scope filter required for your role')`). For each provided scope, verify containment against `ResolveDepartmentIds(semesterId)` / `ResolveProgramIds(semesterId)` / `ResolveCampusIds(semesterId)` (adding `ResolveCampusIds` per Task 10 if missing). Outside-scope → `ForbiddenException('scope not in your assigned access')`.
+    - `fillAndAssertListScope(query: ListPipelinesQueryInput): Promise<ListPipelinesQueryInput>` — resolves caller per TD-2 "List" table. SUPER_ADMIN: return query unchanged. DEAN: if `departmentId` absent, fill `departmentIds = ResolveDepartmentIds(query.semesterId)` as an IN-filter; if provided, verify ∈ resolved set or 403. CHAIRPERSON/CAMPUS_HEAD: same with program/campus. FACULTY: force `facultyId = currentUser.id` regardless of query value (silent override). Returns the augmented query the orchestrator uses for its actual `find`.
+    - `assertCanAccessPipeline(pipeline: AnalysisPipeline): Promise<void>` — resolves caller; SUPER_ADMIN returns immediately.
+      - **FACULTY branch (handled FIRST):** throw `ForbiddenException` unless `pipeline.faculty != null && pipeline.faculty.id === user.id`. **Do NOT call `ResolveDepartmentIds` / `ResolveProgramIds` / `ResolveCampusIds` from the FACULTY branch** — those resolvers throw `ForbiddenException('User does not have a role with scope access.')` for FACULTY per `scope-resolver.service.ts:41-44`, which would surface the wrong exception message. Return early after the ownership check.
+      - **DEAN / CHAIRPERSON / CAMPUS_HEAD branch:** call the matching resolver, then compare the pipeline's scope FK against the resolved set:
+        - If the relevant scope field on the pipeline is **non-null**: require it ∈ user's resolved set (else 403).
+        - If the relevant scope field on the pipeline is **null** (e.g., `pipeline.department === null` means "no department filter — broader than any single department"): **deny for non-SUPER_ADMIN**. Null scope fields represent broader-than-role access and are reserved for SUPER_ADMIN. This applies regardless of which field is null (department, program, campus). Rationale: a DEAN must not read a pipeline that pulled in submissions from outside their dept; a null-scoped pipeline inherently could have.
+      - **STUDENT:** always 403 (belt-and-braces; guard usually blocks first).
+  - Notes: Pipeline-specific logic lives in orchestrator, not in `ScopeResolverService` (keep the resolver generic). FACULTY auto-override in `fillAndAssertListScope` is the single most security-sensitive rule — leave a code comment because "why" is non-obvious ("prevents enumeration of other faculty's pipelines via the list endpoint").
+
+- [x] **Task 4: Add `ListPipelines` orchestrator method.**
+  - File: `src/modules/analysis/services/pipeline-orchestrator.service.ts`
+  - Action: `async ListPipelines(query: ListPipelinesQueryInput): Promise<AnalysisPipeline[]>`. Validates query via Zod. Calls `fillAndAssertListScope(query)` to resolve and augment. Builds Mikro filter using the augmented query (use `$in` for array-filled fields). Returns pipelines ordered by `createdAt DESC`, limited to 10. Populate `['faculty', 'department', 'program', 'campus', 'course', 'semester', 'questionnaireVersion']` so the summary mapper has data for TD-9 fields.
+
+- [x] **Task 5: Call scope checks from existing orchestrator methods (with explicit `populate: ['faculty']`).**
+  - File: `src/modules/analysis/services/pipeline-orchestrator.service.ts`
+  - Import: `import { UniqueConstraintViolationException } from '@mikro-orm/core';`
+  - Action:
+    - `CreatePipeline`: add `await this.assertCanCreatePipeline(input)` immediately after `createPipelineSchema.parse(dto)` and before the duplicate check (L96). Wrap the subsequent `findOne → create → flush` in try/catch for `UniqueConstraintViolationException` (TD-8). On catch, re-run the duplicate `findOne` and return the existing pipeline.
+    - `ConfirmPipeline`: change the `findOne` to `fork.findOne(AnalysisPipeline, pipelineId, { populate: ['faculty', 'department', 'program', 'campus'] })`. Then `await this.assertCanAccessPipeline(pipeline)` **BEFORE any side effect** — in particular, before the `SENTIMENT_WORKER_URL` check (L184-190) which currently mutates `pipeline.status = FAILED` + flushes on a misconfiguration. **Rule: scope check MUST precede every `fork.flush()`, every `pipeline.status = ...` write, and every enqueue call in this method.** A foreign user must never cause side effects even when the worker URL is misconfigured.
+    - `CancelPipeline`: same populate + `assertCanAccessPipeline` placement — scope check BEFORE setting `status = CANCELLED` or any flush.
+    - `GetPipelineStatus`: change the internal `findOne`/`findOneOrFail` to populate `['faculty', 'department', 'program', 'campus', 'course', 'semester', 'questionnaireVersion']` so TD-9 scope shape can be built with both IDs AND display values. Then `await this.assertCanAccessPipeline(pipeline)`. Update the response builder to emit the new scope shape (replacement, not addition — see TD-9).
+    - `GetRecommendations`: add `{ populate: ['faculty'] }` to its `findOne`. Then `await this.assertCanAccessPipeline(pipeline)`.
+  - Notes: Place the scope check AFTER `findOne` so a 404 takes precedence over 403 (avoids some existence-leakage; documented trade-off in Notes→item 5). The `populate: ['faculty']` on GetRecommendations is critical — without it, `pipeline.faculty?.id` reads through the reference proxy and the ownership check is fragile. For Confirm/Cancel, scope-before-side-effects is a security invariant; code-comment it.
+
+- [x] **Task 6: Apply role guards to `AnalysisController`.**
+  - File: `src/modules/analysis/analysis.controller.ts`
+  - Action:
+    - Class-level: replace `@UseJwtGuard()` with `@UseJwtGuard(UserRole.DEAN, UserRole.CHAIRPERSON, UserRole.CAMPUS_HEAD, UserRole.SUPER_ADMIN)` and add `@UseInterceptors(CurrentUserInterceptor)`.
+    - Method-level widening for read endpoints: `@Get('pipelines')`, `@Get('pipelines/:id/status')`, `@Get('pipelines/:id/recommendations')` each gain a method-level `@UseJwtGuard(UserRole.DEAN, UserRole.CHAIRPERSON, UserRole.CAMPUS_HEAD, UserRole.SUPER_ADMIN, UserRole.FACULTY)`.
+  - Notes: Nest's `Reflector.getAllAndOverride([handler, class])` in `RolesGuard:19-54` is guaranteed to prefer method-level metadata over class-level (this is documented Nest behavior; pre-mortem item 1 in prior draft was over-cautious). No explicit `@SetMetadata` fallback needed.
+
+- [x] **Task 7: Add list endpoint to controller.**
+  - File: `src/modules/analysis/analysis.controller.ts`
+  - Action: `@Get('pipelines')` with `@ApiOperation({ summary: 'List pipelines for a scope' })` + `@ApiQuery` entries matching `listPipelinesQuerySchema`. Delegates to `orchestrator.ListPipelines(query)`. Returns `PipelineSummaryResponseDto[]`. No `@Audited` (read op).
+
+- [x] **Task 7a: Create partial unique index migration.**
+  - File (new): `src/migrations/<timestamp>_fac-132-pipeline-scope-unique-index.ts`
+  - Action: MikroORM raw-SQL migration adding `uq_analysis_pipeline_active_scope` per TD-8 SQL. `down()` drops the index. Verify `npx mikro-orm migration:check` reports no pending entity diffs before and after.
+  - Notes: The sentinel `'00000000-0000-0000-0000-000000000000'::uuid` pattern handles NULLable scope FKs correctly. Required because Postgres treats NULL as distinct in unique constraints.
+
+- [x] **Task 8: Update controller spec — extend existing audit harness.**
+  - File: `src/modules/analysis/analysis.controller.spec.ts`
+  - Action: **DO NOT copy** the `analytics.controller.spec.ts` pattern — `analysis.controller.spec.ts` already has its own harness using `auditTestProviders()` and `overrideAuditInterceptors(builder)`. Extend it:
+    1. Add `.overrideGuard(AuthGuard('jwt')).useValue({ canActivate: () => true })` and `.overrideGuard(RolesGuard).useValue({ canActivate: () => true })` to the existing builder chain.
+    2. Add `.overrideInterceptor(CurrentUserInterceptor).useValue({ intercept: (_ctx: unknown, next: { handle: () => unknown }) => next.handle() })` on top of the audit overrides.
+    3. Add list-endpoint delegation test (calls orchestrator's `ListPipelines` with the query).
+  - Notes: Do NOT re-test the role-guard matrix here — that's covered by `roles.guard.spec.ts` (unchanged) and by service-level scope tests (Task 9). **Do NOT write an "audit fires on 403" test** — `AuditInterceptor` at `src/modules/audit/interceptors/audit.interceptor.ts:47-48` uses RxJS `tap(() => ...)` which only runs on `next`/`complete`, not errors. On a rejected call the audit row is NOT emitted today. That's a pre-existing codebase behavior across every audited endpoint (Moodle sync, ingestion, etc.), out of scope for FAC-132. Documented in Known Limitations.
+
+- [x] **Task 9: Update orchestrator service spec — scope validation matrix + TD-9 contract rewrite.**
+  - File: `src/modules/analysis/services/pipeline-orchestrator.service.spec.ts`
+  - Action: Two sub-tasks in one spec update:
+    1. **Rewrite any existing `GetPipelineStatus` test assertions about the `scope` shape** to match TD-9's replaced contract (IDs + display paired). Old assertions that check `scope.semester`, `scope.department`, `scope.faculty` (display values only) will fail after the service change — replace with assertions on `scope.semesterId + scope.semesterCode`, `scope.departmentId + scope.departmentCode`, `scope.facultyId + scope.facultyName`, etc.
+    2. Add a `describe('scope authorization')` block. Mock `ScopeResolverService` + `CurrentUserService`. Test each row:
+    - SUPER_ADMIN creates with `semesterId` only → success.
+    - SUPER_ADMIN reads any pipeline (foreign faculty, foreign dept) → success. **(AC-5a coverage)**
+    - DEAN creates with `semesterId` only → 400 scope required.
+    - DEAN creates with own `departmentId` → success.
+    - DEAN creates with foreign `departmentId` → 403.
+    - DEAN lists with `{ semesterId }` only → service fills `departmentIds` filter from resolver; returns filtered list.
+    - DEAN lists with foreign `departmentId` → 403.
+    - CAMPUS_HEAD creates with own-campus `departmentId` → success.
+    - CAMPUS_HEAD creates with foreign-campus `departmentId` → 403.
+    - CHAIRPERSON creates with own `programId` → success.
+    - CHAIRPERSON creates with foreign `programId` → 403.
+    - FACULTY reads own pipeline (faculty FK matches) → success.
+    - FACULTY reads pipeline with different faculty FK → 403.
+    - FACULTY reads department-scoped pipeline (null faculty FK) → 403.
+    - FACULTY lists with `facultyId = self` → success.
+    - FACULTY lists with `facultyId = other` → other value silently overridden; verify the query passed to EM uses own id.
+    - **FACULTY invokes `CreatePipeline` directly (simulating guard bypass) → `ForbiddenException` thrown before any DB write. (AC-2a — belt-and-braces.)**
+    - STUDENT any op → 403 (belt-and-braces; guard will usually block first).
+    - **`CreatePipeline` race: two concurrent calls with same scope — one wins, the other catches `UniqueConstraintViolationException` and returns the existing pipeline.** Mock `em.flush` to throw the exception on second call; assert orchestrator returns the existing pipeline from re-fetch. (AC covers TD-8.)
+
+- [x] **Task 10: Add `ResolveCampusIds(semesterId)` to `ScopeResolverService` if missing.**
+  - File: `src/modules/common/services/scope-resolver.service.ts`
+  - Action: Currently `resolveCampusHeadDepartmentIds` derives campus scope internally. For pipeline-scope validation of a CAMPUS_HEAD creating a pipeline with explicit `campusId`, we need a public `ResolveCampusIds(semesterId): Promise<string[] | null>` returning `null` for unrestricted / `[]` for no access / `string[]` for the user's allowed campus UUIDs. If the internal helper can be promoted to public, do so; otherwise write a thin new one.
+
+- [x] **Task 11: Update `docs/workflows/analysis-pipeline.md` with "Access Control" section.**
+  - File: `api.faculytics/docs/workflows/analysis-pipeline.md`
+  - Action: Append a new section `## Access Control` documenting: (a) per-endpoint role allowlist, (b) the TD-2 Create scope-authorization matrix, (c) the TD-2 List default-fill behavior, (d) the FACULTY auto-override rule in `ListPipelines`, (e) the `populate: ['faculty']` requirement for ownership checks, (f) the rule that 404 precedes 403 on missing pipelines (and the enumeration caveat — see Notes→F12).
+
+- [x] **Task 12: Update `docs/architecture/scope-resolution.md` with pipeline addendum.**
+  - File: `api.faculytics/docs/architecture/scope-resolution.md`
+  - Action: Append one short section `### Pipeline-scope authorization` linking to `docs/workflows/analysis-pipeline.md#access-control`, noting that pipeline authorization reuses the shared `ScopeResolverService` helpers.
+
+#### Frontend — `app.faculytics`
+
+- [x] **Task 13: Add endpoint entries.**
+  - File: `app.faculytics/network/endpoints.ts`
+  - Action: Add `analysisPipelinesList = "/api/v1/analysis/pipelines"`, `analysisPipelinesCreate = "/api/v1/analysis/pipelines"`, `analysisPipelinesConfirm = "/api/v1/analysis/pipelines/:id/confirm"`, `analysisPipelinesCancel = "/api/v1/analysis/pipelines/:id/cancel"`, `analysisPipelinesStatus = "/api/v1/analysis/pipelines/:id/status"`, `analysisPipelinesRecommendations = "/api/v1/analysis/pipelines/:id/recommendations"`.
+  - Notes: `list` and `create` share the same URL — separate entries are for clarity in consumer call sites.
+
+- [x] **Task 14: Add frontend types — mirror backend verbatim.**
+  - File: `app.faculytics/features/faculty-analytics/types/index.ts`
+  - Action: Add TypeScript types/interfaces mirroring backend shapes. All enum values are UPPERCASE strings matching `api.faculytics/src/modules/analysis/enums/pipeline-status.enum.ts` verbatim:
+
+    ```typescript
+    export type PipelineStatus =
+      | 'AWAITING_CONFIRMATION'
+      | 'EMBEDDING_CHECK'
+      | 'SENTIMENT_ANALYSIS'
+      | 'SENTIMENT_GATE'
+      | 'TOPIC_MODELING'
+      | 'GENERATING_RECOMMENDATIONS'
+      | 'COMPLETED'
+      | 'FAILED'
+      | 'CANCELLED';
+
+    export type RunStatus = 'PENDING' | 'PROCESSING' | 'COMPLETED' | 'FAILED';
+
+    // IDs only — used for CreatePipelineRequest + ListPipelinesQuery inputs
+    export type PipelineScopeIds = {
+      semesterId: string;
+      facultyId?: string;
+      departmentId?: string;
+      programId?: string;
+      campusId?: string;
+      courseId?: string;
+      questionnaireVersionId?: string;
+    };
+
+    // IDs + display values — shape of pipeline.status response's `scope` (per TD-9)
+    export type PipelineScopeDisplay = {
+      semesterId: string;
+      semesterCode: string;
+      departmentId: string | null;
+      departmentCode: string | null;
+      facultyId: string | null;
+      facultyName: string | null;
+      programId: string | null;
+      programCode: string | null;
+      campusId: string | null;
+      campusCode: string | null;
+      courseId: string | null;
+      courseShortname: string | null;
+      questionnaireVersionId: string | null;
+    };
+    ```
+
+    Plus: `PipelineCoverage` ({ totalEnrolled, submissionCount, commentCount, responseRate, lastEnrollmentSyncAt }), `PipelineStageStatus`, `PipelineStatusResponse` (`status: PipelineStatus`, `scope: PipelineScopeDisplay`, `coverage`, `stages`, `warnings: string[]`, `errorMessage`, `retryable`, `createdAt`, `updatedAt`, `confirmedAt`, `completedAt`), `PipelineSummary` (`status: PipelineStatus`, `scope: PipelineScopeDisplay`, `coverage`, `warnings: string[]`, timestamps), `CreatePipelineRequest` (= `PipelineScopeIds`), `ListPipelinesQuery` (= `PipelineScopeIds`), `TopicSource` (`sampleQuotes: string[]` — note backend caps at 3), `DimensionScoresSource`, `SupportingEvidence`, `RecommendedActionDto`, `RecommendationsResponse` (`status: RunStatus` — NOT `PipelineStatus`).
+
+  - Notes: Add a top-of-file comment naming the backend DTO/enum files these mirror, to aid drift detection. **Runtime-validation caveat for `CreatePipelineRequest`:** the type identity with `PipelineScopeIds` makes every scope field optional at compile time. TypeScript will accept `{ semesterId }` alone. The runtime contract — enforced by the backend per TD-2 — is that non-SUPER_ADMIN callers MUST supply at least one scope filter beyond `semesterId`, or the request returns `400 Bad Request`. This is deliberate: type-level branching by role would require either role-parameterized types or a runtime-only enum tag, both worse than accepting the loose compile-time shape plus a clear code comment at the request function.
+
+- [x] **Task 15: Add pipeline request functions.**
+  - File (new): `app.faculytics/features/faculty-analytics/api/analysis-pipeline.requests.ts`
+  - Action: Export `listPipelines(query)`, `createPipeline(body)`, `confirmPipeline(id)`, `cancelPipeline(id)`, `fetchPipelineStatus(id)`, `fetchPipelineRecommendations(id)`. Thin Axios wrappers; return `response.data`.
+  - Notes: New file (not extending `faculty-analytics.requests.ts`) to keep the analytics-vs-analysis concerns separated. Export from feature barrel.
+
+- [x] **Task 16: Create `use-latest-pipeline-for-scope.ts`.**
+  - File (new): `app.faculytics/features/faculty-analytics/hooks/use-latest-pipeline-for-scope.ts`
+  - Action: `useQuery` wrapping `listPipelines`. Accepts scope query (`ListPipelinesQuery` = `PipelineScopeIds`). Query key: **`['analysis', 'list-pipelines-for-scope', query]`** (no token). The query function returns `listPipelines(query)` — the raw array. The hook exposes `latestPipeline = result.data?.[0] ?? null` to consumers as a derived value, but the cached data remains the array. Enabled only when `semesterId` present + auth token present.
+  - Notes: Why cache the array (not just first-or-null)? So Task 19's `setQueryData` after a create mutation can seed a one-element array into the same cache key, matching the shape invariant.
+
+- [x] **Task 17: Create `use-pipeline-status.ts`.**
+  - File (new): `app.faculytics/features/faculty-analytics/hooks/use-pipeline-status.ts`
+  - Action: `useQuery` with `refetchInterval` that returns `false` on **UPPERCASE** terminal statuses (`'COMPLETED' | 'FAILED' | 'CANCELLED'`), else `3000`. Accepts nullable `pipelineId`; `enabled: Boolean(pipelineId) && Boolean(token)`. Query key: `['analysis', 'pipeline-status', pipelineId]` — **no token in queryKey**. Use the `TERMINAL_STATUSES` const from the Codebase Patterns snippet.
+
+- [x] **Task 18: Create `use-pipeline-recommendations.ts` — gate on pipeline status, not run status.**
+  - File (new): `app.faculytics/features/faculty-analytics/hooks/use-pipeline-recommendations.ts`
+  - Action: `useQuery` fetching `GET /:id/recommendations`. Takes `pipelineId: string | null` AND `pipelineStatus: PipelineStatus | undefined` as inputs (caller passes the current pipeline status from `usePipelineStatus`). `enabled: Boolean(pipelineId) && Boolean(token) && pipelineStatus === 'COMPLETED'`. Query key: `['analysis', 'pipeline-recommendations', pipelineId]` — no token.
+  - Notes: Do NOT gate on `recommendations.status === 'COMPLETED'` — that's `RunStatus`, a different enum. Pipeline status (`'COMPLETED'`) is the correct gate because the recommendations run completes before the pipeline transitions to `COMPLETED`.
+
+- [x] **Task 19: Create `use-create-pipeline.ts` — seed cache on success, invalidate in background.**
+  - File (new): `app.faculytics/features/faculty-analytics/hooks/use-create-pipeline.ts`
+  - Action: `useMutation` wrapping `createPipeline`. On `onSuccess(createdPipeline, variables)`:
+    1. `queryClient.setQueryData(['analysis', 'list-pipelines-for-scope', variables], [createdPipeline])` — note the key matches Task 16 exactly (`list-pipelines-for-scope`, not `latest-pipeline-for-scope`) and the seeded value is a **single-element array**, matching the shape `listPipelines` returns. This seeds the cache so the trigger card immediately has the pipeline via the same hook, without waiting for a list refetch.
+    2. `queryClient.invalidateQueries({ queryKey: ['analysis', 'list-pipelines-for-scope'] })` in background to refresh any other scoped listings that may exist.
+  - Notes: The key structure and value shape MUST match Task 16's cache exactly — deep-equal keys + array values — or the seed is invisible to subscribers. The setQueryData guarantees the trigger card transitions Run → Awaiting Confirmation in a single render.
+
+- [x] **Task 20: Create `use-confirm-pipeline.ts`.**
+  - File (new): `app.faculytics/features/faculty-analytics/hooks/use-confirm-pipeline.ts`
+  - Action: `useMutation` wrapping `confirmPipeline`. On success, invalidate status query so the UI immediately reflects `SENTIMENT_ANALYSIS`.
+
+- [x] **Task 21: Create `use-cancel-pipeline.ts`.**
+  - File (new): `app.faculytics/features/faculty-analytics/hooks/use-cancel-pipeline.ts`
+  - Action: `useMutation` wrapping `cancelPipeline`. On success, invalidate status + list.
+
+- [x] **Task 22: Create `pipeline-themes.ts` helper.**
+  - File (new): `app.faculytics/features/faculty-analytics/lib/pipeline-themes.ts`
+  - Action: Pure function `aggregateThemes(actions: RecommendedActionDto[]): RankedTheme[]` where `RankedTheme = { topicLabel, commentCount, sentimentBreakdown, sampleQuotes, referencedBy: number }`. Walks `action.supportingEvidence.sources`, filters `type === 'topic'`, deduplicates by `topicLabel` (first-occurrence-wins, preserving LLM emission order), sums `commentCount`, averages `sentimentBreakdown` weighted by each source's own `commentCount`, collects unique `sampleQuotes` up to **3 total** (matches backend cap `z.array(z.string()).max(3)` at `recommendations.dto.ts:15`), counts how many actions reference the topic. Sorts by descending `commentCount`.
+  - Notes: Pure function — the ONE piece of logic most worth unit-testing when the frontend test framework lands. Leave a `// TODO(post-vitest-adoption): cover in unit test` comment in the file.
+
+- [x] **Task 23: Create `PipelineStatusBadge`.**
+  - File (new): `app.faculytics/features/faculty-analytics/components/pipeline-status-badge.tsx`
+  - Action: Accepts `status: PipelineStatus`. Maps to shadcn `Badge` variant: `awaiting_confirmation → secondary`, `sentiment_* | topic_* | recommendations → default` (with a small spinner), `completed → success` (or `default` if variant missing; define a custom class), `failed → destructive`, `cancelled → outline`. Renders a human-readable label.
+
+- [x] **Task 24: Create `PipelineTriggerCard`.**
+  - File (new): `app.faculytics/features/faculty-analytics/components/pipeline-trigger-card.tsx`
+  - Action: Accepts `scope: PipelineScopeIds` (UUIDs), `pipeline: PipelineSummary | null`, `onStatusChange?: (status: PipelineStatus) => void`. Internally uses `useCreatePipeline`, `useConfirmPipeline`, `useCancelPipeline`, `usePipelineStatus(pipeline?.id)`. UI (all status comparisons UPPERCASE):
+    - If `pipeline === null`: "Run Analysis" button + coverage preview card.
+    - If `pipeline.status === 'AWAITING_CONFIRMATION'`: show `pipeline.warnings` list (from the summary DTO — Task 2 ensures the field exists) + "Confirm & Start" + "Cancel" buttons.
+    - If `pipeline.status ∈ { 'EMBEDDING_CHECK', 'SENTIMENT_ANALYSIS', 'SENTIMENT_GATE', 'TOPIC_MODELING', 'GENERATING_RECOMMENDATIONS' }`: show stepper (stages + status) + "Cancel" button; `PipelineStatusBadge`.
+    - If `pipeline.status ∈ { 'COMPLETED', 'FAILED', 'CANCELLED' }`: show last-run metadata + "Re-run" button.
+    - Role gate: only renders action buttons when `useActiveRole().activeRole` is `'DEAN' | 'CHAIRPERSON' | 'CAMPUS_HEAD' | 'SUPER_ADMIN'`. FACULTY sees the status badge + last-updated label only; no action buttons rendered.
+  - Notes: Coverage warnings come from `pipeline.warnings` (the summary DTO field added in Task 2) — the trigger card does NOT need to call `/status` to display warnings. Confirmation dialog uses shadcn `AlertDialog` with an explicit "I understand" checkbox before the "Confirm" button activates.
+
+- [x] **Task 25: Create `ThemesChipList`.**
+  - File (new): `app.faculytics/features/faculty-analytics/components/themes-chip-list.tsx`
+  - Action: Accepts `themes: RankedTheme[]`. Renders each theme as a shadcn `Badge` with the `topicLabel` and a tiny count indicator. Truncates to top 8 with a "+N more" overflow badge. Compact layout for faculty report.
+  - Notes: Click/hover expansion (sample quotes on hover) is a nice-to-have; ship a minimal version first.
+
+- [x] **Task 26: Create `ThemesRankedList`.**
+  - File (new): `app.faculytics/features/faculty-analytics/components/themes-ranked-list.tsx`
+  - Action: Accepts `themes: RankedTheme[]`. Renders as a vertical list with topic label, comment count, and a horizontal three-segment bar showing sentiment breakdown (positive green / neutral gray / negative red). Shows top 10.
+
+- [x] **Task 27: Create `RecommendationsCard`.**
+  - File (new): `app.faculytics/features/faculty-analytics/components/recommendations-card.tsx`
+  - Action: Accepts `recommendations: RecommendationsResponse`. Splits actions by `category` into two sections (Strengths | Improvements). Each action renders: `headline` (heading), `description`, `actionPlan`, and an expandable "Evidence" accordion showing supporting-evidence details (topics + sample quotes + dimension scores). Uses shadcn `Accordion`, `Card`, `Badge` (for `priority`).
+  - Notes: Same component used on both faculty report and scoped dashboard. Differentiation is only in the wrapper (parent decides whether to show all actions or filter by a specific facultyId in the evidence's topic sources — currently, actions ARE faculty-level, so dean dashboards display ALL faculty recs in the department, not an aggregate LLM synthesis; this is the constraint called out in Notes → Known limitations).
+
+- [x] **Task 28: Integrate into `scoped-analytics-dashboard-screen.tsx`.**
+  - File: `app.faculytics/features/faculty-analytics/components/scoped-analytics-dashboard-screen.tsx`
+  - Action:
+    - Use `useLatestPipelineForScope({ semesterId })` at the top of the screen (no `departmentId` needed — the backend fills in the DEAN/CAMPUS_HEAD's resolved scope per TD-2 List rules). Screen currently has `selectedSemesterId` and `selectedProgramCode`; pass `semesterId: selectedSemesterId`.
+    - Insert `<PipelineTriggerCard scope={{ semesterId: selectedSemesterId }} pipeline={pipeline} />` row immediately after `<ScopedDashboardHeader>`.
+    - When `pipeline?.status === 'COMPLETED'`:
+      - Fetch `usePipelineRecommendations(pipeline.id, pipeline.status)`.
+      - Derive themes via `aggregateThemes(recs.actions)` in a `useMemo`.
+      - Insert `<ThemesRankedList>` + `<RecommendationsCard>` row below the sentiment-chart/attention-card row.
+  - Notes: Hide (don't empty-state) themes/recs when no completed pipeline exists. The screen is currently mounted at `/dean/dashboard` and `/campus-head/dashboard` only; CHAIRPERSON and SUPER_ADMIN route mounting is out of scope for FAC-132 (see Known Limitations).
+
+- [x] **Task 29: Integrate into `faculty-report-screen.tsx`.**
+  - File: `app.faculytics/features/faculty-analytics/components/faculty-report-screen.tsx`
+  - Action: Near the top of the report body, call `useLatestPipelineForScope({ semesterId, facultyId })`. If a pipeline exists:
+    - Show `<PipelineStatusBadge status={pipeline.status} />` inline with the header (compact visual cue).
+    - If `pipeline.status === 'COMPLETED'`, fetch `usePipelineRecommendations(pipeline.id, pipeline.status)`, derive themes, and insert `<ThemesChipList>` + `<RecommendationsCard>` between `<FacultyReportSummaryCards>` and `<FacultyReportSectionPerformanceChart>`.
+    - If `pipeline.status ∈ running-stages`, show a `<PipelineStatusBadge>` + small "Analysis in progress" helper text in the themes/recs slot.
+    - If no pipeline exists (list returns empty), render nothing in the themes/recs slot.
+
+- [x] **Task 30: Extend feature barrel exports.**
+  - File: `app.faculytics/features/faculty-analytics/index.ts`
+  - Action: Export the new components, hooks, types, and the `aggregateThemes` helper so route pages can consume them without deep imports.
+
+- [x] **Task 31: Manual E2E verification across six roles.**
+  - File: (no code change)
+  - Action: See "Manual E2E Checklist" in Testing Strategy below.
+
+### Acceptance Criteria
+
+#### Backend role + scope authorization
+
+- [x] **AC-1 (STUDENT blocked at guard):** Given an authenticated user with role STUDENT, when they call any `/analysis/*` endpoint, then the response is `403 Forbidden` and the orchestrator service is never invoked.
+- [x] **AC-2 (FACULTY cannot create — guard layer):** Given an authenticated FACULTY, when they call `POST /analysis/pipelines`, then the response is `403 Forbidden` (FACULTY not in write-guard allowlist).
+- [x] **AC-2a (FACULTY cannot create — service layer belt-and-braces):** Given the `PipelineOrchestratorService.CreatePipeline` method is invoked directly with a FACULTY user in CLS context (simulating a future controller misconfiguration that widens the guard), when the service runs, then it throws `ForbiddenException` before any DB write — verified by asserting no `fork.persist` / `fork.flush` calls occurred.
+- [x] **AC-3 (DEAN out-of-scope create):** Given a DEAN assigned to department `dept-A`, when they call `POST /analysis/pipelines` with body `{ semesterId: 'sem-1', departmentId: 'dept-B' }`, then the response is `403 Forbidden` with message containing `"scope not in your assigned access"`.
+- [x] **AC-4 (DEAN must scope):** Given a DEAN, when they call `POST /analysis/pipelines` with body `{ semesterId: 'sem-1' }` only, then the response is `400 Bad Request` with message `"scope filter required for your role"`.
+- [x] **AC-5 (SUPER_ADMIN unrestricted create):** Given a SUPER_ADMIN, when they call `POST /analysis/pipelines` with body `{ semesterId: 'sem-1' }` only, then a pipeline is created in `AWAITING_CONFIRMATION` status and returned.
+- [x] **AC-5a (SUPER_ADMIN reads any pipeline):** Given a SUPER_ADMIN who did not create pipeline `pipe-foreign` (triggered by another user, any scope), when they call `GET /analysis/pipelines/:id/status` or `GET /analysis/pipelines/:id/recommendations`, then the response is `200 OK` with the full payload.
+- [x] **AC-6 (DEAN in-scope create):** Given a DEAN assigned to `dept-A`, when they call `POST /analysis/pipelines` with `{ semesterId: 'sem-1', departmentId: 'dept-A' }`, then a pipeline is created successfully.
+- [x] **AC-7 (CAMPUS_HEAD in-scope create):** Given a CAMPUS_HEAD assigned to `campus-X`, when they call `POST /analysis/pipelines` with a `departmentId` belonging to `campus-X` (resolved via scope resolver), then the pipeline is created successfully.
+- [x] **AC-8 (CAMPUS_HEAD out-of-scope create):** Given a CAMPUS_HEAD assigned to `campus-X`, when they call `POST /analysis/pipelines` with a `departmentId` belonging to a different campus, then the response is `403 Forbidden`.
+- [x] **AC-9 (CHAIRPERSON backend scope — API-level only):** Given a CHAIRPERSON assigned to program `prog-A`, when they call `POST /analysis/pipelines` directly (via curl / Postman — no CHAIRPERSON dashboard UI exists in FAC-132, see Known Limitations), then `programId: 'prog-A'` → success (201); `programId: 'prog-B'` → 403.
+- [x] **AC-10 (FACULTY read own):** Given a FACULTY user `fac-1`, when they call `GET /analysis/pipelines/:id/status` for a pipeline where `pipeline.faculty.id === 'fac-1'`, then the response is `200 OK` with the full status payload.
+- [x] **AC-11 (FACULTY read foreign):** Given FACULTY `fac-1`, when they call `GET /analysis/pipelines/:id/status` for a pipeline where `pipeline.faculty.id !== 'fac-1'`, then the response is `403 Forbidden`.
+- [x] **AC-12 (FACULTY read dept pipeline):** Given FACULTY `fac-1`, when they call `GET /analysis/pipelines/:id/status` for a department-scoped pipeline (null faculty FK), then the response is `403 Forbidden`.
+- [x] **AC-13 (DEAN list with explicit in-scope dept):** Given a DEAN assigned to `dept-A`, when they call `GET /analysis/pipelines?semesterId=sem-1&departmentId=dept-A`, then the response is `200 OK` with an array of pipeline summaries for that scope, ordered by `createdAt DESC`.
+- [x] **AC-13a (DEAN list with default-fill):** Given a DEAN assigned to `dept-A` and `dept-A2`, when they call `GET /analysis/pipelines?semesterId=sem-1` (no departmentId), then the response is `200 OK` and the returned list contains ONLY pipelines whose `department_id ∈ { dept-A, dept-A2 }`. No 400 is returned (list endpoint fills in the caller's scope; this differs from Create which 400s).
+- [x] **AC-14 (DEAN list foreign):** Given a DEAN assigned to `dept-A`, when they call `GET /analysis/pipelines?semesterId=sem-1&departmentId=dept-B`, then the response is `403 Forbidden`.
+- [x] **AC-15 (FACULTY list auto-override):** Given a FACULTY `fac-1`, when they call `GET /analysis/pipelines?semesterId=sem-1&facultyId=fac-2` (attempting to list another faculty's pipelines), then the response is `200 OK` with results filtered to `facultyId=fac-1` only (the query param is silently overridden).
+- [x] **AC-16 (non-terminal cancel authorization):** Given a CAMPUS_HEAD whose scope does not include the pipeline's campus, when they call `POST /analysis/pipelines/:id/cancel`, then the response is `403 Forbidden` and the pipeline status is unchanged.
+- [x] **AC-17 (404 precedes 403):** Given any authorized user, when they call any `/analysis/pipelines/:id/*` endpoint with an `:id` that does not exist, then the response is `404 Not Found` (not 403).
+- [x] **AC-17a (unique-index race handling):** Given two concurrent `POST /analysis/pipelines` requests with identical scope tuples, when both reach the orchestrator before either flushes, then exactly one pipeline is created and both requests return `200 OK` with the same pipeline id (the losing request catches `UniqueConstraintViolationException`, re-fetches, and returns the winner).
+
+#### Frontend surfacing
+
+- [x] **AC-18 (Dean trigger visible):** Given a DEAN navigates to the scoped analytics dashboard, when the page renders, then the `PipelineTriggerCard` is visible and its "Run Analysis" button is enabled (or disabled with tooltip if a pipeline is already running).
+- [x] **AC-19 (Coverage warnings confirmed):** Given the dashboard shows a newly created pipeline in `AWAITING_CONFIRMATION` with warnings, when the user clicks "Confirm & Start", then a confirmation dialog lists each warning and requires an "I understand" checkbox before the "Confirm" button activates.
+- [x] **AC-20 (Polling while running):** Given a pipeline is in a running stage (`SENTIMENT_ANALYSIS`, `SENTIMENT_GATE`, `TOPIC_MODELING`, `GENERATING_RECOMMENDATIONS`, or `EMBEDDING_CHECK`), when `usePipelineStatus` is active, then the query refetches every 3000ms until a terminal status is observed.
+- [x] **AC-21 (Polling stops on terminal):** Given a pipeline transitions from `TOPIC_MODELING` to `COMPLETED`, when the next poll response arrives, then `refetchInterval` returns `false` (the hook compares against UPPERCASE `'COMPLETED' | 'FAILED' | 'CANCELLED'`) and subsequent polls stop.
+- [x] **AC-22 (Themes rendered on dashboard):** Given the dashboard loads a completed pipeline, when `ThemesRankedList` renders, then topics are ordered by descending `commentCount` and each shows its sentiment breakdown bar.
+- [x] **AC-23 (Recommendations rendered on dashboard):** Given a completed pipeline with recommendation actions, when `RecommendationsCard` renders, then STRENGTH and IMPROVEMENT actions appear in distinct sections and each action's evidence is expandable.
+- [x] **AC-24 (Faculty sees own themes + recs):** Given a FACULTY on `/faculty/report/:id` has a completed pipeline for `(semester, faculty)`, when the report renders, then `ThemesChipList` appears after `FacultyReportSummaryCards` and `RecommendationsCard` appears in the faculty report body.
+- [x] **AC-25 (Faculty sees no themes without pipeline):** Given a FACULTY has no pipeline for `(semester, faculty)`, when the report renders, then the themes + recs slots are absent (no empty-state message, no broken layout).
+- [x] **AC-26 (Faculty sees progress badge while running):** Given a FACULTY has a pipeline in a running stage for `(semester, faculty)`, when the report renders, then a `PipelineStatusBadge` + "Analysis in progress" helper text appear in place of the themes/recs sections.
+- [x] **AC-27 (Faculty hides trigger controls):** Given any view that renders `PipelineTriggerCard`, when the current user's role is FACULTY, then no action buttons (Run, Confirm, Cancel, Re-run) are rendered — only the status badge + metadata.
+
+#### Integration + docs
+
+- [x] **AC-28 (Workflow doc updated):** Given the PR is open, when a reviewer inspects `docs/workflows/analysis-pipeline.md`, then it contains an "Access Control" section with the per-endpoint allowlist and the scope-authorization matrix.
+- [x] **AC-29 (Scope-resolution doc addendum):** Given the PR is open, when a reviewer inspects `docs/architecture/scope-resolution.md`, then it contains a "Pipeline-scope authorization" subsection referencing the workflow doc.
+
+### Dependencies
+
+**External libraries/services:**
+
+- None new. All required packages already installed in both `api.faculytics` (NestJS 11, MikroORM 6, Passport, Zod, class-validator, Jest, BullMQ, OpenAI SDK) and `app.faculytics` (Next.js 16, React 19, TanStack Query v5, Axios, Zustand, shadcn/ui, Tailwind 4).
+
+**Internal tickets (all completed):**
+
+- FAC-125 (department source tracking)
+- FAC-127 (admin manual scope override)
+- FAC-128 (faculty home-department snapshot on submissions)
+- FAC-129 (dean faculty listing filter by home dept)
+- FAC-130 (MV home-department aggregation)
+- FAC-131 (CAMPUS_HEAD role + local user provisioning)
+- `frontend-pipeline-polling` spec (status DTO contract; `status: 'implementation-complete'` / `stepsCompleted: [1,2,3,4]` verified 2026-04-14 against the spec's frontmatter — safe to depend on the contract)
+- `recommendation-engine-faculty-level` spec (faculty-level recs + supporting-evidence schema; `status: 'implementation-complete'` — safe to depend on `RecommendedAction.supportingEvidence` shape)
+
+**Data dependencies:**
+
+- A seeded environment with at least: 1 semester, 1 campus, 2 departments (one with a CAMPUS_HEAD assigned, one without), 2 programs under one department, 1 chairperson, 1 dean, 2 faculty, 1 student, and enough `QuestionnaireSubmission` rows to satisfy the coverage warnings threshold (≥ 30 submissions + ≥ 10 comments).
+
+### Testing Strategy
+
+**Backend unit tests (Jest + NestJS TestingModule):**
+
+- `analysis.controller.spec.ts` — controller delegation tests with `.overrideGuard` + `.overrideInterceptor` pattern. Assert each method calls its orchestrator counterpart with expected args. Add list-endpoint test. **Do NOT test role-guard matrix here**; that logic is covered by `roles.guard.spec.ts` (unchanged) and by service-level scope tests.
+- `pipeline-orchestrator.service.spec.ts` — scope authorization matrix (17 scenarios in Task 9). Mock `ScopeResolverService` methods to return specific scope shapes per role. Mock `CurrentUserService.getOrFail()` to return the user under test. Assert exception types/messages for negative cases; assert orchestration proceeds for positive cases.
+- `scope-resolver.service.spec.ts` — if Task 10 adds `ResolveCampusIds`, add focused unit tests for it (happy path + empty + null).
+
+**Backend E2E tests:**
+
+- Out of scope for this ticket. The existing `test/` folder does not currently have an `analysis.e2e-spec.ts`. Adding one would require a DB + Redis + mock-worker stack in CI, which is a larger undertaking. Flag as a follow-up.
+
+**Frontend automated tests:**
+
+- Deliberately deferred (TD-6). The exception: Task 22's `pipeline-themes.ts` pure helper is simple enough that if Vitest is ever introduced later, this is the first file to cover.
+
+**Manual E2E checklist:**
+
+1. **Environment:** `cd api.faculytics && docker compose up` (Redis + mock worker); in another terminal `npm run start:dev`; in a third terminal `cd app.faculytics && bun dev`.
+2. **Provision roles via admin console** (uses FAC-127's manual-scope-override flow + FAC-131's local-user provisioning):
+   - 1 SUPER_ADMIN (from seeder `SUPER_ADMIN_USERNAME`/`SUPER_ADMIN_PASSWORD`).
+   - 1 DEAN: local-provision user, then admin console → Users → Edit scope → assign department `dept-CS`.
+   - 1 CAMPUS_HEAD: local-provision user, assign to `campus-main` (must contain `dept-CS` + `dept-EE`).
+   - 1 CHAIRPERSON: local-provision, assign to program `prog-BSCS`.
+   - 2 FACULTY (one in `dept-CS`, one in `dept-EE`) — either Moodle-synced or locally provisioned.
+   - 1 STUDENT.
+   - Ensure each FACULTY has ≥ 30 QuestionnaireSubmissions with ≥ 10 comments for the current semester (uses existing CSV test submission generator from the `tech-spec-csv-test-submission-generator` ticket).
+   - Estimate: ~20 minutes for a fresh environment; ~3 minutes per role if the submission seed already exists.
+3. **As DEAN (dept-CS):** Log in → navigate to `/dean/dashboard`. `PipelineTriggerCard` should be visible. Click "Run Analysis" → dialog lists coverage warnings if any → confirm → observe polling transition through stages to `COMPLETED` (~2 min with mock worker). Verify `ThemesRankedList` + `RecommendationsCard` render below the charts. Attempt a direct `POST /analysis/pipelines` (via devtools / curl) with `departmentId: <dept-EE>` → 403.
+4. **As CAMPUS_HEAD:** Log in → navigate to `/campus-head/dashboard`. Trigger pipeline for a department in `campus-main` → succeeds. Direct POST for a dept in another campus → 403. Verify themes + recs render.
+5. **As FACULTY (dept-CS):** Navigate to own faculty report. If pipeline from step 3 completed for their `(semester, faculty)`, `ThemesChipList` + `RecommendationsCard` render after summary cards. No trigger card visible. Direct POST to `/analysis/pipelines` via devtools → 403. `GET /analysis/pipelines?semesterId=X&facultyId=<other>` → backend silently returns THEIR OWN list (verify via network inspector).
+6. **As STUDENT:** All `/analysis/*` calls return 403 regardless of method. No themes/recs surfaces.
+7. **API-level only — CHAIRPERSON + SUPER_ADMIN:** These roles have no dashboard UI in FAC-132 (see Known Limitations). Verify authorization via direct API calls: CHAIRPERSON `POST /analysis/pipelines { programId: <assigned> }` → 201; with foreign `programId` → 403. SUPER_ADMIN `POST /analysis/pipelines { semesterId }` (no scope filter) → 201. SUPER_ADMIN `GET /analysis/pipelines/:id/status` for any pipeline → 200.
+8. **Regression check:** Existing `/analytics/*` endpoints (dean overview, attention list, faculty report, faculty report comments) unaffected — same data, same response shapes.
+9. **Doc spot-check:** Verify `docs/workflows/analysis-pipeline.md` contains "Access Control" section with the scope matrix and FACULTY auto-override note.
+
+### Notes
+
+#### High-risk items (pre-mortem)
+
+1. **`ScopeResolverService` internals may not cleanly handle campus-scope checks.** Current code uses a private `resolveCampusHeadDepartmentIds` — pipeline-scope for a CAMPUS_HEAD creating a `campusId` filter (not `departmentId`) needs a direct campus check. **Mitigation:** Task 10 extracts/adds a public `ResolveCampusIds(semesterId)` helper. If the helper requires more than a rename, the scope of this ticket expands slightly — acceptable.
+2. **Scope drift mid-pipeline.** A DEAN who triggers a pipeline and is then reassigned to a different department mid-execution will lose read access to their own pipeline. **Mitigation:** This mirrors `/analytics/*` behavior and is expected. Documented in the workflow doc.
+3. **Duplicate-trigger race is mitigated by TD-8 partial unique index.** Two concurrent `POST /analysis/pipelines` with the same scope tuple: the DB rejects the second insert with `UniqueConstraintViolationException`; the orchestrator catches it and re-fetches the winner. Both callers see the same pipeline id. Unit test (Task 9's race scenario) covers this path. Frontend mutation `onSuccess` seeds the cache with the returned pipeline (Task 19), so both clients converge without flicker.
+4. **LLM cost regression (false alarm).** FAC-132 adds zero new LLM invocations. Topic labels and recommendations are generated by existing pipeline stages. Called out only to preempt review questions.
+5. **Visibility of 403 vs 404 information leakage.** Task 5 explicitly sequences `findOne` → 404 before scope check → 403. **Threat model note:** combined with the FACULTY auto-override in `ListPipelines` (Task 3), this creates an enumeration surface for the **non-FACULTY** scoped roles — e.g., a DEAN who knows a foreign pipeline's UUID can distinguish "exists but forbidden" (403) from "doesn't exist" (404). This is bounded by UUID opacity (no sequential IDs) and the practical reality that pipeline UUIDs are not exposed externally. For FACULTY, the auto-override of the list endpoint means they never learn foreign pipeline UUIDs in the first place — so the oracle is ineffective against them. Trade-off accepted; documented in the workflow doc's Access Control section.
+6. **Interceptor ordering — `CurrentUserInterceptor` (class-level) + `MetaDataInterceptor`/`AuditInterceptor` (method-level).** Nest runs class-level interceptors outside method-level, so `CurrentUserInterceptor` populates CLS before the audit interceptors run and before `@Audited` routes reach the service. Untested combo in `AnalysisController` specifically. **Mitigation:** Task 8 adds an audit-fidelity test that verifies audit rows still fire on 403-reject paths. If the test fails, fallback is to move `CurrentUserInterceptor` to method-level on each endpoint (more verbose but explicitly ordered).
+
+#### Known limitations
+
+- **No aggregate (dept/program/campus-level) LLM recommendations.** Dean dashboards show the union of faculty-level recommendations for the department, not a synthesized dept-level narrative. A future ticket can add an aggregate-scope prompt + LLM call.
+- **`UserRole.ADMIN` is NOT included in any `/analysis/*` or `/analytics/*` guard allowlist.** This matches the pre-existing codebase convention established before FAC-132 (see `analytics.controller.ts:29-36` — the analytics controller also omits ADMIN). ADMIN is reserved for admin-console operations (audit logs, user provisioning, scope assignment) and does not have trigger or read access to analytics or pipeline surfaces. Promoting ADMIN to analytics/pipeline-read would be a separate product-decision ticket and is not part of FAC-132.
+- **Audit rows do not fire on rejected (4xx/5xx) calls.** `AuditInterceptor` at `src/modules/audit/interceptors/audit.interceptor.ts:47-48` uses RxJS `tap(() => ...)` which runs only on successful emissions. On a rejected call (including all 403s added by FAC-132's scope guards), no audit row is written. This is a pre-existing codebase behavior affecting every audited endpoint (Moodle sync, ingestion, questionnaire submission, etc.). Fixing it requires changing `tap(fn)` to `tap({ next, error })` across the audit pipeline — a cross-cutting refactor deferred to a follow-up ticket. For FAC-132, successful-path audit (pipeline created, confirmed, cancelled) still works as before.
+- **No CHAIRPERSON or SUPER_ADMIN scoped-dashboard UI routes.** `ScopedAnalyticsDashboardScreen` is currently mounted only at `/dean/dashboard` and `/campus-head/dashboard`. CHAIRPERSON and SUPER_ADMIN role-guard enforcement works at the API level (AC-9, AC-5, AC-5a cover this), but there's no in-app dashboard for these roles to trigger pipelines from. Follow-up ticket: "mount `ScopedAnalyticsDashboardScreen` at `/chairperson/dashboard` and `/super-admin/dashboard`". Today those roles use the API directly (via Postman/curl) or wait for the follow-up.
+- **No frontend automated tests.** Explicit gap (TD-6). Introducing Vitest + RTL is a separate convention-setting ticket; this one runs on manual E2E + manual regression.
+- **Pipeline summary list is not paginated.** `ListPipelines` returns the 10 most recent matching pipelines. Adequate for current usage; add pagination when/if a scope accumulates hundreds of pipelines.
+- **Scope is not displayed on the trigger card in user-friendly terms.** The card shows "semester X, department Y" using IDs or codes; the frontend does not currently look up human-readable names for the scope filters. TD-9 unblocks this (scope response now includes display values alongside IDs), but wiring the display is a polish pass, not in this ticket.
+- **No `/auth/me` extension for "my departments" or "my campuses".** Frontend detects the user's active ROLE (via `useActiveRole()`) but not their assigned institutional scope (dept/campus/program UUIDs). FAC-132 sidesteps this gap by letting the backend default-fill list scope from the resolver. If future work needs client-side scope awareness (e.g., a picker for multi-dept DEANs), `/auth/me` must expose the scope explicitly.
+
+#### Future considerations (follow-up tickets — NOT part of this spec)
+
+- Aggregate-scope LLM recommendations (new prompt templates at dept/program/campus level).
+- Change `AuditInterceptor` to fire on both success and error outcomes (switch `tap(fn)` to `tap({ next, error })`). Cross-cutting; needs a separate audit-behavior review because every audited endpoint gains rejection entries.
+- Mount `ScopedAnalyticsDashboardScreen` for CHAIRPERSON + SUPER_ADMIN routes.
+- Vitest + React Testing Library adoption for `app.faculytics`; start with `pipeline-themes.ts` unit coverage.
+- Auto-trigger pipelines on semester state transitions.
+- Admin console pipeline trigger UI (`admin.faculytics`) for SUPER_ADMIN power users.
+- Pipeline history page listing past runs per scope, with diff view between runs.
+- `UserInstitutionalRole` extension for CHAIRPERSON holding multiple programs (already supported by data model; surface + validate in trigger UX).
+- Human-readable scope display on the trigger card (uses TD-9's display values).
+- `/auth/me` extension to expose current-user institutional scope, enabling client-side scope-picker UX.
+
+## Review Notes
+
+- Adversarial review completed 2026-04-14 (36 findings, auto-fix applied to critical + high-priority issues).
+- **Fixed during review:**
+  - **F1 (Critical)** — Create/Confirm/Cancel endpoints now return `PipelineSummaryResponseDto` (not `PipelineResponseDto`), matching the list endpoint and the frontend `PipelineSummary` type. Orchestrator populates all scope refs before return. Cache-seeding in `useCreatePipeline` now delivers the correct shape.
+  - **F2 (Critical)** — `CreatePipeline.existingFilter` now binds every non-provided scope field to `null`, matching the partial unique index's COALESCE-sentinel semantics. Fixes silent superset-match + race-recovery corruption.
+  - **F13 (Medium)** — `useConfirmPipeline` now invalidates `list-pipelines-for-scope` in addition to `pipeline-status`.
+  - **F19 (Low)** — Controller `:id` params now use `ParseUUIDPipe` (matches `AnalyticsController` convention).
+  - **F21 (Low)** — `analysis.controller.spec.ts` `GetPipelineStatus` mock scope updated to TD-9 shape.
+  - **F22 (Low)** — Added AC-17 test asserting 404 precedes scope-resolver invocation.
+- **Defended as design decisions:**
+  - **F4** — `assertCanAccessPipeline` CAMPUS_HEAD allowing dept-scoped pipelines with null campus is consistent with TD-2's "campusId OR departmentId" create rule. A DEAN's dept-scoped pipeline IS legitimately readable by the CAMPUS_HEAD of that campus (role hierarchy).
+  - **F5** — `Endpoints.analysisPipelines` merged list+create entry satisfies the lint rule `no-duplicate-enum-values`; a single shared URL with HTTP verb distinction is idiomatic.
+  - **F6** — `PipelineSummary.lastEnrollmentSyncAt` hardcoded null in the list response is an acknowledged limitation; computing it per-pipeline in `ListPipelines` would N+1 the query. Frontend falls back to `/status` for fresh sync timestamps.
+- **Acknowledged and deferred** (low-severity polish — not blocking):
+  - F8 (existence-oracle bounded by UUID opacity, documented).
+  - F17, F20, F27, F28–F36 — style/UX nits and test-coverage expansions.
+  - F23 (persistent FAILED state on SENTIMENT_WORKER_URL misconfig — pre-existing, out of FAC-132 scope).
+  - F24 (spinner icon on running status badges — UX polish).
+  - F25 (default tab in RecommendationsCard when no improvements — UX polish).
+  - F32 (mutation error surfacing in UI — UX polish).
+
+**Verification status:** backend build + lint clean, 62/62 analysis tests passing, frontend typecheck + lint clean. Manual E2E (Task 31) is outside this automated pass per TD-6.

--- a/docs/architecture/scope-resolution.md
+++ b/docs/architecture/scope-resolution.md
@@ -152,6 +152,10 @@ When a user holds multiple roles, the highest-priority role wins:
 2. `DEAN` — department-level scope
 3. `CHAIRPERSON` — program-level scope (narrower)
 
+### Pipeline-scope authorization
+
+Analysis-pipeline authorization (create/confirm/cancel/read) reuses `ResolveDepartmentIds`, `ResolveProgramIds`, and `ResolveCampusIds`. Pipeline-specific rules — required axis per role, list default-fill, FACULTY auto-override, 404-before-403 ordering, and the active-scope unique index — live in [analysis-pipeline.md §Access Control](../workflows/analysis-pipeline.md#access-control). `PipelineOrchestratorService` calls these resolvers before any DB write or flush so a foreign caller cannot cause side effects.
+
 ## Source Files
 
 | File                                                          | Purpose                                                      |

--- a/docs/workflows/analysis-pipeline.md
+++ b/docs/workflows/analysis-pipeline.md
@@ -154,3 +154,93 @@ Returns a structured response with:
 - Sentiment gate statistics
 - Warnings and error messages
 - Timestamps (created, confirmed, completed)
+
+The `scope` object returns **both IDs and display values** side-by-side (e.g., `{ semesterId, semesterCode, departmentId, departmentCode, facultyId, facultyName, ... }`). IDs are used by the frontend for cache keys and lookups; display values are used for rendering. See FAC-132 TD-9 for the contract.
+
+## Discovery
+
+**Endpoint:** `GET /analysis/pipelines`
+
+Returns the 10 most recent pipelines matching the query, ordered by `createdAt DESC`. Query parameters:
+
+| Parameter                | Required | Description                         |
+| ------------------------ | -------- | ----------------------------------- |
+| `semesterId`             | Yes      | Target semester                     |
+| `facultyId`              | No       | Filter to a specific faculty member |
+| `departmentId`           | No       | Filter to a department              |
+| `programId`              | No       | Filter to a program                 |
+| `campusId`               | No       | Filter to a campus                  |
+| `courseId`               | No       | Filter to a course                  |
+| `questionnaireVersionId` | No       | Filter to a specific version        |
+
+Scope-filling behavior per role is documented in [Access Control](#access-control).
+
+## Access Control
+
+Authorization for every `/analysis/*` endpoint is enforced at two layers:
+
+1. **Role guard (`@UseJwtGuard` + `RolesGuard`)** — class-level allowlist plus per-method widening. Roles outside the allowlist get `403 Forbidden` before the service runs.
+2. **Service-layer scope check** — `PipelineOrchestratorService` validates the caller's institutional scope against the pipeline's scope fields via `ScopeResolverService`. Belt-and-braces against guard misconfiguration.
+
+### Role allowlist per endpoint
+
+| Endpoint                                       | Allowed roles                                        |
+| ---------------------------------------------- | ---------------------------------------------------- |
+| `POST /analysis/pipelines`                     | SUPER_ADMIN, DEAN, CHAIRPERSON, CAMPUS_HEAD          |
+| `POST /analysis/pipelines/:id/confirm`         | SUPER_ADMIN, DEAN, CHAIRPERSON, CAMPUS_HEAD          |
+| `POST /analysis/pipelines/:id/cancel`          | SUPER_ADMIN, DEAN, CHAIRPERSON, CAMPUS_HEAD          |
+| `GET  /analysis/pipelines`                     | SUPER_ADMIN, DEAN, CHAIRPERSON, CAMPUS_HEAD, FACULTY |
+| `GET  /analysis/pipelines/:id/status`          | SUPER_ADMIN, DEAN, CHAIRPERSON, CAMPUS_HEAD, FACULTY |
+| `GET  /analysis/pipelines/:id/recommendations` | SUPER_ADMIN, DEAN, CHAIRPERSON, CAMPUS_HEAD, FACULTY |
+
+STUDENT and ADMIN are never in the allowlist. STUDENT is end-user; ADMIN is reserved for admin-console operations (not analytics).
+
+### Create / Confirm / Cancel / Read-by-id scope matrix
+
+These operations require an **explicit scope filter** on the axis appropriate to the caller's role. Absence of the filter returns `400 Bad Request` with `"scope filter required for your role"`. A filter outside the caller's resolved set returns `403 Forbidden` with `"scope not in your assigned access"`.
+
+| Role        | Required on create           | Validation against                          |
+| ----------- | ---------------------------- | ------------------------------------------- |
+| SUPER_ADMIN | None (`semesterId` only OK)  | — (unrestricted)                            |
+| DEAN        | `departmentId`               | `ResolveDepartmentIds(semesterId)`          |
+| CHAIRPERSON | `programId`                  | `ResolveProgramIds(semesterId)`             |
+| CAMPUS_HEAD | `campusId` OR `departmentId` | `ResolveCampusIds` / `ResolveDepartmentIds` |
+| FACULTY     | _(blocked at guard — 403)_   | —                                           |
+| STUDENT     | _(blocked at guard — 403)_   | —                                           |
+
+**Read-by-id additional rules:**
+
+- FACULTY may read `GET /:id/status` or `GET /:id/recommendations` only when `pipeline.faculty.id === user.id`. Department-scoped pipelines (null `faculty` FK) are 403 for FACULTY.
+- A pipeline with a **null** scope field on the caller's axis (e.g., `pipeline.department === null` for a DEAN) is 403 for all scoped roles — null means "no filter", i.e., broader-than-role access, reserved for SUPER_ADMIN.
+- Pipelines not found return `404 Not Found` **before** the scope check, so 404 takes precedence over 403. This exposes a minor existence-oracle for scoped roles who know a foreign UUID. Bounded by UUID opacity and the fact that FACULTY never learns foreign UUIDs (see list auto-override below).
+
+### List scope-filling
+
+`GET /analysis/pipelines` fills in the caller's resolved scope when the corresponding query parameter is omitted — this differs from create, which 400s on absence. Rationale: the dean dashboard can call `listPipelines({ semesterId })` without needing to enumerate department UUIDs on the client.
+
+| Role        | Behavior                                                                                                                                    |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| SUPER_ADMIN | Query unchanged.                                                                                                                            |
+| DEAN        | If `departmentId` omitted, service fills an IN-filter with `ResolveDepartmentIds(semesterId)`. If provided, verify ∈ resolved set else 403. |
+| CHAIRPERSON | Same with `programId` and `ResolveProgramIds(semesterId)`.                                                                                  |
+| CAMPUS_HEAD | Same with `campusId` and `ResolveCampusIds(semesterId)`.                                                                                    |
+| FACULTY     | `facultyId` is silently overridden to the caller's own user id. Any foreign `facultyId` in the query is dropped.                            |
+| STUDENT     | 403.                                                                                                                                        |
+
+The FACULTY auto-override prevents enumeration of other faculty's pipelines and ensures FACULTY never learns foreign pipeline UUIDs.
+
+### Population requirement for ownership checks
+
+`ConfirmPipeline`, `CancelPipeline`, `GetPipelineStatus`, and `GetRecommendations` populate `['faculty', 'department', 'program', 'campus']` on the pipeline before running `assertCanAccessPipeline`. Reading `pipeline.faculty?.id` through an unpopulated reference proxy is fragile — explicit populate is load-bearing.
+
+### Scope check ordering for side-effecting endpoints
+
+For `ConfirmPipeline` and `CancelPipeline`, the scope check runs **before** any `fork.flush()`, status mutation, or queue enqueue. A foreign caller must never cause side effects — even when an unrelated check (e.g., worker URL misconfiguration) would otherwise fail the pipeline.
+
+### Unique-scope invariant
+
+A partial unique index (`uq_analysis_pipeline_active_scope`) enforces one active pipeline per `(semester, scope tuple)` at the DB level. Concurrent creates with identical scope produce `UniqueConstraintViolationException`; the orchestrator catches it and re-fetches the winner so both callers see the same pipeline id (idempotent).
+
+### Scope drift mid-pipeline
+
+A DEAN who triggers a pipeline and is then reassigned to a different department mid-execution loses read access to their own pipeline. This mirrors `/analytics/*` behavior and is intentional — the scope check evaluates against current assignments, not historical ones.

--- a/src/migrations/.snapshot-faculytics_db.json
+++ b/src/migrations/.snapshot-faculytics_db.json
@@ -77,7 +77,7 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "unique": false,
+          "unique": true,
           "length": 255,
           "precision": null,
           "scale": null,
@@ -408,6 +408,23 @@
           "keyName": "analysis_pipeline_semester_id_status_index",
           "unique": false,
           "primary": false
+        },
+        {
+          "columnNames": [
+            "semester_id",
+            "COALESCE(faculty_id, NONE::character varying)",
+            "COALESCE(department_id, NONE::character varying)",
+            "COALESCE(program_id, NONE::character varying)",
+            "COALESCE(campus_id, NONE::character varying)",
+            "COALESCE(course_id, NONE::character varying)",
+            "COALESCE(questionnaire_version_id, NONE::character varying)"
+          ],
+          "composite": true,
+          "constraint": false,
+          "keyName": "uq_analysis_pipeline_active_scope",
+          "unique": true,
+          "primary": false,
+          "expression": "CREATE UNIQUE INDEX uq_analysis_pipeline_active_scope ON public.analysis_pipeline USING btree (semester_id, COALESCE(faculty_id, 'NONE'::character varying), COALESCE(department_id, 'NONE'::character varying), COALESCE(program_id, 'NONE'::character varying), COALESCE(campus_id, 'NONE'::character varying), COALESCE(course_id, 'NONE'::character varying), COALESCE(questionnaire_version_id, 'NONE'::character varying)) WHERE ((status <> ALL (ARRAY['COMPLETED'::text, 'FAILED'::text, 'CANCELLED'::text])) AND (deleted_at IS NULL))"
         }
       ],
       "checks": [],

--- a/src/migrations/Migration20260414155236_fac-132-pipeline-scope-unique-index.ts
+++ b/src/migrations/Migration20260414155236_fac-132-pipeline-scope-unique-index.ts
@@ -1,0 +1,42 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260414155236 extends Migration {
+  // FAC-132: partial unique index enforcing one canonical pipeline per
+  // (semester, scope) tuple while any non-terminal pipeline exists.
+  //
+  // Why a partial index (not @Unique decorator or plain unique constraint):
+  // - `analysis_pipeline` scope FKs (faculty_id, department_id, ...) are
+  //   nullable. Postgres treats NULL as distinct in unique constraints, so a
+  //   plain constraint would permit unlimited duplicate (semester, NULL,
+  //   NULL, ...) active pipelines. COALESCE-to-sentinel fixes this.
+  // - Soft-deleted rows and terminal-state pipelines (COMPLETED/FAILED/
+  //   CANCELLED) must NOT participate — a new active pipeline for a scope
+  //   should always be insertable once the previous one settles.
+  //
+  // FK columns are varchar(255) (see Migration20260313170918) — the text
+  // literal 'NONE' is the sentinel. Do NOT cast to uuid; the columns are
+  // text-typed.
+
+  private readonly INDEX_NAME = 'uq_analysis_pipeline_active_scope';
+
+  override async up(): Promise<void> {
+    this.addSql(`
+      CREATE UNIQUE INDEX "${this.INDEX_NAME}"
+        ON "analysis_pipeline" (
+          "semester_id",
+          COALESCE("faculty_id", 'NONE'),
+          COALESCE("department_id", 'NONE'),
+          COALESCE("program_id", 'NONE'),
+          COALESCE("campus_id", 'NONE'),
+          COALESCE("course_id", 'NONE'),
+          COALESCE("questionnaire_version_id", 'NONE')
+        )
+        WHERE "status" NOT IN ('COMPLETED', 'FAILED', 'CANCELLED')
+          AND "deleted_at" IS NULL;
+    `);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`DROP INDEX IF EXISTS "${this.INDEX_NAME}";`);
+  }
+}

--- a/src/modules/analysis/analysis.controller.spec.ts
+++ b/src/modules/analysis/analysis.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { AuthGuard } from '@nestjs/passport';
 import { AnalysisController } from './analysis.controller';
 import { PipelineOrchestratorService } from './services/pipeline-orchestrator.service';
 import { PipelineStatus } from './enums';
@@ -6,13 +7,15 @@ import {
   auditTestProviders,
   overrideAuditInterceptors,
 } from '../audit/testing/audit-test.helpers';
+import { RolesGuard } from 'src/security/guards/roles.guard';
+import { CurrentUserInterceptor } from '../common/interceptors/current-user.interceptor';
 
 const makeMockPipeline = (
   overrides: Partial<Record<string, unknown>> = {},
 ) => ({
   id: 'p1',
   status: PipelineStatus.AWAITING_CONFIRMATION,
-  semester: { id: 's1' },
+  semester: { id: 's1', code: 'S2026' },
   faculty: undefined,
   questionnaireVersion: undefined,
   department: undefined,
@@ -27,6 +30,7 @@ const makeMockPipeline = (
   warnings: [],
   errorMessage: undefined,
   createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
   confirmedAt: undefined,
   completedAt: undefined,
   ...overrides,
@@ -36,6 +40,7 @@ describe('AnalysisController', () => {
   let controller: AnalysisController;
   let mockOrchestrator: {
     CreatePipeline: jest.Mock;
+    ListPipelines: jest.Mock;
     ConfirmPipeline: jest.Mock;
     CancelPipeline: jest.Mock;
     GetPipelineStatus: jest.Mock;
@@ -45,6 +50,7 @@ describe('AnalysisController', () => {
   beforeEach(async () => {
     mockOrchestrator = {
       CreatePipeline: jest.fn(),
+      ListPipelines: jest.fn(),
       ConfirmPipeline: jest.fn(),
       CancelPipeline: jest.fn(),
       GetPipelineStatus: jest.fn(),
@@ -60,7 +66,16 @@ describe('AnalysisController', () => {
         },
         ...auditTestProviders(),
       ],
-    });
+    })
+      .overrideGuard(AuthGuard('jwt'))
+      .useValue({ canActivate: () => true })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .overrideInterceptor(CurrentUserInterceptor)
+      .useValue({
+        intercept: (_ctx: unknown, next: { handle: () => unknown }) =>
+          next.handle(),
+      });
     const module: TestingModule =
       await overrideAuditInterceptors(builder).compile();
 
@@ -81,17 +96,20 @@ describe('AnalysisController', () => {
         user: { userId: 'u1', moodleUserId: 1 },
       } as unknown as Parameters<typeof controller.CreatePipeline>[1];
 
-      const result = await controller.CreatePipeline(body, req);
+      const result = (await controller.CreatePipeline(
+        body,
+        req,
+      )) as unknown as {
+        id: string;
+        status: string;
+        scope: { semesterId: string };
+        coverage: { responseRate: number };
+      };
 
-      expect(result).toEqual(
-        expect.objectContaining({
-          id: 'p1',
-          status: PipelineStatus.AWAITING_CONFIRMATION,
-          semesterId: 's1',
-          triggeredById: 'u1',
-          responseRate: 0.5,
-        }),
-      );
+      expect(result.id).toBe('p1');
+      expect(result.status).toBe(PipelineStatus.AWAITING_CONFIRMATION);
+      expect(result.scope.semesterId).toBe('s1');
+      expect(result.coverage.responseRate).toBe(0.5);
       expect(mockOrchestrator.CreatePipeline).toHaveBeenCalledWith(body, 'u1');
     });
   });
@@ -103,15 +121,15 @@ describe('AnalysisController', () => {
       });
       mockOrchestrator.ConfirmPipeline.mockResolvedValue(mockPipeline);
 
-      const result = await controller.ConfirmPipeline('p1');
+      const result = (await controller.ConfirmPipeline('p1')) as unknown as {
+        id: string;
+        status: string;
+        scope: { semesterId: string };
+      };
 
-      expect(result).toEqual(
-        expect.objectContaining({
-          id: 'p1',
-          status: PipelineStatus.EMBEDDING_CHECK,
-          semesterId: 's1',
-        }),
-      );
+      expect(result.id).toBe('p1');
+      expect(result.status).toBe(PipelineStatus.EMBEDDING_CHECK);
+      expect(result.scope.semesterId).toBe('s1');
       expect(mockOrchestrator.ConfirmPipeline).toHaveBeenCalledWith('p1');
     });
   });
@@ -123,15 +141,15 @@ describe('AnalysisController', () => {
       });
       mockOrchestrator.CancelPipeline.mockResolvedValue(mockPipeline);
 
-      const result = await controller.CancelPipeline('p1');
+      const result = (await controller.CancelPipeline('p1')) as unknown as {
+        id: string;
+        status: string;
+        scope: { semesterId: string };
+      };
 
-      expect(result).toEqual(
-        expect.objectContaining({
-          id: 'p1',
-          status: PipelineStatus.CANCELLED,
-          semesterId: 's1',
-        }),
-      );
+      expect(result.id).toBe('p1');
+      expect(result.status).toBe(PipelineStatus.CANCELLED);
+      expect(result.scope.semesterId).toBe('s1');
       expect(mockOrchestrator.CancelPipeline).toHaveBeenCalledWith('p1');
     });
   });
@@ -141,7 +159,13 @@ describe('AnalysisController', () => {
       const mockStatus = {
         id: 'p1',
         status: PipelineStatus.SENTIMENT_ANALYSIS,
-        scope: { semester: 'S2026' },
+        // TD-9 shape — paired IDs + display values
+        scope: {
+          semesterId: 's1',
+          semesterCode: 'S2026',
+          departmentId: null,
+          departmentCode: null,
+        },
         coverage: { totalEnrolled: 100, submissionCount: 50 },
         stages: {
           embeddings: {
@@ -186,6 +210,31 @@ describe('AnalysisController', () => {
 
       expect(result).toBe(mockStatus);
       expect(mockOrchestrator.GetPipelineStatus).toHaveBeenCalledWith('p1');
+    });
+  });
+
+  describe('ListPipelines', () => {
+    it('should delegate to orchestrator.ListPipelines and map to summary DTOs', async () => {
+      const mockPipeline = makeMockPipeline({
+        semester: { id: 's1', code: 'S2026' },
+      });
+      mockOrchestrator.ListPipelines.mockResolvedValue([mockPipeline]);
+
+      const query = { semesterId: 's1' };
+      const result = await controller.ListPipelines(query);
+
+      expect(mockOrchestrator.ListPipelines).toHaveBeenCalledWith(query);
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(1);
+      const first = result[0] as unknown as {
+        id: string;
+        status: string;
+        scope: { semesterId: string; semesterCode: string };
+      };
+      expect(first.id).toBe('p1');
+      expect(first.status).toBe(PipelineStatus.AWAITING_CONFIRMATION);
+      expect(first.scope.semesterId).toBe('s1');
+      expect(first.scope.semesterCode).toBe('S2026');
     });
   });
 

--- a/src/modules/analysis/analysis.controller.ts
+++ b/src/modules/analysis/analysis.controller.ts
@@ -3,24 +3,35 @@ import {
   Controller,
   Get,
   Param,
+  ParseUUIDPipe,
   Post,
+  Query,
   Req,
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import { UseJwtGuard } from 'src/security/decorators';
+import { UserRole } from 'src/modules/auth/roles.enum';
 import { MetaDataInterceptor } from '../common/interceptors/metadata.interceptor';
 import { AuditInterceptor } from '../audit/interceptors/audit.interceptor';
 import { Audited } from '../audit/decorators/audited.decorator';
 import { AuditAction } from '../audit/audit-action.enum';
+import { CurrentUserInterceptor } from '../common/interceptors/current-user.interceptor';
 import type { AuthenticatedRequest } from '../common/interceptors/http/authenticated-request';
 import { PipelineOrchestratorService } from './services/pipeline-orchestrator.service';
 import { CreatePipelineDto } from './dto/create-pipeline.dto';
-import { PipelineResponseDto } from './dto/responses/pipeline.response.dto';
+import { ListPipelinesQueryDto } from './dto/list-pipelines.dto';
+import { PipelineSummaryResponseDto } from './dto/responses/pipeline-summary.response.dto';
 
 @ApiTags('Analysis')
 @Controller('analysis')
-@UseJwtGuard()
+@UseJwtGuard(
+  UserRole.DEAN,
+  UserRole.CHAIRPERSON,
+  UserRole.CAMPUS_HEAD,
+  UserRole.SUPER_ADMIN,
+)
+@UseInterceptors(CurrentUserInterceptor)
 export class AnalysisController {
   constructor(private readonly orchestrator: PipelineOrchestratorService) {}
 
@@ -39,7 +50,21 @@ export class AnalysisController {
       body,
       req.user!.userId,
     );
-    return PipelineResponseDto.Map(pipeline);
+    return PipelineSummaryResponseDto.Map(pipeline);
+  }
+
+  @Get('pipelines')
+  @UseJwtGuard(
+    UserRole.DEAN,
+    UserRole.CHAIRPERSON,
+    UserRole.CAMPUS_HEAD,
+    UserRole.SUPER_ADMIN,
+    UserRole.FACULTY,
+  )
+  @ApiOperation({ summary: 'List pipelines for a scope' })
+  async ListPipelines(@Query() query: ListPipelinesQueryDto) {
+    const pipelines = await this.orchestrator.ListPipelines(query);
+    return pipelines.map((p) => PipelineSummaryResponseDto.Map(p));
   }
 
   @Post('pipelines/:id/confirm')
@@ -49,9 +74,9 @@ export class AnalysisController {
   })
   @UseInterceptors(MetaDataInterceptor, AuditInterceptor)
   @ApiOperation({ summary: 'Confirm and start pipeline execution' })
-  async ConfirmPipeline(@Param('id') id: string) {
+  async ConfirmPipeline(@Param('id', ParseUUIDPipe) id: string) {
     const pipeline = await this.orchestrator.ConfirmPipeline(id);
-    return PipelineResponseDto.Map(pipeline);
+    return PipelineSummaryResponseDto.Map(pipeline);
   }
 
   @Post('pipelines/:id/cancel')
@@ -61,20 +86,34 @@ export class AnalysisController {
   })
   @UseInterceptors(MetaDataInterceptor, AuditInterceptor)
   @ApiOperation({ summary: 'Cancel a non-terminal pipeline' })
-  async CancelPipeline(@Param('id') id: string) {
+  async CancelPipeline(@Param('id', ParseUUIDPipe) id: string) {
     const pipeline = await this.orchestrator.CancelPipeline(id);
-    return PipelineResponseDto.Map(pipeline);
+    return PipelineSummaryResponseDto.Map(pipeline);
   }
 
   @Get('pipelines/:id/status')
+  @UseJwtGuard(
+    UserRole.DEAN,
+    UserRole.CHAIRPERSON,
+    UserRole.CAMPUS_HEAD,
+    UserRole.SUPER_ADMIN,
+    UserRole.FACULTY,
+  )
   @ApiOperation({ summary: 'Get pipeline status' })
-  async GetPipelineStatus(@Param('id') id: string) {
+  async GetPipelineStatus(@Param('id', ParseUUIDPipe) id: string) {
     return this.orchestrator.GetPipelineStatus(id);
   }
 
   @Get('pipelines/:id/recommendations')
+  @UseJwtGuard(
+    UserRole.DEAN,
+    UserRole.CHAIRPERSON,
+    UserRole.CAMPUS_HEAD,
+    UserRole.SUPER_ADMIN,
+    UserRole.FACULTY,
+  )
   @ApiOperation({ summary: 'Get recommendations for a completed pipeline' })
-  async GetRecommendations(@Param('id') id: string) {
+  async GetRecommendations(@Param('id', ParseUUIDPipe) id: string) {
     return this.orchestrator.GetRecommendations(id);
   }
 }

--- a/src/modules/analysis/analysis.module.ts
+++ b/src/modules/analysis/analysis.module.ts
@@ -13,7 +13,9 @@ import {
   TopicAssignment,
   TopicModelRun,
 } from '../../entities/index.entity';
+import { User } from '../../entities/user.entity';
 import { CommonModule } from '../common/common.module';
+import DataLoaderModule from '../common/data-loaders/index.module';
 import { AnalysisService } from './analysis.service';
 import { AnalysisController } from './analysis.controller';
 import { SentimentProcessor } from './processors/sentiment.processor';
@@ -43,8 +45,17 @@ import { RecommendationGenerationService } from './services/recommendation-gener
       RecommendationRun,
       RecommendedAction,
       SubmissionEmbedding,
+      // Registering User makes UserRepository available to RolesGuard when
+      // FAC-132's @UseJwtGuard(...roles) applies RolesGuard at the
+      // controller level (RolesGuard consumes UserRepository to check
+      // user.roles). Matches the pattern in AnalyticsModule.
+      User,
     ]),
     CommonModule,
+    // Provides UserLoader for CurrentUserInterceptor (FAC-132 added the
+    // class-level @UseInterceptors(CurrentUserInterceptor)). Same pattern
+    // as AnalyticsModule.
+    DataLoaderModule,
   ],
   controllers: [AnalysisController],
   providers: [

--- a/src/modules/analysis/dto/list-pipelines.dto.ts
+++ b/src/modules/analysis/dto/list-pipelines.dto.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsUUID } from 'class-validator';
+
+export const listPipelinesQuerySchema = z.object({
+  semesterId: z.string().uuid(),
+  facultyId: z.string().uuid().optional(),
+  departmentId: z.string().uuid().optional(),
+  programId: z.string().uuid().optional(),
+  campusId: z.string().uuid().optional(),
+  courseId: z.string().uuid().optional(),
+  questionnaireVersionId: z.string().uuid().optional(),
+});
+
+export type ListPipelinesQueryInput = z.infer<typeof listPipelinesQuerySchema>;
+
+export class ListPipelinesQueryDto {
+  @ApiProperty({ description: 'Semester ID (required)' })
+  @IsUUID()
+  @IsNotEmpty()
+  semesterId!: string;
+
+  @ApiPropertyOptional({ description: 'Faculty user ID' })
+  @IsUUID()
+  @IsOptional()
+  facultyId?: string;
+
+  @ApiPropertyOptional({ description: 'Department ID' })
+  @IsUUID()
+  @IsOptional()
+  departmentId?: string;
+
+  @ApiPropertyOptional({ description: 'Program ID' })
+  @IsUUID()
+  @IsOptional()
+  programId?: string;
+
+  @ApiPropertyOptional({ description: 'Campus ID' })
+  @IsUUID()
+  @IsOptional()
+  campusId?: string;
+
+  @ApiPropertyOptional({ description: 'Course ID' })
+  @IsUUID()
+  @IsOptional()
+  courseId?: string;
+
+  @ApiPropertyOptional({ description: 'Questionnaire version ID' })
+  @IsUUID()
+  @IsOptional()
+  questionnaireVersionId?: string;
+}

--- a/src/modules/analysis/dto/pipeline-status.dto.ts
+++ b/src/modules/analysis/dto/pipeline-status.dto.ts
@@ -20,14 +20,22 @@ const sentimentGateSchema = stageStatusSchema.extend({
 export const pipelineStatusSchema = z.object({
   id: z.string().uuid(),
   status: z.string(),
+  // TD-9 (FAC-132): paired IDs + display values. Frontend uses IDs for
+  // cache keys / invalidation and display values for UI rendering.
   scope: z.object({
-    semester: z.string(),
-    department: z.string().nullable(),
-    faculty: z.string().nullable(),
-    questionnaireVersion: z.string().nullable(),
-    program: z.string().nullable(),
-    campus: z.string().nullable(),
-    course: z.string().nullable(),
+    semesterId: z.string(),
+    semesterCode: z.string(),
+    departmentId: z.string().nullable(),
+    departmentCode: z.string().nullable(),
+    facultyId: z.string().nullable(),
+    facultyName: z.string().nullable(),
+    programId: z.string().nullable(),
+    programCode: z.string().nullable(),
+    campusId: z.string().nullable(),
+    campusCode: z.string().nullable(),
+    courseId: z.string().nullable(),
+    courseShortname: z.string().nullable(),
+    questionnaireVersionId: z.string().nullable(),
   }),
   coverage: z.object({
     totalEnrolled: z.number().int(),

--- a/src/modules/analysis/dto/responses/pipeline-summary.response.dto.ts
+++ b/src/modules/analysis/dto/responses/pipeline-summary.response.dto.ts
@@ -1,0 +1,120 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { AnalysisPipeline } from 'src/entities/analysis-pipeline.entity';
+import { PipelineStatus } from '../../enums';
+
+class PipelineSummaryScopeDto {
+  @ApiProperty()
+  semesterId!: string;
+
+  @ApiProperty()
+  semesterCode!: string;
+
+  @ApiPropertyOptional({ nullable: true })
+  departmentId!: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  departmentCode!: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  facultyId!: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  facultyName!: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  programId!: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  programCode!: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  campusId!: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  campusCode!: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  courseId!: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  courseShortname!: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  questionnaireVersionId!: string | null;
+}
+
+class PipelineSummaryCoverageDto {
+  @ApiProperty()
+  totalEnrolled!: number;
+
+  @ApiProperty()
+  submissionCount!: number;
+
+  @ApiProperty()
+  commentCount!: number;
+
+  @ApiProperty()
+  responseRate!: number;
+
+  @ApiPropertyOptional({ nullable: true })
+  lastEnrollmentSyncAt!: string | null;
+}
+
+export class PipelineSummaryResponseDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty({ enum: PipelineStatus })
+  status!: PipelineStatus;
+
+  @ApiProperty({ type: PipelineSummaryScopeDto })
+  scope!: PipelineSummaryScopeDto;
+
+  @ApiProperty({ type: PipelineSummaryCoverageDto })
+  coverage!: PipelineSummaryCoverageDto;
+
+  @ApiProperty({ type: [String] })
+  warnings!: string[];
+
+  @ApiProperty()
+  createdAt!: string;
+
+  @ApiProperty()
+  updatedAt!: string;
+
+  @ApiPropertyOptional({ nullable: true })
+  completedAt!: string | null;
+
+  static Map(pipeline: AnalysisPipeline): PipelineSummaryResponseDto {
+    return {
+      id: pipeline.id,
+      status: pipeline.status,
+      scope: {
+        semesterId: pipeline.semester?.id ?? '',
+        semesterCode: pipeline.semester?.code ?? '',
+        departmentId: pipeline.department?.id ?? null,
+        departmentCode: pipeline.department?.code ?? null,
+        facultyId: pipeline.faculty?.id ?? null,
+        facultyName: pipeline.faculty?.fullName ?? null,
+        programId: pipeline.program?.id ?? null,
+        programCode: pipeline.program?.code ?? null,
+        campusId: pipeline.campus?.id ?? null,
+        campusCode: pipeline.campus?.code ?? null,
+        courseId: pipeline.course?.id ?? null,
+        courseShortname: pipeline.course?.shortname ?? null,
+        questionnaireVersionId: pipeline.questionnaireVersion?.id ?? null,
+      },
+      coverage: {
+        totalEnrolled: pipeline.totalEnrolled,
+        submissionCount: pipeline.submissionCount,
+        commentCount: pipeline.commentCount,
+        responseRate: Number(pipeline.responseRate),
+        lastEnrollmentSyncAt: null,
+      },
+      warnings: pipeline.warnings ?? [],
+      createdAt: pipeline.createdAt.toISOString(),
+      updatedAt: pipeline.updatedAt.toISOString(),
+      completedAt: pipeline.completedAt?.toISOString() ?? null,
+    };
+  }
+}

--- a/src/modules/analysis/services/pipeline-orchestrator.service.spec.ts
+++ b/src/modules/analysis/services/pipeline-orchestrator.service.spec.ts
@@ -1,10 +1,18 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
 import { getQueueToken } from '@nestjs/bullmq';
 import { EntityManager } from '@mikro-orm/postgresql';
+import { UniqueConstraintViolationException } from '@mikro-orm/core';
 import { QueueName } from 'src/configurations/common/queue-names';
+import { UserRole } from 'src/modules/auth/roles.enum';
+import { ScopeResolverService } from 'src/modules/common/services/scope-resolver.service';
+import { CurrentUserService } from 'src/modules/common/cls/current-user.service';
 import { PipelineOrchestratorService } from './pipeline-orchestrator.service';
 import { TopicLabelService } from './topic-label.service';
 import { AnalysisService } from '../analysis.service';
@@ -19,10 +27,24 @@ describe('PipelineOrchestratorService', () => {
   let recommendationsQueue: { add: jest.Mock };
   let analyticsRefreshQueue: { add: jest.Mock };
   let mockAnalysisService: { EnqueueJob: jest.Mock };
+  let mockScopeResolver: {
+    ResolveDepartmentIds: jest.Mock;
+    ResolveProgramIds: jest.Mock;
+    ResolveCampusIds: jest.Mock;
+    ResolveProgramCodes: jest.Mock;
+  };
+  let mockCurrentUserService: { getOrFail: jest.Mock; get: jest.Mock };
 
   const createMockQueue = () => ({
     add: jest.fn().mockResolvedValue({ id: 'mock-job-id' }),
   });
+
+  const setCurrentUser = (
+    id: string,
+    roles: UserRole[] = [UserRole.SUPER_ADMIN],
+  ) => {
+    mockCurrentUserService.getOrFail.mockReturnValue({ id, roles });
+  };
 
   beforeEach(async () => {
     mockFork = {
@@ -42,6 +64,8 @@ describe('PipelineOrchestratorService', () => {
       getReference: jest
         .fn()
         .mockImplementation((_entity: unknown, id: string) => ({ id })),
+      persist: jest.fn(),
+      populate: jest.fn().mockResolvedValue(undefined),
       flush: jest.fn(),
       nativeUpdate: jest.fn(),
     };
@@ -57,6 +81,19 @@ describe('PipelineOrchestratorService', () => {
     mockAnalysisService = {
       EnqueueJob: jest.fn().mockResolvedValue('mock-job-id'),
     };
+    mockScopeResolver = {
+      ResolveDepartmentIds: jest.fn().mockResolvedValue(null),
+      ResolveProgramIds: jest.fn().mockResolvedValue(null),
+      ResolveCampusIds: jest.fn().mockResolvedValue(null),
+      ResolveProgramCodes: jest.fn().mockResolvedValue(null),
+    };
+    mockCurrentUserService = {
+      getOrFail: jest.fn().mockReturnValue({
+        id: 'user-1',
+        roles: [UserRole.SUPER_ADMIN],
+      }),
+      get: jest.fn(),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -67,6 +104,8 @@ describe('PipelineOrchestratorService', () => {
           provide: TopicLabelService,
           useValue: { generateLabels: jest.fn().mockResolvedValue(undefined) },
         },
+        { provide: ScopeResolverService, useValue: mockScopeResolver },
+        { provide: CurrentUserService, useValue: mockCurrentUserService },
         {
           provide: getQueueToken(QueueName.SENTIMENT),
           useValue: sentimentQueue,
@@ -514,8 +553,10 @@ describe('PipelineOrchestratorService', () => {
 
       expect(status.id).toBe('p1');
       expect(status.status).toBe(PipelineStatus.SENTIMENT_ANALYSIS);
-      expect(status.scope.semester).toBe('S2026');
-      expect(status.scope.department).toBe('CCS');
+      // TD-9 (FAC-132): scope is paired IDs + display values.
+      expect(status.scope.semesterId).toBe('s1');
+      expect(status.scope.semesterCode).toBe('S2026');
+      expect(status.scope.departmentCode).toBe('CCS');
       expect(status.coverage.totalEnrolled).toBe(100);
       expect(status.updatedAt).toBe('2026-03-13T12:00:00.000Z');
 
@@ -772,6 +813,382 @@ describe('PipelineOrchestratorService', () => {
       expect(status.stages.sentimentGate.status).toBe('completed');
       expect(status.stages.sentimentGate.included).toBe(80);
       expect(status.stages.sentimentGate.excluded).toBe(40);
+    });
+  });
+
+  // FAC-132: service-layer scope authorization matrix. Guard behavior is
+  // covered by roles.guard.spec.ts; these tests cover the orchestrator's
+  // own scope checks (belt-and-braces + scope-filter validation).
+  describe('scope authorization', () => {
+    const semesterId = '550e8400-e29b-41d4-a716-446655440000';
+    const deptA = '11111111-1111-4111-8111-111111111111';
+    const deptA2 = '11111111-1111-4111-8111-111111111112';
+    const deptB = '22222222-2222-4222-8222-222222222222';
+    const progA = '33333333-3333-4333-8333-333333333333';
+    const progB = '44444444-4444-4444-8444-444444444444';
+    const campusX = '55555555-5555-4555-8555-555555555555';
+    const facultyOneId = '66666666-6666-4666-8666-666666666666';
+    const facultyTwoId = '77777777-7777-4777-8777-777777777777';
+
+    const primeCoverageMocks = () => {
+      mockFork.findOne
+        .mockResolvedValueOnce(null) // existing active duplicate
+        .mockResolvedValueOnce({ updatedAt: new Date() }); // latest enrollment
+      mockFork.find.mockResolvedValueOnce([{ course: { id: 'c1' } }]);
+      mockFork.count
+        .mockResolvedValueOnce(50)
+        .mockResolvedValueOnce(40)
+        .mockResolvedValueOnce(200);
+    };
+
+    describe('CreatePipeline', () => {
+      it('SUPER_ADMIN: creates with semesterId only (no scope filter)', async () => {
+        setCurrentUser('admin-1', [UserRole.SUPER_ADMIN]);
+        primeCoverageMocks();
+
+        await service.CreatePipeline({ semesterId }, 'admin-1');
+
+        expect(mockFork.create).toHaveBeenCalled();
+      });
+
+      it('DEAN with multiple departments: 400 when scope filter absent', async () => {
+        setCurrentUser('dean-1', [UserRole.DEAN]);
+        mockScopeResolver.ResolveDepartmentIds.mockResolvedValue([
+          deptA,
+          deptA2,
+        ]);
+
+        await expect(
+          service.CreatePipeline({ semesterId }, 'dean-1'),
+        ).rejects.toThrow(BadRequestException);
+        expect(mockFork.create).not.toHaveBeenCalled();
+      });
+
+      // UX gap: dashboard's PipelineTriggerCard only knows {semesterId}.
+      // For a single-dept DEAN the service auto-fills the dept so
+      // "Run Analysis" works without a picker UI.
+      it('DEAN with single department: auto-fills departmentId when omitted', async () => {
+        setCurrentUser('dean-1', [UserRole.DEAN]);
+        mockScopeResolver.ResolveDepartmentIds.mockResolvedValue([deptA]);
+        primeCoverageMocks();
+
+        await service.CreatePipeline({ semesterId }, 'dean-1');
+
+        expect(mockFork.create).toHaveBeenCalled();
+        // Verify the auto-filled departmentId reaches the entity factory
+        const createPayload = mockFork.create.mock.calls[0][1] as {
+          department?: { id: string };
+        };
+        expect(createPayload.department?.id).toBe(deptA);
+      });
+
+      it('DEAN: creates with own departmentId', async () => {
+        setCurrentUser('dean-1', [UserRole.DEAN]);
+        mockScopeResolver.ResolveDepartmentIds.mockResolvedValue([deptA]);
+        primeCoverageMocks();
+
+        await service.CreatePipeline(
+          { semesterId, departmentId: deptA },
+          'dean-1',
+        );
+
+        expect(mockFork.create).toHaveBeenCalled();
+      });
+
+      // Regression: Moodle DEAN users are typically also FACULTY. The
+      // service must treat them as DEAN for create purposes — the FACULTY
+      // role on the same user must NOT short-circuit to a 403.
+      it('DEAN+FACULTY: creates with own departmentId (multi-role precedence)', async () => {
+        setCurrentUser('dean-1', [UserRole.DEAN, UserRole.FACULTY]);
+        mockScopeResolver.ResolveDepartmentIds.mockResolvedValue([deptA]);
+        primeCoverageMocks();
+
+        await service.CreatePipeline(
+          { semesterId, departmentId: deptA },
+          'dean-1',
+        );
+
+        expect(mockFork.create).toHaveBeenCalled();
+      });
+
+      it('DEAN: 403 with foreign departmentId', async () => {
+        setCurrentUser('dean-1', [UserRole.DEAN]);
+        mockScopeResolver.ResolveDepartmentIds.mockResolvedValue([deptA]);
+
+        await expect(
+          service.CreatePipeline({ semesterId, departmentId: deptB }, 'dean-1'),
+        ).rejects.toThrow(ForbiddenException);
+        expect(mockFork.create).not.toHaveBeenCalled();
+      });
+
+      it('CHAIRPERSON: creates with own programId', async () => {
+        setCurrentUser('chair-1', [UserRole.CHAIRPERSON]);
+        mockScopeResolver.ResolveProgramIds.mockResolvedValue([progA]);
+        primeCoverageMocks();
+
+        await service.CreatePipeline(
+          { semesterId, programId: progA },
+          'chair-1',
+        );
+
+        expect(mockFork.create).toHaveBeenCalled();
+      });
+
+      it('CHAIRPERSON: 403 with foreign programId', async () => {
+        setCurrentUser('chair-1', [UserRole.CHAIRPERSON]);
+        mockScopeResolver.ResolveProgramIds.mockResolvedValue([progA]);
+
+        await expect(
+          service.CreatePipeline({ semesterId, programId: progB }, 'chair-1'),
+        ).rejects.toThrow(ForbiddenException);
+      });
+
+      it('CAMPUS_HEAD: creates with own campusId', async () => {
+        setCurrentUser('head-1', [UserRole.CAMPUS_HEAD]);
+        mockScopeResolver.ResolveCampusIds.mockResolvedValue([campusX]);
+        primeCoverageMocks();
+
+        await service.CreatePipeline(
+          { semesterId, campusId: campusX },
+          'head-1',
+        );
+
+        expect(mockFork.create).toHaveBeenCalled();
+      });
+
+      it('CAMPUS_HEAD: 403 with foreign-campus departmentId', async () => {
+        setCurrentUser('head-1', [UserRole.CAMPUS_HEAD]);
+        mockScopeResolver.ResolveDepartmentIds.mockResolvedValue([deptA]);
+
+        await expect(
+          service.CreatePipeline({ semesterId, departmentId: deptB }, 'head-1'),
+        ).rejects.toThrow(ForbiddenException);
+      });
+
+      it('FACULTY: 403 at service layer even without guard (AC-2a)', async () => {
+        setCurrentUser(facultyOneId, [UserRole.FACULTY]);
+
+        await expect(
+          service.CreatePipeline(
+            { semesterId, facultyId: facultyOneId },
+            facultyOneId,
+          ),
+        ).rejects.toThrow(ForbiddenException);
+        expect(mockFork.create).not.toHaveBeenCalled();
+        expect(mockFork.flush).not.toHaveBeenCalled();
+      });
+
+      it('STUDENT: 403 at service layer', async () => {
+        setCurrentUser('stu-1', [UserRole.STUDENT]);
+
+        await expect(
+          service.CreatePipeline({ semesterId }, 'stu-1'),
+        ).rejects.toThrow(ForbiddenException);
+      });
+
+      it('race handling: UniqueConstraintViolationException → returns winner', async () => {
+        setCurrentUser('admin-1', [UserRole.SUPER_ADMIN]);
+        const winner = {
+          id: 'winner-p',
+          status: PipelineStatus.AWAITING_CONFIRMATION,
+        };
+        // First findOne = no existing duplicate. flush throws. Second findOne
+        // (re-fetch in the catch) returns the winner.
+        mockFork.findOne
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce({ updatedAt: new Date() }) // enrollment for coverage
+          .mockResolvedValueOnce(winner); // re-fetch after unique violation
+        mockFork.find.mockResolvedValueOnce([{ course: { id: 'c1' } }]);
+        mockFork.count
+          .mockResolvedValueOnce(50)
+          .mockResolvedValueOnce(40)
+          .mockResolvedValueOnce(200);
+        mockFork.flush.mockRejectedValueOnce(
+          new UniqueConstraintViolationException(
+            new Error('duplicate key'),
+            // @ts-expect-error — constructor accepts optional query info
+            undefined,
+          ),
+        );
+
+        const result = await service.CreatePipeline({ semesterId }, 'admin-1');
+
+        expect(result).toBe(winner);
+      });
+    });
+
+    describe('ListPipelines', () => {
+      it('SUPER_ADMIN: returns unfiltered', async () => {
+        setCurrentUser('admin-1', [UserRole.SUPER_ADMIN]);
+        mockFork.find.mockResolvedValueOnce([]);
+
+        await service.ListPipelines({ semesterId });
+
+        expect(mockFork.find).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({ semester: semesterId }),
+          expect.anything(),
+        );
+      });
+
+      it('DEAN: fills departmentIds IN-filter when departmentId omitted', async () => {
+        setCurrentUser('dean-1', [UserRole.DEAN]);
+        mockScopeResolver.ResolveDepartmentIds.mockResolvedValue([
+          deptA,
+          deptA2,
+        ]);
+        mockFork.find.mockResolvedValueOnce([]);
+
+        await service.ListPipelines({ semesterId });
+
+        const filter = mockFork.find.mock.calls[0][1] as Record<
+          string,
+          unknown
+        >;
+        expect(filter).toEqual(
+          expect.objectContaining({
+            semester: semesterId,
+            department: { $in: [deptA, deptA2] },
+          }),
+        );
+      });
+
+      it('DEAN: 403 with foreign departmentId', async () => {
+        setCurrentUser('dean-1', [UserRole.DEAN]);
+        mockScopeResolver.ResolveDepartmentIds.mockResolvedValue([deptA]);
+
+        await expect(
+          service.ListPipelines({ semesterId, departmentId: deptB }),
+        ).rejects.toThrow(ForbiddenException);
+      });
+
+      it('FACULTY: silently overrides facultyId to own id', async () => {
+        setCurrentUser(facultyOneId, [UserRole.FACULTY]);
+        mockFork.find.mockResolvedValueOnce([]);
+
+        await service.ListPipelines({ semesterId, facultyId: facultyTwoId });
+
+        const filter = mockFork.find.mock.calls[0][1] as Record<
+          string,
+          unknown
+        >;
+        expect(filter).toEqual(
+          expect.objectContaining({
+            semester: semesterId,
+            faculty: facultyOneId,
+          }),
+        );
+      });
+
+      it('STUDENT: 403', async () => {
+        setCurrentUser('stu-1', [UserRole.STUDENT]);
+
+        await expect(service.ListPipelines({ semesterId })).rejects.toThrow(
+          ForbiddenException,
+        );
+      });
+    });
+
+    describe('assertCanAccessPipeline (via GetPipelineStatus / GetRecommendations)', () => {
+      const facultyId = facultyOneId;
+      const makePipeline = (overrides: Record<string, unknown> = {}) => ({
+        id: 'p1',
+        status: PipelineStatus.COMPLETED,
+        semester: { id: semesterId, code: 'S2026' },
+        faculty: null,
+        department: null,
+        program: null,
+        campus: null,
+        course: null,
+        questionnaireVersion: null,
+        totalEnrolled: 100,
+        submissionCount: 50,
+        commentCount: 40,
+        responseRate: 0.5,
+        warnings: [],
+        errorMessage: null,
+        sentimentGateIncluded: null,
+        sentimentGateExcluded: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        confirmedAt: new Date(),
+        completedAt: new Date(),
+        ...overrides,
+      });
+
+      it('SUPER_ADMIN: reads any pipeline (foreign faculty / foreign dept) — AC-5a', async () => {
+        setCurrentUser('admin-1', [UserRole.SUPER_ADMIN]);
+        const pipeline = makePipeline({
+          faculty: { id: facultyTwoId, fullName: 'Foreign' },
+          department: { id: deptB, code: 'FRG' },
+        });
+        mockFork.findOne
+          .mockResolvedValueOnce(pipeline)
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(null);
+        mockFork.find.mockResolvedValueOnce([]);
+
+        const status = await service.GetPipelineStatus('p1');
+        expect(status.id).toBe('p1');
+      });
+
+      it('FACULTY reads own pipeline — success', async () => {
+        setCurrentUser(facultyId, [UserRole.FACULTY]);
+        const pipeline = makePipeline({
+          faculty: { id: facultyId, fullName: 'Me' },
+        });
+        mockFork.findOne
+          .mockResolvedValueOnce(pipeline)
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(null);
+        mockFork.find.mockResolvedValueOnce([]);
+
+        const status = await service.GetPipelineStatus('p1');
+        expect(status.id).toBe('p1');
+      });
+
+      it('FACULTY reads foreign-faculty pipeline — 403', async () => {
+        setCurrentUser(facultyId, [UserRole.FACULTY]);
+        const pipeline = makePipeline({
+          faculty: { id: facultyTwoId, fullName: 'Other' },
+        });
+        mockFork.findOne.mockResolvedValueOnce(pipeline);
+
+        await expect(service.GetPipelineStatus('p1')).rejects.toThrow(
+          ForbiddenException,
+        );
+      });
+
+      it('FACULTY reads department-scoped pipeline (null faculty FK) — 403', async () => {
+        setCurrentUser(facultyId, [UserRole.FACULTY]);
+        const pipeline = makePipeline({
+          faculty: null,
+          department: { id: deptA, code: 'CCS' },
+        });
+        mockFork.findOne.mockResolvedValueOnce(pipeline);
+
+        await expect(service.GetPipelineStatus('p1')).rejects.toThrow(
+          ForbiddenException,
+        );
+      });
+
+      // AC-17: `findOne` returning null must surface 404 BEFORE any scope
+      // check runs. A DEAN with an out-of-scope-but-nonexistent pipeline id
+      // must see 404, not 403.
+      it('AC-17: 404 precedes 403 on missing pipeline id for a scoped role', async () => {
+        setCurrentUser('dean-1', [UserRole.DEAN]);
+        mockScopeResolver.ResolveDepartmentIds.mockResolvedValue([deptA]);
+        mockFork.findOne.mockResolvedValueOnce(null);
+
+        await expect(service.GetPipelineStatus('p1')).rejects.toThrow(
+          NotFoundException,
+        );
+        // Scope resolver must not have been consulted — 404 short-circuits
+        // before assertCanAccessPipeline runs.
+        expect(mockScopeResolver.ResolveDepartmentIds).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/src/modules/analysis/services/pipeline-orchestrator.service.ts
+++ b/src/modules/analysis/services/pipeline-orchestrator.service.ts
@@ -4,10 +4,12 @@ import {
   Logger,
   BadRequestException,
   NotFoundException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import { EntityManager } from '@mikro-orm/postgresql';
+import { UniqueConstraintViolationException } from '@mikro-orm/core';
 import { v4 } from 'uuid';
 import { env } from 'src/configurations/env';
 import { QueueName } from 'src/configurations/common/queue-names';
@@ -27,6 +29,7 @@ import { Program } from 'src/entities/program.entity';
 import { Campus } from 'src/entities/campus.entity';
 import { Course } from 'src/entities/course.entity';
 import { Enrollment } from 'src/entities/enrollment.entity';
+import { UserRole } from 'src/modules/auth/roles.enum';
 import { PipelineStatus, RunStatus } from '../enums';
 import { SENTIMENT_GATE, COVERAGE_WARNINGS } from '../constants';
 import { buildSubmissionScope } from '../lib/build-submission-scope';
@@ -34,6 +37,10 @@ import {
   CreatePipelineInput,
   createPipelineSchema,
 } from '../dto/create-pipeline.dto';
+import {
+  ListPipelinesQueryInput,
+  listPipelinesQuerySchema,
+} from '../dto/list-pipelines.dto';
 import { BatchAnalysisJobMessage } from '../dto/batch-analysis-job-message.dto';
 import { batchAnalysisJobSchema } from '../dto/batch-analysis-job-message.dto';
 import { PipelineStatusResponse } from '../dto/pipeline-status.dto';
@@ -44,6 +51,8 @@ import {
 import { RecommendationsResponseDto } from '../dto/responses/recommendations.response.dto';
 import { AnalysisService } from '../analysis.service';
 import { TopicLabelService } from './topic-label.service';
+import { ScopeResolverService } from 'src/modules/common/services/scope-resolver.service';
+import { CurrentUserService } from 'src/modules/common/cls/current-user.service';
 
 interface CoverageStats {
   totalEnrolled: number;
@@ -69,6 +78,20 @@ const TERMINAL_STATUSES = [
   PipelineStatus.CANCELLED,
 ];
 
+// Populate list for endpoints that return a PipelineSummary to the
+// frontend. Covers every scope FK + the faculty name used in the summary
+// DTO. Keeping this centralized prevents drift between Create/Confirm/
+// Cancel and ListPipelines.
+const SUMMARY_POPULATE = [
+  'semester',
+  'faculty',
+  'questionnaireVersion',
+  'department',
+  'program',
+  'campus',
+  'course',
+] as const;
+
 @Injectable()
 export class PipelineOrchestratorService {
   private readonly logger = new Logger(PipelineOrchestratorService.name);
@@ -77,6 +100,8 @@ export class PipelineOrchestratorService {
     private readonly em: EntityManager,
     private readonly analysisService: AnalysisService,
     private readonly topicLabelService: TopicLabelService,
+    private readonly scopeResolver: ScopeResolverService,
+    private readonly currentUserService: CurrentUserService,
     @InjectQueue(QueueName.SENTIMENT) private readonly sentimentQueue: Queue,
     @InjectQueue(QueueName.TOPIC_MODEL) private readonly topicModelQueue: Queue,
     @InjectQueue(QueueName.RECOMMENDATIONS)
@@ -89,7 +114,15 @@ export class PipelineOrchestratorService {
     dto: CreatePipelineInput,
     triggeredById: string,
   ): Promise<AnalysisPipeline> {
-    const input = createPipelineSchema.parse(dto);
+    const parsed = createPipelineSchema.parse(dto);
+
+    // Belt-and-braces service-layer scope check. The controller-level
+    // @UseJwtGuard + RolesGuard blocks STUDENT/FACULTY before reaching here,
+    // but this guards against future guard misconfiguration (see AC-2a).
+    // Returns input augmented with auto-filled scope when the caller has
+    // exactly one assigned scope and didn't specify one explicitly.
+    const input = await this.assertCanCreatePipeline(parsed);
+
     const fork = this.em.fork();
 
     // Check for active duplicate
@@ -97,21 +130,27 @@ export class PipelineOrchestratorService {
       (s) => !TERMINAL_STATUSES.includes(s),
     );
 
+    // Every scope field is bound exactly — non-provided fields become
+    // `null`. This matches the partial unique index's COALESCE-to-sentinel
+    // behavior (TD-8). Without the explicit nulls, a too-loose `findOne`
+    // can match a superset-scoped pipeline (e.g. a DEAN asking for
+    // `{sem, dept}` would match a pipeline `{sem, dept, faculty, program}`),
+    // returning a mis-scoped pipeline and bypassing the index intent.
     const existingFilter: Record<string, unknown> = {
       semester: input.semesterId,
       status: { $in: activeStatuses },
+      faculty: input.facultyId ?? null,
+      department: input.departmentId ?? null,
+      program: input.programId ?? null,
+      campus: input.campusId ?? null,
+      course: input.courseId ?? null,
+      questionnaireVersion: input.questionnaireVersionId ?? null,
     };
-    if (input.facultyId) existingFilter['faculty'] = input.facultyId;
-    if (input.departmentId) existingFilter['department'] = input.departmentId;
-    if (input.programId) existingFilter['program'] = input.programId;
-    if (input.campusId) existingFilter['campus'] = input.campusId;
-    if (input.courseId) existingFilter['course'] = input.courseId;
-    if (input.questionnaireVersionId)
-      existingFilter['questionnaireVersion'] = input.questionnaireVersionId;
 
     const existingPipeline = await fork.findOne(
       AnalysisPipeline,
       existingFilter,
+      { populate: SUMMARY_POPULATE },
     );
     if (existingPipeline) {
       return existingPipeline;
@@ -159,21 +198,89 @@ export class PipelineOrchestratorService {
       status: PipelineStatus.AWAITING_CONFIRMATION,
     });
 
-    await fork.flush();
+    // TD-8: partial unique index enforces one-canonical-pipeline-per-scope at
+    // the DB. A concurrent insert that lost the race throws
+    // UniqueConstraintViolationException — re-fetch the winner so both
+    // requests see the same pipeline id (idempotent).
+    try {
+      await fork.flush();
+    } catch (err) {
+      if (err instanceof UniqueConstraintViolationException) {
+        const winner = await fork.findOne(AnalysisPipeline, existingFilter, {
+          populate: SUMMARY_POPULATE,
+        });
+        if (winner) {
+          this.logger.log(
+            `CreatePipeline race resolved: returning existing ${winner.id} for semester ${input.semesterId}`,
+          );
+          return winner;
+        }
+      }
+      throw err;
+    }
 
     this.logger.log(
       `Created pipeline ${pipeline.id} for semester ${input.semesterId}`,
     );
+    // Populate references before returning so controller can map to the
+    // full PipelineSummary shape (frontend relies on scope codes/names).
+    await fork.populate(pipeline, SUMMARY_POPULATE);
     return pipeline;
+  }
+
+  async ListPipelines(
+    query: ListPipelinesQueryInput,
+  ): Promise<AnalysisPipeline[]> {
+    const parsed = listPipelinesQuerySchema.parse(query);
+    const filled = await this.fillAndAssertListScope(parsed);
+
+    const fork = this.em.fork();
+    const filter: Record<string, unknown> = {
+      semester: filled.semesterId,
+    };
+    if (filled.facultyId) filter['faculty'] = filled.facultyId;
+    if (filled.questionnaireVersionId)
+      filter['questionnaireVersion'] = filled.questionnaireVersionId;
+    if (filled.courseId) filter['course'] = filled.courseId;
+    if (filled.programId) filter['program'] = filled.programId;
+    if (filled.campusId) filter['campus'] = filled.campusId;
+
+    // Default-filled departmentIds come through as string[] (via $in), a
+    // client-provided scalar departmentId still works.
+    if (filled.departmentIdSet) {
+      filter['department'] = { $in: filled.departmentIdSet };
+    } else if (filled.departmentId) {
+      filter['department'] = filled.departmentId;
+    }
+    if (filled.programIdSet) {
+      filter['program'] = { $in: filled.programIdSet };
+    }
+    if (filled.campusIdSet) {
+      filter['campus'] = { $in: filled.campusIdSet };
+    }
+
+    return fork.find(AnalysisPipeline, filter, {
+      populate: SUMMARY_POPULATE,
+      orderBy: { createdAt: 'DESC' },
+      limit: 10,
+    });
   }
 
   async ConfirmPipeline(pipelineId: string): Promise<AnalysisPipeline> {
     const fork = this.em.fork();
-    const pipeline = await fork.findOne(AnalysisPipeline, pipelineId);
+    const pipeline = await fork.findOne(AnalysisPipeline, pipelineId, {
+      populate: SUMMARY_POPULATE,
+    });
 
     if (!pipeline) {
       throw new NotFoundException(`Pipeline ${pipelineId} not found`);
     }
+
+    // Scope check MUST precede every flush / status write / enqueue below —
+    // a foreign user must never cause side effects even when the worker URL
+    // is misconfigured (the SENTIMENT_WORKER_URL check used to flip status
+    // to FAILED on any caller).
+    await this.assertCanAccessPipeline(pipeline);
 
     if (pipeline.status !== PipelineStatus.AWAITING_CONFIRMATION) {
       throw new BadRequestException(
@@ -426,6 +533,8 @@ export class PipelineOrchestratorService {
       throw new NotFoundException(`Pipeline ${pipelineId} not found`);
     }
 
+    await this.assertCanAccessPipeline(pipeline);
+
     // Get latest runs
     const sentimentRun = await fork.findOne(
       SentimentRun,
@@ -551,13 +660,19 @@ export class PipelineOrchestratorService {
       id: pipeline.id,
       status: pipeline.status,
       scope: {
-        semester: pipeline.semester?.code || pipeline.semester?.id || '',
-        department: pipeline.department?.code || null,
-        faculty: pipeline.faculty?.fullName || null,
-        questionnaireVersion: pipeline.questionnaireVersion?.id || null,
-        program: pipeline.program?.code || null,
-        campus: pipeline.campus?.code || null,
-        course: pipeline.course?.shortname || null,
+        semesterId: pipeline.semester?.id ?? '',
+        semesterCode: pipeline.semester?.code ?? '',
+        departmentId: pipeline.department?.id ?? null,
+        departmentCode: pipeline.department?.code ?? null,
+        facultyId: pipeline.faculty?.id ?? null,
+        facultyName: pipeline.faculty?.fullName ?? null,
+        programId: pipeline.program?.id ?? null,
+        programCode: pipeline.program?.code ?? null,
+        campusId: pipeline.campus?.id ?? null,
+        campusCode: pipeline.campus?.code ?? null,
+        courseId: pipeline.course?.id ?? null,
+        courseShortname: pipeline.course?.shortname ?? null,
+        questionnaireVersionId: pipeline.questionnaireVersion?.id ?? null,
       },
       coverage: {
         totalEnrolled,
@@ -604,11 +719,17 @@ export class PipelineOrchestratorService {
 
   async CancelPipeline(pipelineId: string): Promise<AnalysisPipeline> {
     const fork = this.em.fork();
-    const pipeline = await fork.findOne(AnalysisPipeline, pipelineId);
+    const pipeline = await fork.findOne(AnalysisPipeline, pipelineId, {
+      populate: SUMMARY_POPULATE,
+    });
 
     if (!pipeline) {
       throw new NotFoundException(`Pipeline ${pipelineId} not found`);
     }
+
+    // Scope check BEFORE setting CANCELLED / flushing — foreign callers must
+    // not mutate pipeline state.
+    await this.assertCanAccessPipeline(pipeline);
 
     if (TERMINAL_STATUSES.includes(pipeline.status)) {
       throw new BadRequestException(
@@ -638,6 +759,278 @@ export class PipelineOrchestratorService {
     await fork.flush();
 
     this.logger.error(`Pipeline ${pipelineId} failed at ${stage}: ${error}`);
+  }
+
+  // --- Scope Authorization (FAC-132) ---
+
+  private async assertCanCreatePipeline(
+    input: CreatePipelineInput,
+  ): Promise<CreatePipelineInput> {
+    const user = this.currentUserService.getOrFail();
+
+    if (user.roles.includes(UserRole.SUPER_ADMIN)) {
+      return input;
+    }
+
+    // Roles are not mutually exclusive — a Moodle user provisioned as
+    // DEAN is typically also FACULTY. Try the scoped roles in order of
+    // precedence; the catch-all `throw` at the bottom rejects users who
+    // have ONLY FACULTY/STUDENT (or no recognized role).
+    //
+    // Auto-fill rule: if the caller has exactly ONE assigned scope on
+    // their axis and didn't specify one explicitly, fill it in. This
+    // closes the UX gap where the dashboard's PipelineTriggerCard only
+    // knows {semesterId}. Multi-scope users still get 400 — they need to
+    // pick (future picker UI).
+
+    if (user.roles.includes(UserRole.DEAN)) {
+      let departmentId = input.departmentId;
+      const allowed = await this.scopeResolver.ResolveDepartmentIds(
+        input.semesterId,
+      );
+      if (!departmentId) {
+        if (allowed === null) {
+          return input; // SUPER_ADMIN-equivalent, won't normally hit
+        }
+        if (allowed.length === 0) {
+          throw new ForbiddenException(
+            'No departments assigned to your account for this semester',
+          );
+        }
+        if (allowed.length === 1) {
+          departmentId = allowed[0];
+        } else {
+          throw new BadRequestException(
+            'Multiple departments assigned — please specify departmentId',
+          );
+        }
+      } else if (allowed !== null && !allowed.includes(departmentId)) {
+        throw new ForbiddenException('scope not in your assigned access');
+      }
+      return { ...input, departmentId };
+    }
+
+    if (user.roles.includes(UserRole.CHAIRPERSON)) {
+      let programId = input.programId;
+      const allowed = await this.scopeResolver.ResolveProgramIds(
+        input.semesterId,
+      );
+      if (!programId) {
+        if (allowed === null) {
+          return input;
+        }
+        if (allowed.length === 0) {
+          throw new ForbiddenException(
+            'No programs assigned to your account for this semester',
+          );
+        }
+        if (allowed.length === 1) {
+          programId = allowed[0];
+        } else {
+          throw new BadRequestException(
+            'Multiple programs assigned — please specify programId',
+          );
+        }
+      } else if (allowed !== null && !allowed.includes(programId)) {
+        throw new ForbiddenException('scope not in your assigned access');
+      }
+      return { ...input, programId };
+    }
+
+    if (user.roles.includes(UserRole.CAMPUS_HEAD)) {
+      let campusId = input.campusId;
+      const departmentId = input.departmentId;
+      const allowedCampuses = await this.scopeResolver.ResolveCampusIds(
+        input.semesterId,
+      );
+      if (!campusId && !departmentId) {
+        if (allowedCampuses === null) {
+          return input;
+        }
+        if (allowedCampuses.length === 0) {
+          throw new ForbiddenException(
+            'No campuses assigned to your account for this semester',
+          );
+        }
+        if (allowedCampuses.length === 1) {
+          campusId = allowedCampuses[0];
+        } else {
+          throw new BadRequestException(
+            'Multiple campuses assigned — please specify campusId or departmentId',
+          );
+        }
+      } else {
+        if (
+          campusId &&
+          allowedCampuses !== null &&
+          !allowedCampuses.includes(campusId)
+        ) {
+          throw new ForbiddenException('scope not in your assigned access');
+        }
+        if (departmentId) {
+          const allowedDepts = await this.scopeResolver.ResolveDepartmentIds(
+            input.semesterId,
+          );
+          if (allowedDepts !== null && !allowedDepts.includes(departmentId)) {
+            throw new ForbiddenException('scope not in your assigned access');
+          }
+        }
+      }
+      return { ...input, campusId };
+    }
+
+    throw new ForbiddenException('scope not in your assigned access');
+  }
+
+  private async fillAndAssertListScope(query: ListPipelinesQueryInput): Promise<
+    ListPipelinesQueryInput & {
+      departmentIdSet?: string[];
+      programIdSet?: string[];
+      campusIdSet?: string[];
+    }
+  > {
+    const user = this.currentUserService.getOrFail();
+
+    if (user.roles.includes(UserRole.SUPER_ADMIN)) {
+      return { ...query };
+    }
+
+    // Try scoped roles BEFORE the FACULTY auto-override — a Moodle DEAN
+    // is typically also FACULTY, and the more-permissive DEAN behavior
+    // must win.
+
+    if (user.roles.includes(UserRole.DEAN)) {
+      const allowed = await this.scopeResolver.ResolveDepartmentIds(
+        query.semesterId,
+      );
+      if (allowed === null) return { ...query };
+      if (query.departmentId) {
+        if (!allowed.includes(query.departmentId)) {
+          throw new ForbiddenException('scope not in your assigned access');
+        }
+        return { ...query };
+      }
+      return { ...query, departmentIdSet: allowed };
+    }
+
+    if (user.roles.includes(UserRole.CHAIRPERSON)) {
+      const allowed = await this.scopeResolver.ResolveProgramIds(
+        query.semesterId,
+      );
+      if (allowed === null) return { ...query };
+      if (query.programId) {
+        if (!allowed.includes(query.programId)) {
+          throw new ForbiddenException('scope not in your assigned access');
+        }
+        return { ...query };
+      }
+      return { ...query, programIdSet: allowed };
+    }
+
+    if (user.roles.includes(UserRole.CAMPUS_HEAD)) {
+      const allowed = await this.scopeResolver.ResolveCampusIds(
+        query.semesterId,
+      );
+      if (allowed === null) return { ...query };
+      if (query.campusId) {
+        if (!allowed.includes(query.campusId)) {
+          throw new ForbiddenException('scope not in your assigned access');
+        }
+        return { ...query };
+      }
+      return { ...query, campusIdSet: allowed };
+    }
+
+    if (user.roles.includes(UserRole.FACULTY)) {
+      // Silently override any facultyId in the query to the caller's own
+      // user id. Rationale: prevents enumeration of other faculty's
+      // pipelines via the list endpoint — a FACULTY querying
+      // `{ facultyId: 'other' }` must see their own list, not a 403
+      // (which would leak the existence of the foreign faculty's pipeline).
+      return { ...query, facultyId: user.id };
+    }
+
+    if (user.roles.includes(UserRole.STUDENT)) {
+      throw new ForbiddenException('STUDENT cannot list analysis pipelines.');
+    }
+
+    throw new ForbiddenException('scope not in your assigned access');
+  }
+
+  private async assertCanAccessPipeline(
+    pipeline: AnalysisPipeline,
+  ): Promise<void> {
+    const user = this.currentUserService.getOrFail();
+
+    if (user.roles.includes(UserRole.SUPER_ADMIN)) {
+      return;
+    }
+
+    // Roles are not mutually exclusive (e.g. DEAN+FACULTY). Try EACH role
+    // the user holds; if ANY grants access the pipeline is readable. Only
+    // throw if none qualifies. The Resolve*Ids resolvers throw on roles
+    // they don't recognize, so each branch is gated by an explicit role
+    // membership check before invoking.
+
+    // DEAN: pipeline must have a non-null department in the user's
+    // resolved set. Null department = no filter on that axis = broader
+    // than DEAN scope = SUPER_ADMIN only.
+    if (user.roles.includes(UserRole.DEAN) && pipeline.department) {
+      const allowed = await this.scopeResolver.ResolveDepartmentIds(
+        pipeline.semester.id,
+      );
+      if (allowed === null || allowed.includes(pipeline.department.id)) {
+        return;
+      }
+    }
+
+    if (user.roles.includes(UserRole.CHAIRPERSON) && pipeline.program) {
+      const allowed = await this.scopeResolver.ResolveProgramIds(
+        pipeline.semester.id,
+      );
+      if (allowed === null || allowed.includes(pipeline.program.id)) {
+        return;
+      }
+    }
+
+    if (
+      user.roles.includes(UserRole.CAMPUS_HEAD) &&
+      (pipeline.campus || pipeline.department)
+    ) {
+      let campusOk = !pipeline.campus;
+      let deptOk = !pipeline.department;
+      if (pipeline.campus) {
+        const allowedCampuses = await this.scopeResolver.ResolveCampusIds(
+          pipeline.semester.id,
+        );
+        campusOk =
+          allowedCampuses === null ||
+          allowedCampuses.includes(pipeline.campus.id);
+      }
+      if (pipeline.department) {
+        const allowedDepts = await this.scopeResolver.ResolveDepartmentIds(
+          pipeline.semester.id,
+        );
+        deptOk =
+          allowedDepts === null ||
+          allowedDepts.includes(pipeline.department.id);
+      }
+      // Every non-null axis must be in scope.
+      if (campusOk && deptOk) {
+        return;
+      }
+    }
+
+    // FACULTY: ownership only — the pipeline's faculty FK must match.
+    if (
+      user.roles.includes(UserRole.FACULTY) &&
+      pipeline.faculty &&
+      pipeline.faculty.id === user.id
+    ) {
+      return;
+    }
+
+    throw new ForbiddenException('scope not in your assigned access');
   }
 
   // --- Private Helpers ---
@@ -938,11 +1331,18 @@ export class PipelineOrchestratorService {
     pipelineId: string,
   ): Promise<RecommendationsResponseDto> {
     const fork = this.em.fork();
-    const pipeline = await fork.findOne(AnalysisPipeline, pipelineId);
+    const pipeline = await fork.findOne(AnalysisPipeline, pipelineId, {
+      populate: ['faculty', 'department', 'program', 'campus'],
+    });
 
     if (!pipeline) {
       throw new NotFoundException(`Pipeline ${pipelineId} not found`);
     }
+
+    // Populate faculty above is load-bearing for assertCanAccessPipeline's
+    // ownership check — reading pipeline.faculty?.id through a reference
+    // proxy without populate is fragile.
+    await this.assertCanAccessPipeline(pipeline);
 
     const run = await fork.findOne(
       RecommendationRun,

--- a/src/modules/common/services/scope-resolver.service.ts
+++ b/src/modules/common/services/scope-resolver.service.ts
@@ -5,6 +5,7 @@ import { UserInstitutionalRole } from 'src/entities/user-institutional-role.enti
 import { MoodleCategory } from 'src/entities/moodle-category.entity';
 import { Department } from 'src/entities/department.entity';
 import { Program } from 'src/entities/program.entity';
+import { Campus } from 'src/entities/campus.entity';
 import { Semester } from 'src/entities/semester.entity';
 import { CurrentUserService } from '../cls/current-user.service';
 
@@ -109,6 +110,78 @@ export class ScopeResolverService {
     throw new ForbiddenException(
       'User does not have a role with scope access.',
     );
+  }
+
+  /**
+   * Resolves campus IDs the user is allowed to access for a given semester.
+   * Returns `null` for unrestricted access (super admin, dean, chairperson —
+   * these roles operate at department/program axes and are unrestricted at the
+   * campus level), `[]` when a campus-scoped role has no matching campus, or
+   * `string[]` of campus UUIDs the user is campus head of.
+   *
+   * Note: FACULTY and STUDENT hit the terminal `throw` — matches the behavior
+   * of `ResolveDepartmentIds` / `ResolveProgramIds`. Callers must route by
+   * role before invoking this resolver for those roles.
+   */
+  async ResolveCampusIds(semesterId: string): Promise<string[] | null> {
+    const user = this.currentUserService.getOrFail();
+
+    if (user.roles.includes(UserRole.SUPER_ADMIN)) {
+      return null;
+    }
+
+    if (
+      user.roles.includes(UserRole.DEAN) ||
+      user.roles.includes(UserRole.CHAIRPERSON)
+    ) {
+      return null;
+    }
+
+    if (user.roles.includes(UserRole.CAMPUS_HEAD)) {
+      return this.resolveCampusHeadCampusIds(user.id, semesterId);
+    }
+
+    throw new ForbiddenException(
+      'User does not have a role with scope access.',
+    );
+  }
+
+  private async resolveCampusHeadCampusIds(
+    userId: string,
+    semesterId: string,
+  ): Promise<string[]> {
+    const roles = await this.em.find(
+      UserInstitutionalRole,
+      { user: userId, role: UserRole.CAMPUS_HEAD as string },
+      { populate: ['moodleCategory'] },
+    );
+    if (roles.length === 0) return [];
+
+    const promotedCategoryIds = roles
+      .map((r) => r.moodleCategory?.moodleCategoryId)
+      .filter((id): id is number => id != null);
+
+    if (promotedCategoryIds.length === 0) return [];
+
+    // Restrict to campuses that actually host the given semester — prevents a
+    // CAMPUS_HEAD from triggering pipelines on a semester outside their campus
+    // even if they're head of multiple campuses.
+    const semester = await this.em.findOne(
+      Semester,
+      { id: semesterId },
+      { populate: ['campus'] },
+    );
+    if (!semester?.campus?.moodleCategoryId) return [];
+    if (!promotedCategoryIds.includes(semester.campus.moodleCategoryId)) {
+      return [];
+    }
+
+    const campuses = await this.em.find(Campus, {
+      moodleCategoryId: { $in: promotedCategoryIds },
+      id: semester.campus.id,
+    });
+
+    return campuses.map((c) => c.id);
   }
 
   private async resolveChairpersonPrograms(


### PR DESCRIPTION
## Summary

Backend half of the FAC-132 integration slice. Wires role + scope guards onto the analysis pipeline endpoints and exposes the list/discovery surface the frontend consumes.

- **Guards** — `AnalysisController` gets `@UseJwtGuard(DEAN, CHAIRPERSON, CAMPUS_HEAD, SUPER_ADMIN)` at the class level with method-level widening for FACULTY on reads. STUDENT/ADMIN remain blocked throughout.
- **Scope authorization** — `PipelineOrchestratorService` gains three helpers (`assertCanCreatePipeline`, `fillAndAssertListScope`, `assertCanAccessPipeline`) that gate Create/Confirm/Cancel/GetPipelineStatus/GetRecommendations. Scoped roles are tried before FACULTY/STUDENT so Moodle multi-role users (DEAN+FACULTY) aren't falsely rejected. The helper auto-fills the scope axis when the caller has exactly one assigned scope, else 400.
- **New endpoint** — `GET /analysis/pipelines` for scope-aware discovery. FACULTY list auto-overrides `facultyId` to the caller's own id to prevent enumeration.
- **TD-8 partial unique index** — `uq_analysis_pipeline_active_scope` enforces one active pipeline per `(semester, scope)` tuple at the DB with a text sentinel for nullable FKs. `CreatePipeline` wraps `flush` in a `UniqueConstraintViolationException` catch and re-fetches the winner for idempotent race recovery. `existingFilter` now binds every non-provided scope field to `null` to match the index semantics.
- **TD-9 scope response shape** — `/status` response's `scope` object is replaced with paired IDs + display values so the frontend can use IDs for cache keys and display values for rendering. `Create`/`Confirm`/`Cancel` now also return `PipelineSummary`.
- **ResolveCampusIds** — new public helper on `ScopeResolverService` scoped to campuses hosting the given semester.
- **DI wiring** — `AnalysisModule` registers `User` (for `RolesGuard.UserRepository`) and imports `DataLoaderModule` (for `CurrentUserInterceptor.UserLoader`).
- **Docs** — Access Control section in `docs/workflows/analysis-pipeline.md` + pipeline-scope addendum in `docs/architecture/scope-resolution.md`.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm run lint\` clean on touched files
- [x] \`npx jest --testPathPatterns="analysis"\` — 64/64 passing
- [x] Scope authorization matrix coverage: SUPER_ADMIN unrestricted, DEAN/CHAIRPERSON/CAMPUS_HEAD in/out of scope, FACULTY own/foreign/dept-scoped, FACULTY list auto-override, FACULTY service-layer 403 (belt-and-braces), STUDENT 403
- [x] AC-17 test: 404 precedes 403 on missing pipeline for a scoped role
- [x] AC-17a test: UniqueConstraintViolationException race returns the existing pipeline
- [x] DEAN+FACULTY multi-role precedence regression
- [x] Single-department DEAN auto-fill on create
- [x] Manual E2E checklist (client in companion PR on app.faculytics)

Companion PR: app.faculytics frontend integration (separate PR, develop-targeted).