### PR TITLE
[STAGING] FAC-134 feat: qualitative analytics view for faculty analysis page (#…

### DIFF
--- a/src/modules/analysis/dto/create-pipeline.dto.ts
+++ b/src/modules/analysis/dto/create-pipeline.dto.ts
@@ -1,11 +1,12 @@
 import { z } from 'zod';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsNotEmpty, IsOptional, IsUUID } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
 
 export const createPipelineSchema = z.object({
   semesterId: z.string().uuid(),
   facultyId: z.string().uuid().optional(),
   questionnaireVersionId: z.string().uuid().optional(),
+  questionnaireTypeCode: z.string().min(1).optional(),
   departmentId: z.string().uuid().optional(),
   programId: z.string().uuid().optional(),
   campusId: z.string().uuid().optional(),
@@ -29,6 +30,14 @@ export class CreatePipelineDto {
   @IsUUID()
   @IsOptional()
   questionnaireVersionId?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Questionnaire type code; server resolves to the latest ACTIVE version for that type when versionId is omitted',
+  })
+  @IsString()
+  @IsOptional()
+  questionnaireTypeCode?: string;
 
   @ApiPropertyOptional({ description: 'Department ID' })
   @IsUUID()

--- a/src/modules/analysis/dto/list-pipelines.dto.ts
+++ b/src/modules/analysis/dto/list-pipelines.dto.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsNotEmpty, IsOptional, IsUUID } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
 
 export const listPipelinesQuerySchema = z.object({
   semesterId: z.string().uuid(),
@@ -10,6 +10,7 @@ export const listPipelinesQuerySchema = z.object({
   campusId: z.string().uuid().optional(),
   courseId: z.string().uuid().optional(),
   questionnaireVersionId: z.string().uuid().optional(),
+  questionnaireTypeCode: z.string().min(1).optional(),
 });
 
 export type ListPipelinesQueryInput = z.infer<typeof listPipelinesQuerySchema>;
@@ -49,4 +50,12 @@ export class ListPipelinesQueryDto {
   @IsUUID()
   @IsOptional()
   questionnaireVersionId?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Filter pipelines whose questionnaire version belongs to this type code',
+  })
+  @IsString()
+  @IsOptional()
+  questionnaireTypeCode?: string;
 }

--- a/src/modules/analysis/services/pipeline-orchestrator.service.spec.ts
+++ b/src/modules/analysis/services/pipeline-orchestrator.service.spec.ts
@@ -47,6 +47,7 @@ describe('PipelineOrchestratorService', () => {
   };
 
   beforeEach(async () => {
+    const mockExecute = jest.fn().mockResolvedValue([]);
     mockFork = {
       findOne: jest.fn(),
       findOneOrFail: jest.fn(),
@@ -68,6 +69,8 @@ describe('PipelineOrchestratorService', () => {
       populate: jest.fn().mockResolvedValue(undefined),
       flush: jest.fn(),
       nativeUpdate: jest.fn(),
+      getConnection: jest.fn().mockReturnValue({ execute: mockExecute }),
+      execute: mockExecute,
     };
 
     const mockEm = {
@@ -1086,6 +1089,149 @@ describe('PipelineOrchestratorService', () => {
         await expect(service.ListPipelines({ semesterId })).rejects.toThrow(
           ForbiddenException,
         );
+      });
+
+      it('aggregate query (no facultyId): binds every unspecified scope key to null', async () => {
+        setCurrentUser('admin-1', [UserRole.SUPER_ADMIN]);
+        mockFork.find.mockResolvedValueOnce([]);
+
+        await service.ListPipelines({ semesterId });
+
+        const filter = mockFork.find.mock.calls[0][1] as Record<
+          string,
+          unknown
+        >;
+        expect(filter).toEqual({
+          semester: semesterId,
+          faculty: null,
+          course: null,
+          questionnaireVersion: null,
+          department: null,
+          program: null,
+          campus: null,
+        });
+      });
+
+      it('facultyId query: binds faculty/course/qV but leaves dept/program/campus unbound', async () => {
+        setCurrentUser('admin-1', [UserRole.SUPER_ADMIN]);
+        mockFork.find.mockResolvedValueOnce([]);
+
+        await service.ListPipelines({
+          semesterId,
+          facultyId: facultyOneId,
+        });
+
+        const filter = mockFork.find.mock.calls[0][1] as Record<
+          string,
+          unknown
+        >;
+        expect(filter.faculty).toBe(facultyOneId);
+        expect(filter.course).toBeNull();
+        expect(filter.questionnaireVersion).toBeNull();
+        // dept/program/campus unbound — a faculty pipeline stays
+        // discoverable regardless of which scoped role triggered it.
+        expect(filter).not.toHaveProperty('department');
+        expect(filter).not.toHaveProperty('program');
+        expect(filter).not.toHaveProperty('campus');
+      });
+
+      it('resolves questionnaireTypeCode to deep filter when no versionId', async () => {
+        setCurrentUser('admin-1', [UserRole.SUPER_ADMIN]);
+        mockFork.find.mockResolvedValueOnce([]);
+
+        await service.ListPipelines({
+          semesterId,
+          facultyId: facultyOneId,
+          questionnaireTypeCode: 'STUDENT_EVAL',
+        });
+
+        const filter = mockFork.find.mock.calls[0][1] as Record<
+          string,
+          unknown
+        >;
+        expect(filter.questionnaireVersion).toEqual({
+          questionnaire: { type: { code: 'STUDENT_EVAL' } },
+        });
+      });
+
+      it('questionnaireVersionId wins over questionnaireTypeCode if both passed', async () => {
+        setCurrentUser('admin-1', [UserRole.SUPER_ADMIN]);
+        mockFork.find.mockResolvedValueOnce([]);
+
+        const versionId = '550e8400-e29b-41d4-a716-446655440030';
+        await service.ListPipelines({
+          semesterId,
+          questionnaireVersionId: versionId,
+          questionnaireTypeCode: 'STUDENT_EVAL',
+        });
+
+        const filter = mockFork.find.mock.calls[0][1] as Record<
+          string,
+          unknown
+        >;
+        expect(filter.questionnaireVersion).toBe(versionId);
+      });
+
+      it('DEAN on faculty page: drops dept/program/campus filters (facultyId is more-specific scope)', async () => {
+        setCurrentUser('dean-1', [UserRole.DEAN]);
+        mockScopeResolver.ResolveDepartmentIds.mockResolvedValue([deptA]);
+        // assertFacultyInScope looks up faculty's dept via raw SQL execute
+        mockFork.execute.mockResolvedValueOnce([{ department_id: deptA }]);
+        mockFork.find.mockResolvedValueOnce([]);
+
+        await service.ListPipelines({
+          semesterId,
+          facultyId: facultyOneId,
+          questionnaireTypeCode: 'STUDENT_EVAL',
+        });
+
+        const filter = mockFork.find.mock.calls[0][1] as Record<
+          string,
+          unknown
+        >;
+        expect(filter.faculty).toBe(facultyOneId);
+        // dept/program/campus unbound so the same faculty pipeline is
+        // discoverable across DEAN/CHAIRPERSON/CAMPUS_HEAD as long as each
+        // has faculty access.
+        expect(filter).not.toHaveProperty('department');
+        expect(filter).not.toHaveProperty('program');
+        expect(filter).not.toHaveProperty('campus');
+      });
+
+      it('DEAN on faculty page: 403 when faculty belongs to foreign dept', async () => {
+        setCurrentUser('dean-1', [UserRole.DEAN]);
+        mockScopeResolver.ResolveDepartmentIds.mockResolvedValue([deptA]);
+        mockFork.execute.mockResolvedValueOnce([{ department_id: deptB }]);
+
+        await expect(
+          service.ListPipelines({
+            semesterId,
+            facultyId: facultyOneId,
+            questionnaireTypeCode: 'STUDENT_EVAL',
+          }),
+        ).rejects.toThrow(ForbiddenException);
+      });
+
+      it('CAMPUS_HEAD on faculty page: finds a DEAN-triggered pipeline (dept/campus unbound)', async () => {
+        setCurrentUser('ch-1', [UserRole.CAMPUS_HEAD]);
+        mockScopeResolver.ResolveDepartmentIds.mockResolvedValue([deptA]);
+        mockFork.execute.mockResolvedValueOnce([{ department_id: deptA }]);
+        mockFork.find.mockResolvedValueOnce([]);
+
+        await service.ListPipelines({
+          semesterId,
+          facultyId: facultyOneId,
+          questionnaireTypeCode: 'STUDENT_EVAL',
+        });
+
+        const filter = mockFork.find.mock.calls[0][1] as Record<
+          string,
+          unknown
+        >;
+        expect(filter.faculty).toBe(facultyOneId);
+        expect(filter).not.toHaveProperty('campus');
+        expect(filter).not.toHaveProperty('department');
+        expect(filter).not.toHaveProperty('program');
       });
     });
 

--- a/src/modules/analysis/services/pipeline-orchestrator.service.ts
+++ b/src/modules/analysis/services/pipeline-orchestrator.service.ts
@@ -123,6 +123,21 @@ export class PipelineOrchestratorService {
     // exactly one assigned scope and didn't specify one explicitly.
     const input = await this.assertCanCreatePipeline(parsed);
 
+    // Resolve questionnaireTypeCode → latest ACTIVE version. Pipelines
+    // store a concrete `questionnaireVersionId` (submissions are bound to
+    // a version), so we commit the type code to a version at trigger time.
+    if (!input.questionnaireVersionId && input.questionnaireTypeCode) {
+      const resolvedVersionId = await this.resolveLatestActiveVersionId(
+        input.questionnaireTypeCode,
+      );
+      if (!resolvedVersionId) {
+        throw new BadRequestException(
+          `No ACTIVE questionnaire version exists for type "${input.questionnaireTypeCode}"`,
+        );
+      }
+      input.questionnaireVersionId = resolvedVersionId;
+    }
+
     const fork = this.em.fork();
 
     // Check for active duplicate
@@ -235,28 +250,60 @@ export class PipelineOrchestratorService {
     const filled = await this.fillAndAssertListScope(parsed);
 
     const fork = this.em.fork();
+    // Two filter modes:
+    //  1. Faculty-level query (facultyId present): match on {semester,
+    //     faculty, qV, course} only. Dept/program/campus are metadata
+    //     about the triggering caller, NOT match criteria — so a
+    //     DEAN-triggered pipeline stays visible to a CAMPUS_HEAD viewing
+    //     the same faculty.
+    //  2. Aggregate query (no facultyId): bind every scope key explicitly
+    //     (null by default) so narrower-scope pipelines don't leak.
+    //     Matches CreatePipeline's `existingFilter` shape.
     const filter: Record<string, unknown> = {
       semester: filled.semesterId,
+      course: filled.courseId ?? null,
     };
-    if (filled.facultyId) filter['faculty'] = filled.facultyId;
-    if (filled.questionnaireVersionId)
-      filter['questionnaireVersion'] = filled.questionnaireVersionId;
-    if (filled.courseId) filter['course'] = filled.courseId;
-    if (filled.programId) filter['program'] = filled.programId;
-    if (filled.campusId) filter['campus'] = filled.campusId;
 
-    // Default-filled departmentIds come through as string[] (via $in), a
-    // client-provided scalar departmentId still works.
-    if (filled.departmentIdSet) {
-      filter['department'] = { $in: filled.departmentIdSet };
-    } else if (filled.departmentId) {
-      filter['department'] = filled.departmentId;
+    if (filled.questionnaireVersionId) {
+      filter['questionnaireVersion'] = filled.questionnaireVersionId;
+    } else if (filled.questionnaireTypeCode) {
+      filter['questionnaireVersion'] = {
+        questionnaire: { type: { code: filled.questionnaireTypeCode } },
+      };
+    } else {
+      filter['questionnaireVersion'] = null;
     }
-    if (filled.programIdSet) {
-      filter['program'] = { $in: filled.programIdSet };
-    }
-    if (filled.campusIdSet) {
-      filter['campus'] = { $in: filled.campusIdSet };
+
+    if (filled.facultyId) {
+      filter['faculty'] = filled.facultyId;
+      // Faculty-level query: intentionally leave dept/program/campus
+      // unbound. See comment above.
+    } else {
+      filter['faculty'] = null;
+
+      if (filled.departmentId) {
+        filter['department'] = filled.departmentId;
+      } else if (filled.departmentIdSet) {
+        filter['department'] = { $in: filled.departmentIdSet };
+      } else {
+        filter['department'] = null;
+      }
+
+      if (filled.programId) {
+        filter['program'] = filled.programId;
+      } else if (filled.programIdSet) {
+        filter['program'] = { $in: filled.programIdSet };
+      } else {
+        filter['program'] = null;
+      }
+
+      if (filled.campusId) {
+        filter['campus'] = filled.campusId;
+      } else if (filled.campusIdSet) {
+        filter['campus'] = { $in: filled.campusIdSet };
+      } else {
+        filter['campus'] = null;
+      }
     }
 
     return fork.find(AnalysisPipeline, filter, {
@@ -899,6 +946,21 @@ export class PipelineOrchestratorService {
     // is typically also FACULTY, and the more-permissive DEAN behavior
     // must win.
 
+    // Faculty-level queries (query.facultyId set) short-circuit the set
+    // filters for scoped roles. Rationale: a faculty-level pipeline is
+    // "the pipeline for faculty F" regardless of which scoped role
+    // triggered it — its department/program/campus fields are metadata
+    // about origin, not match criteria. We still enforce authorization
+    // via the faculty's home department ∈ caller's resolved depts.
+    const isScopedRole =
+      user.roles.includes(UserRole.DEAN) ||
+      user.roles.includes(UserRole.CHAIRPERSON) ||
+      user.roles.includes(UserRole.CAMPUS_HEAD);
+    if (query.facultyId && isScopedRole) {
+      await this.assertFacultyInScope(query.facultyId, query.semesterId);
+      return { ...query };
+    }
+
     if (user.roles.includes(UserRole.DEAN)) {
       const allowed = await this.scopeResolver.ResolveDepartmentIds(
         query.semesterId,
@@ -1034,6 +1096,51 @@ export class PipelineOrchestratorService {
   }
 
   // --- Private Helpers ---
+
+  private async assertFacultyInScope(
+    facultyId: string,
+    semesterId: string,
+  ): Promise<void> {
+    const allowedDepts =
+      await this.scopeResolver.ResolveDepartmentIds(semesterId);
+    if (allowedDepts === null) return; // unrestricted (SUPER_ADMIN-equivalent)
+
+    const fork = this.em.fork();
+    const rows: { department_id: string | null }[] = await fork
+      .getConnection()
+      .execute(
+        'SELECT u.department_id FROM "user" u WHERE u.id = ? AND u.deleted_at IS NULL',
+        [facultyId],
+      );
+    if (rows.length === 0) {
+      throw new NotFoundException('Faculty not found');
+    }
+    const facultyDeptId = rows[0].department_id;
+    if (!facultyDeptId || !allowedDepts.includes(facultyDeptId)) {
+      throw new ForbiddenException('scope not in your assigned access');
+    }
+  }
+
+  private async resolveLatestActiveVersionId(
+    typeCode: string,
+  ): Promise<string | null> {
+    const fork = this.em.fork();
+    const rows: { id: string }[] = await fork.getConnection().execute(
+      `SELECT qv.id
+           FROM questionnaire_version qv
+           JOIN questionnaire q ON q.id = qv.questionnaire_id
+           JOIN questionnaire_type qt ON qt.id = q.type_id
+          WHERE qt.code = ?
+            AND qv.status = 'ACTIVE'
+            AND qv.deleted_at IS NULL
+            AND q.deleted_at IS NULL
+            AND qt.deleted_at IS NULL
+          ORDER BY qv.version_number DESC
+          LIMIT 1`,
+      [typeCode],
+    );
+    return rows[0]?.id ?? null;
+  }
 
   private BuildScopeFromPipeline(pipeline: AnalysisPipeline): ScopeFilter {
     const scope: ScopeFilter = { semester: pipeline.semester.id };

--- a/src/modules/analytics/analytics.controller.ts
+++ b/src/modules/analytics/analytics.controller.ts
@@ -17,12 +17,14 @@ import {
   FacultyTrendsQueryDto,
   FacultyReportQueryDto,
   FacultyReportCommentsQueryDto,
+  QualitativeSummaryQueryDto,
 } from './dto/analytics-query.dto';
 import { DepartmentOverviewResponseDto } from './dto/responses/department-overview.response.dto';
 import { AttentionListResponseDto } from './dto/responses/attention-list.response.dto';
 import { FacultyTrendsResponseDto } from './dto/responses/faculty-trends.response.dto';
 import { FacultyReportResponseDto } from './dto/responses/faculty-report.response.dto';
 import { FacultyReportCommentsResponseDto } from './dto/responses/faculty-report-comments.response.dto';
+import { QualitativeSummaryResponseDto } from './dto/responses/qualitative-summary.response.dto';
 
 @ApiTags('Analytics')
 @Controller('analytics')
@@ -96,11 +98,35 @@ export class AnalyticsController {
   @ApiQuery({ name: 'courseId', required: false, type: String })
   @ApiQuery({ name: 'page', required: false, type: Number })
   @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({
+    name: 'sentiment',
+    required: false,
+    enum: ['positive', 'neutral', 'negative'],
+  })
+  @ApiQuery({ name: 'themeId', required: false, type: String })
   @ApiResponse({ status: 200, type: FacultyReportCommentsResponseDto })
   async GetFacultyReportComments(
     @Param('facultyId', ParseUUIDPipe) facultyId: string,
     @Query() query: FacultyReportCommentsQueryDto,
   ): Promise<FacultyReportCommentsResponseDto> {
     return this.analyticsService.GetFacultyReportComments(facultyId, query);
+  }
+
+  @Get('faculty/:facultyId/qualitative-summary')
+  @ApiOperation({
+    summary:
+      'Get aggregated qualitative summary (sentiment distribution + themes) for faculty',
+  })
+  @ApiQuery({ name: 'semesterId', required: true, type: String })
+  @ApiQuery({ name: 'questionnaireTypeCode', required: true, type: String })
+  @ApiQuery({ name: 'courseId', required: false, type: String })
+  @ApiResponse({ status: 200, type: QualitativeSummaryResponseDto })
+  @ApiResponse({ status: 403, description: 'Out of scope for requesting user' })
+  @ApiResponse({ status: 404, description: 'Faculty not found' })
+  async GetQualitativeSummary(
+    @Param('facultyId', ParseUUIDPipe) facultyId: string,
+    @Query() query: QualitativeSummaryQueryDto,
+  ): Promise<QualitativeSummaryResponseDto> {
+    return this.analyticsService.GetQualitativeSummary(facultyId, query);
   }
 }

--- a/src/modules/analytics/analytics.service.spec.ts
+++ b/src/modules/analytics/analytics.service.spec.ts
@@ -8,6 +8,8 @@ import { QuestionnaireSchemaSnapshot } from 'src/modules/questionnaires/lib/ques
 describe('AnalyticsService', () => {
   let service: AnalyticsService;
   let mockExecute: jest.Mock;
+  let mockFindOne: jest.Mock;
+  let mockFind: jest.Mock;
   let mockScopeResolver: {
     ResolveDepartmentIds: jest.Mock;
     ResolveProgramCodes: jest.Mock;
@@ -15,9 +17,13 @@ describe('AnalyticsService', () => {
 
   beforeEach(async () => {
     mockExecute = jest.fn().mockResolvedValue([]);
+    mockFindOne = jest.fn().mockResolvedValue(null);
+    mockFind = jest.fn().mockResolvedValue([]);
 
     const mockEm = {
       execute: mockExecute,
+      findOne: mockFindOne,
+      find: mockFind,
       getConnection: jest.fn().mockReturnValue({ execute: mockExecute }),
     };
 
@@ -1249,6 +1255,444 @@ describe('AnalyticsService', () => {
       // Verify courseId was passed in SQL params
       const countCall = mockExecute.mock.calls[2] as [string, unknown[]];
       expect(countCall[1]).toContain(courseId);
+    });
+
+    describe('filters (sentiment + themeId)', () => {
+      const sentimentRunId = 'sr-run-1';
+      const topicModelRunId = 'tm-run-1';
+      const pipelineId = 'pipe-1';
+      const themeId = '550e8400-e29b-41d4-a716-446655440050';
+
+      const mockPipelineResolved = () => {
+        // findLatestCompletedPipelineByScope, resolvePipelineRuns(sentiment + topic)
+        mockFindOne
+          .mockResolvedValueOnce({ id: pipelineId })
+          .mockResolvedValueOnce({ id: sentimentRunId })
+          .mockResolvedValueOnce({ id: topicModelRunId });
+      };
+
+      it('returns empty when sentiment filter requested but no pipeline found', async () => {
+        mockExecute
+          .mockResolvedValueOnce([{ id: 'type-1', name: 'Student Evaluation' }])
+          .mockResolvedValueOnce([
+            {
+              id: 'v-1',
+              version_number: 1,
+              schema_snapshot: { meta: {}, sections: [] },
+            },
+          ]);
+        // findOne returns null by default (no pipeline)
+
+        const result = await service.GetFacultyReportComments(facultyId, {
+          ...baseQuery,
+          sentiment: 'negative',
+        });
+
+        expect(result.items).toHaveLength(0);
+        expect(result.meta.totalItems).toBe(0);
+      });
+
+      it('applies sentiment filter in SQL params when pipeline exists', async () => {
+        mockExecute
+          .mockResolvedValueOnce([{ id: 'type-1', name: 'Student Evaluation' }])
+          .mockResolvedValueOnce([
+            {
+              id: 'v-1',
+              version_number: 1,
+              schema_snapshot: { meta: {}, sections: [] },
+            },
+          ])
+          .mockResolvedValueOnce([{ total: '1' }])
+          .mockResolvedValueOnce([
+            {
+              text: 'A negative comment',
+              submitted_at: '2026-03-20T10:00:00.000Z',
+              sentiment: 'negative',
+              theme_ids: [themeId],
+            },
+          ]);
+        mockPipelineResolved();
+
+        const result = await service.GetFacultyReportComments(facultyId, {
+          ...baseQuery,
+          sentiment: 'negative',
+        });
+
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0].sentiment).toBe('negative');
+        expect(result.items[0].themeIds).toEqual([themeId]);
+
+        // Verify sentiment/run ids were included in count SQL params
+        const countCall = mockExecute.mock.calls[2] as [string, unknown[]];
+        expect(countCall[1]).toContain(sentimentRunId);
+        expect(countCall[1]).toContain('negative');
+      });
+
+      it('applies themeId filter via topic_assignment join', async () => {
+        mockExecute
+          .mockResolvedValueOnce([{ id: 'type-1', name: 'Student Evaluation' }])
+          .mockResolvedValueOnce([
+            {
+              id: 'v-1',
+              version_number: 1,
+              schema_snapshot: { meta: {}, sections: [] },
+            },
+          ])
+          .mockResolvedValueOnce([{ total: '3' }])
+          .mockResolvedValueOnce([
+            {
+              text: 'Theme comment',
+              submitted_at: '2026-03-20T10:00:00.000Z',
+              sentiment: 'positive',
+              theme_ids: [themeId],
+            },
+          ]);
+        mockPipelineResolved();
+
+        const result = await service.GetFacultyReportComments(facultyId, {
+          ...baseQuery,
+          themeId,
+        });
+
+        expect(result.items).toHaveLength(1);
+        expect(result.meta.totalItems).toBe(3);
+        const countCall = mockExecute.mock.calls[2] as [string, unknown[]];
+        expect(countCall[1]).toContain(themeId);
+        expect(countCall[1]).toContain(topicModelRunId);
+      });
+
+      it('composes both filters with AND semantics', async () => {
+        mockExecute
+          .mockResolvedValueOnce([{ id: 'type-1', name: 'Student Evaluation' }])
+          .mockResolvedValueOnce([
+            {
+              id: 'v-1',
+              version_number: 1,
+              schema_snapshot: { meta: {}, sections: [] },
+            },
+          ])
+          .mockResolvedValueOnce([{ total: '1' }])
+          .mockResolvedValueOnce([
+            {
+              text: 'Neg+theme',
+              submitted_at: '2026-03-20T10:00:00.000Z',
+              sentiment: 'negative',
+              theme_ids: [themeId],
+            },
+          ]);
+        mockPipelineResolved();
+
+        const result = await service.GetFacultyReportComments(facultyId, {
+          ...baseQuery,
+          sentiment: 'negative',
+          themeId,
+        });
+
+        expect(result.items).toHaveLength(1);
+        expect(result.meta.totalItems).toBe(1);
+        const countSql = (mockExecute.mock.calls[2] as [string, unknown[]])[0];
+        expect(countSql).toContain('sentiment_result');
+        expect(countSql).toContain('topic_assignment');
+        expect(countSql).toContain('is_dominant = true');
+      });
+
+      it('populates per-row annotations unconditionally when pipeline exists', async () => {
+        mockExecute
+          .mockResolvedValueOnce([{ id: 'type-1', name: 'Student Evaluation' }])
+          .mockResolvedValueOnce([
+            {
+              id: 'v-1',
+              version_number: 1,
+              schema_snapshot: { meta: {}, sections: [] },
+            },
+          ])
+          .mockResolvedValueOnce([{ total: '1' }])
+          .mockResolvedValueOnce([
+            {
+              text: 'Annotated',
+              submitted_at: '2026-03-20T10:00:00.000Z',
+              sentiment: 'positive',
+              theme_ids: [themeId],
+            },
+          ]);
+        mockPipelineResolved();
+
+        const result = await service.GetFacultyReportComments(
+          facultyId,
+          baseQuery,
+        );
+
+        expect(result.items[0].sentiment).toBe('positive');
+        expect(result.items[0].themeIds).toEqual([themeId]);
+      });
+    });
+  });
+
+  describe('GetQualitativeSummary', () => {
+    const facultyId = '550e8400-e29b-41d4-a716-446655440001';
+    const semesterId = '550e8400-e29b-41d4-a716-446655440000';
+    const baseQuery = {
+      semesterId,
+      questionnaireTypeCode: 'STUDENT_EVAL',
+    };
+
+    it('returns empty DTO when no completed pipeline exists', async () => {
+      // findOne returns null by default
+      const result = await service.GetQualitativeSummary(facultyId, baseQuery);
+
+      expect(result.sentimentDistribution).toEqual({
+        positive: 0,
+        neutral: 0,
+        negative: 0,
+      });
+      expect(result.themes).toEqual([]);
+    });
+
+    it('throws ForbiddenException when scope validation fails', async () => {
+      mockScopeResolver.ResolveDepartmentIds.mockResolvedValue([
+        'dept-allowed',
+      ]);
+      mockExecute.mockResolvedValueOnce([
+        {
+          id: facultyId,
+          department_id: 'dept-other',
+          first_name: 'John',
+          last_name: 'Doe',
+        },
+      ]);
+
+      await expect(
+        service.GetQualitativeSummary(facultyId, baseQuery),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('aggregates sentiment distribution and themes sorted by descending count', async () => {
+      const pipelineId = 'pipe-x';
+      const sentimentRunId = 'sr-x';
+      const topicModelRunId = 'tm-x';
+
+      mockFindOne
+        .mockResolvedValueOnce({ id: pipelineId }) // pipeline
+        .mockResolvedValueOnce({ id: sentimentRunId }) // sentiment run
+        .mockResolvedValueOnce({ id: topicModelRunId }); // topic model run
+
+      mockFind
+        // sentiment results
+        .mockResolvedValueOnce([
+          {
+            label: 'positive',
+            positiveScore: 0.9,
+            negativeScore: 0.05,
+            submission: { id: 's1' },
+          },
+          {
+            label: 'negative',
+            positiveScore: 0.1,
+            negativeScore: 0.8,
+            submission: { id: 's2' },
+          },
+          {
+            label: 'negative',
+            positiveScore: 0.15,
+            negativeScore: 0.75,
+            submission: { id: 's3' },
+          },
+        ])
+        // topics (sorted desc docCount — returned in DB order)
+        .mockResolvedValueOnce([
+          {
+            id: 't-pacing',
+            label: 'Pacing',
+            rawLabel: 'Pacing',
+            docCount: 2,
+          },
+          {
+            id: 't-content',
+            label: null,
+            rawLabel: 'Content Quality',
+            docCount: 1,
+          },
+        ])
+        // topic assignments (dominant-only)
+        .mockResolvedValueOnce([
+          {
+            topic: { id: 't-pacing' },
+            submission: { id: 's2' },
+            isDominant: true,
+          },
+          {
+            topic: { id: 't-pacing' },
+            submission: { id: 's3' },
+            isDominant: true,
+          },
+          {
+            topic: { id: 't-content' },
+            submission: { id: 's1' },
+            isDominant: true,
+          },
+        ])
+        // quote submissions
+        .mockResolvedValueOnce([
+          { id: 's1', cleanedComment: 'Great teacher John Smith here' },
+          { id: 's2', cleanedComment: 'Pacing was off' },
+          { id: 's3', cleanedComment: 'Too fast to follow' },
+        ]);
+
+      const result = await service.GetQualitativeSummary(facultyId, baseQuery);
+
+      expect(result.sentimentDistribution).toEqual({
+        positive: 1,
+        neutral: 0,
+        negative: 2,
+      });
+      expect(result.themes).toHaveLength(2);
+      expect(result.themes[0].label).toBe('Pacing');
+      expect(result.themes[0].count).toBe(2);
+      expect(result.themes[0].sentimentSplit).toEqual({
+        positive: 0,
+        neutral: 0,
+        negative: 2,
+      });
+      expect(result.themes[1].label).toBe('Content Quality');
+      expect(result.themes[1].count).toBe(1);
+      // PII scrub: "John Smith" -> "[name]"
+      expect(result.themes[1].sampleQuotes?.[0]).toContain('[name]');
+    });
+
+    it('caps sample quotes at 3 per theme and applies length truncation', async () => {
+      const longText = 'x'.repeat(500);
+      mockFindOne
+        .mockResolvedValueOnce({ id: 'p' })
+        .mockResolvedValueOnce({ id: 'sr' })
+        .mockResolvedValueOnce({ id: 'tm' });
+      mockFind
+        // sentiment for 5 submissions
+        .mockResolvedValueOnce([
+          {
+            label: 'negative',
+            positiveScore: 0.1,
+            negativeScore: 0.8,
+            submission: { id: 'a' },
+          },
+          {
+            label: 'negative',
+            positiveScore: 0.1,
+            negativeScore: 0.85,
+            submission: { id: 'b' },
+          },
+          {
+            label: 'negative',
+            positiveScore: 0.1,
+            negativeScore: 0.9,
+            submission: { id: 'c' },
+          },
+          {
+            label: 'negative',
+            positiveScore: 0.1,
+            negativeScore: 0.92,
+            submission: { id: 'd' },
+          },
+          {
+            label: 'negative',
+            positiveScore: 0.1,
+            negativeScore: 0.95,
+            submission: { id: 'e' },
+          },
+        ])
+        // one topic
+        .mockResolvedValueOnce([
+          { id: 't1', label: 'Topic1', rawLabel: 'Topic1', docCount: 5 },
+        ])
+        // assignments
+        .mockResolvedValueOnce([
+          { topic: { id: 't1' }, submission: { id: 'a' }, isDominant: true },
+          { topic: { id: 't1' }, submission: { id: 'b' }, isDominant: true },
+          { topic: { id: 't1' }, submission: { id: 'c' }, isDominant: true },
+          { topic: { id: 't1' }, submission: { id: 'd' }, isDominant: true },
+          { topic: { id: 't1' }, submission: { id: 'e' }, isDominant: true },
+        ])
+        // quote submissions (3 picked: top 3 strongest-signal = e, d, c)
+        .mockResolvedValueOnce([
+          { id: 'c', cleanedComment: longText },
+          { id: 'd', cleanedComment: 'short' },
+          { id: 'e', cleanedComment: 'another short one' },
+        ]);
+
+      const result = await service.GetQualitativeSummary(facultyId, baseQuery);
+
+      expect(result.themes[0].sampleQuotes).toHaveLength(3);
+      const truncated = result.themes[0].sampleQuotes!.find((q) =>
+        q.endsWith('…'),
+      );
+      expect(truncated).toBeDefined();
+      expect(truncated!.length).toBeLessThanOrEqual(281);
+    });
+
+    it('returns partial response when topic model run missing (sentiment only)', async () => {
+      mockFindOne
+        .mockResolvedValueOnce({ id: 'p' })
+        .mockResolvedValueOnce({ id: 'sr' })
+        .mockResolvedValueOnce(null); // no topic model run
+      mockFind.mockResolvedValueOnce([
+        {
+          label: 'positive',
+          positiveScore: 0.9,
+          negativeScore: 0.05,
+          submission: { id: 's1' },
+        },
+      ]);
+
+      const result = await service.GetQualitativeSummary(facultyId, baseQuery);
+
+      expect(result.sentimentDistribution.positive).toBe(1);
+      expect(result.themes).toEqual([]);
+    });
+  });
+
+  describe('findLatestCompletedPipelineByScope', () => {
+    it('is invoked via GetQualitativeSummary with correct filter', async () => {
+      const facultyId = '550e8400-e29b-41d4-a716-446655440001';
+      const semesterId = '550e8400-e29b-41d4-a716-446655440000';
+      const courseId = '550e8400-e29b-41d4-a716-446655440022';
+
+      await service.GetQualitativeSummary(facultyId, {
+        semesterId,
+        questionnaireTypeCode: 'STUDENT_EVAL',
+        courseId,
+      });
+
+      expect(mockFindOne).toHaveBeenCalled();
+      const call = mockFindOne.mock.calls[0] as unknown as [
+        unknown,
+        Record<string, unknown>,
+        Record<string, unknown>,
+      ];
+      const filter = call[1];
+      expect(filter.status).toBe('COMPLETED');
+      expect(filter.faculty).toBe(facultyId);
+      expect(filter.semester).toBe(semesterId);
+      expect(filter.course).toBe(courseId);
+      const qv = filter.questionnaireVersion as Record<string, unknown>;
+      expect(qv).toBeDefined();
+      const opts = call[2];
+      expect(opts.orderBy).toEqual({ createdAt: 'DESC' });
+    });
+
+    it('uses course=null in filter when courseId not provided', async () => {
+      const facultyId = '550e8400-e29b-41d4-a716-446655440001';
+      const semesterId = '550e8400-e29b-41d4-a716-446655440000';
+
+      await service.GetQualitativeSummary(facultyId, {
+        semesterId,
+        questionnaireTypeCode: 'STUDENT_EVAL',
+      });
+
+      const call = mockFindOne.mock.calls[0] as unknown as [
+        unknown,
+        Record<string, unknown>,
+      ];
+      const filter = call[1];
+      expect(filter.course).toBeNull();
     });
   });
 });

--- a/src/modules/analytics/analytics.service.ts
+++ b/src/modules/analytics/analytics.service.ts
@@ -17,6 +17,8 @@ import {
   FacultyReportQueryDto,
   FacultyReportCommentsQueryDto,
   BaseFacultyReportQueryDto,
+  QualitativeSummaryQueryDto,
+  SentimentLabel,
 } from './dto/analytics-query.dto';
 import { ReportCommentDto } from './dto/responses/faculty-report-comments.response.dto';
 import {
@@ -34,7 +36,19 @@ import {
 } from './dto/responses/faculty-trends.response.dto';
 import { FacultyReportResponseDto } from './dto/responses/faculty-report.response.dto';
 import { FacultyReportCommentsResponseDto } from './dto/responses/faculty-report-comments.response.dto';
+import {
+  QualitativeSummaryResponseDto,
+  QualitativeThemeDto,
+} from './dto/responses/qualitative-summary.response.dto';
 import { PaginationMeta } from 'src/modules/common/dto/pagination.dto';
+import { AnalysisPipeline } from 'src/entities/analysis-pipeline.entity';
+import { SentimentRun } from 'src/entities/sentiment-run.entity';
+import { SentimentResult } from 'src/entities/sentiment-result.entity';
+import { TopicModelRun } from 'src/entities/topic-model-run.entity';
+import { Topic } from 'src/entities/topic.entity';
+import { TopicAssignment } from 'src/entities/topic-assignment.entity';
+import { QuestionnaireSubmission } from 'src/entities/questionnaire-submission.entity';
+import { PipelineStatus } from 'src/modules/analysis/enums';
 
 interface QuestionMeta {
   text: string;
@@ -63,6 +77,25 @@ const ATTENTION_THRESHOLDS = {
   MIN_SEMESTERS_FOR_TREND: 3,
   MIN_R2_FOR_TREND: 0.5,
 } as const;
+
+const QUALITATIVE_SUMMARY_LIMITS = {
+  MAX_SAMPLE_QUOTES_PER_THEME: 3,
+  QUOTE_MAX_LENGTH: 280,
+} as const;
+
+const SENTIMENT_LABEL_VALUES: SentimentLabel[] = [
+  'positive',
+  'neutral',
+  'negative',
+];
+
+function scrubQuote(raw: string): string {
+  const truncated =
+    raw.length > QUALITATIVE_SUMMARY_LIMITS.QUOTE_MAX_LENGTH
+      ? `${raw.slice(0, QUALITATIVE_SUMMARY_LIMITS.QUOTE_MAX_LENGTH)}…`
+      : raw;
+  return truncated.replace(/[A-Z][a-z]+\s[A-Z][a-z]+/g, '[name]');
+}
 
 @Injectable()
 export class AnalyticsService {
@@ -585,17 +618,40 @@ export class AnalyticsService {
       query.questionnaireTypeCode,
     );
 
+    const page = query.page!;
+    const limit = query.limit!;
+
     if (versionIds.length === 0) {
-      return {
-        items: [],
-        meta: {
-          totalItems: 0,
-          itemCount: 0,
-          itemsPerPage: query.limit!,
-          totalPages: 0,
-          currentPage: query.page!,
-        } as PaginationMeta,
-      };
+      return this.emptyCommentsResponse(page, limit);
+    }
+
+    // Resolve pipeline (for per-row annotations + sentiment/theme filters).
+    const pipeline = await this.findLatestCompletedPipelineByScope(
+      facultyId,
+      query.semesterId,
+      query.questionnaireTypeCode,
+      query.courseId,
+    );
+
+    // If filters require a pipeline but none exists, return empty.
+    if (!pipeline && (query.sentiment || query.themeId)) {
+      return this.emptyCommentsResponse(page, limit);
+    }
+
+    let sentimentRunId: string | null = null;
+    let topicModelRunId: string | null = null;
+    if (pipeline) {
+      const runs = await this.resolvePipelineRuns(pipeline.id);
+      sentimentRunId = runs.sentimentRun?.id ?? null;
+      topicModelRunId = runs.topicModelRun?.id ?? null;
+    }
+
+    // Filters whose runs are missing → empty (cannot satisfy filter).
+    if (query.sentiment && !sentimentRunId) {
+      return this.emptyCommentsResponse(page, limit);
+    }
+    if (query.themeId && !topicModelRunId) {
+      return this.emptyCommentsResponse(page, limit);
     }
 
     const baseParams: unknown[] = [
@@ -609,29 +665,89 @@ export class AnalyticsService {
       baseParams.push(query.courseId);
     }
 
+    let sentimentFilterSql = '';
+    if (query.sentiment) {
+      sentimentFilterSql = ` AND EXISTS (
+        SELECT 1 FROM sentiment_result sr
+        WHERE sr.submission_id = qs.id
+          AND sr.run_id = ?
+          AND sr.label = ?
+          AND sr.deleted_at IS NULL
+      )`;
+      baseParams.push(sentimentRunId!, query.sentiment);
+    }
+
+    let themeFilterSql = '';
+    if (query.themeId) {
+      themeFilterSql = ` AND EXISTS (
+        SELECT 1 FROM topic_assignment ta_f
+        JOIN topic t_f ON t_f.id = ta_f.topic_id
+        WHERE ta_f.submission_id = qs.id
+          AND ta_f.topic_id = ?
+          AND ta_f.is_dominant = true
+          AND ta_f.deleted_at IS NULL
+          AND t_f.run_id = ?
+          AND t_f.deleted_at IS NULL
+      )`;
+      baseParams.push(query.themeId, topicModelRunId!);
+    }
+
     const whereClause = `
       WHERE qs.faculty_id = ?
         AND qs.semester_id = ?
         AND qs.questionnaire_version_id = ANY(?)
         AND qs.qualitative_comment IS NOT NULL
         AND TRIM(qs.qualitative_comment) != ''
-        AND qs.deleted_at IS NULL${courseFilter}
+        AND qs.deleted_at IS NULL${courseFilter}${sentimentFilterSql}${themeFilterSql}
     `;
 
     const countSql = `SELECT COUNT(*) AS total FROM questionnaire_submission qs ${whereClause}`;
 
-    const page = query.page!;
-    const limit = query.limit!;
     const offset = (page - 1) * limit;
 
-    const paginatedParams = [...baseParams, limit, offset];
+    // Per-row annotation LEFT JOINs when a pipeline is resolved.
+    let annotationSelect = '';
+    let annotationJoins = '';
+    const annotationParams: unknown[] = [];
+    if (sentimentRunId) {
+      annotationSelect += `, sr_ann.label AS sentiment`;
+      annotationJoins += `
+        LEFT JOIN LATERAL (
+          SELECT sr.label FROM sentiment_result sr
+          WHERE sr.submission_id = qs.id
+            AND sr.run_id = ?
+            AND sr.deleted_at IS NULL
+          ORDER BY sr.processed_at DESC
+          LIMIT 1
+        ) sr_ann ON true`;
+      annotationParams.push(sentimentRunId);
+    }
+    if (topicModelRunId) {
+      annotationSelect += `, ta_ann.theme_ids AS theme_ids`;
+      annotationJoins += `
+        LEFT JOIN LATERAL (
+          SELECT array_agg(DISTINCT ta.topic_id) AS theme_ids
+          FROM topic_assignment ta
+          JOIN topic t ON t.id = ta.topic_id
+          WHERE ta.submission_id = qs.id
+            AND ta.is_dominant = true
+            AND ta.deleted_at IS NULL
+            AND t.run_id = ?
+            AND t.deleted_at IS NULL
+        ) ta_ann ON true`;
+      annotationParams.push(topicModelRunId);
+    }
+
     const paginatedSql = `
-      SELECT qs.qualitative_comment AS text, qs.submitted_at
+      SELECT qs.qualitative_comment AS text, qs.submitted_at${annotationSelect}
       FROM questionnaire_submission qs
+      ${annotationJoins}
       ${whereClause}
       ORDER BY qs.submitted_at DESC
       LIMIT ? OFFSET ?
     `;
+
+    const paginatedParams = [...annotationParams, ...baseParams, limit, offset];
 
     const [countRows, commentRows] = await Promise.all([
       this.em.execute(countSql, baseParams),
@@ -639,10 +755,28 @@ export class AnalyticsService {
     ]);
 
     const totalItems = Number(countRows[0]?.total ?? 0);
-    const items = commentRows.map((r) => ({
-      text: r.text as string,
-      submittedAt: new Date(r.submitted_at as string).toISOString(),
-    }));
+    const items: ReportCommentDto[] = commentRows.map((r) => {
+      const row = r as {
+        text: string;
+        submitted_at: string;
+        sentiment?: string | null;
+        theme_ids?: string[] | null;
+      };
+      const dto: ReportCommentDto = {
+        text: row.text,
+        submittedAt: new Date(row.submitted_at).toISOString(),
+      };
+      if (
+        row.sentiment &&
+        SENTIMENT_LABEL_VALUES.includes(row.sentiment as SentimentLabel)
+      ) {
+        dto.sentiment = row.sentiment as SentimentLabel;
+      }
+      if (row.theme_ids && row.theme_ids.length > 0) {
+        dto.themeIds = row.theme_ids;
+      }
+      return dto;
+    });
 
     const totalPages = Math.ceil(totalItems / limit) || 0;
 
@@ -656,6 +790,220 @@ export class AnalyticsService {
         currentPage: page,
       } as PaginationMeta,
     };
+  }
+
+  async GetQualitativeSummary(
+    facultyId: string,
+    query: QualitativeSummaryQueryDto,
+  ): Promise<QualitativeSummaryResponseDto> {
+    await this.validateFacultyScope(facultyId, query.semesterId);
+
+    const emptyResponse: QualitativeSummaryResponseDto = {
+      sentimentDistribution: { positive: 0, neutral: 0, negative: 0 },
+      themes: [],
+    };
+
+    const pipeline = await this.findLatestCompletedPipelineByScope(
+      facultyId,
+      query.semesterId,
+      query.questionnaireTypeCode,
+      query.courseId,
+    );
+
+    if (!pipeline) {
+      return emptyResponse;
+    }
+
+    const { sentimentRun, topicModelRun } = await this.resolvePipelineRuns(
+      pipeline.id,
+    );
+
+    // Global sentiment distribution from all SentimentResults of the run.
+    const sentimentDistribution = { positive: 0, neutral: 0, negative: 0 };
+    const sentimentBySubmission = new Map<
+      string,
+      { label: string; strength: number }
+    >();
+    if (sentimentRun) {
+      const sentimentResults = await this.em.find(
+        SentimentResult,
+        { run: sentimentRun.id },
+        { populate: ['submission'] },
+      );
+      for (const sr of sentimentResults) {
+        if (sr.label === 'positive') sentimentDistribution.positive++;
+        else if (sr.label === 'neutral') sentimentDistribution.neutral++;
+        else if (sr.label === 'negative') sentimentDistribution.negative++;
+        sentimentBySubmission.set(sr.submission.id, {
+          label: sr.label,
+          strength: Math.abs(
+            Number(sr.positiveScore) - Number(sr.negativeScore),
+          ),
+        });
+      }
+    }
+
+    if (!topicModelRun) {
+      return { sentimentDistribution, themes: [] };
+    }
+
+    const topics = await this.em.find(
+      Topic,
+      { run: topicModelRun.id },
+      { orderBy: { docCount: 'DESC' } },
+    );
+
+    if (topics.length === 0) {
+      return { sentimentDistribution, themes: [] };
+    }
+
+    const topicIds = topics.map((t) => t.id);
+    const dominantAssignments = await this.em.find(
+      TopicAssignment,
+      { topic: { $in: topicIds }, isDominant: true },
+      { populate: ['submission'] },
+    );
+
+    // Group dominant assignments by topic id.
+    const assignmentsByTopic = new Map<string, TopicAssignment[]>();
+    for (const ta of dominantAssignments) {
+      const list = assignmentsByTopic.get(ta.topic.id) ?? [];
+      list.push(ta);
+      assignmentsByTopic.set(ta.topic.id, list);
+    }
+
+    // Collect submission ids whose comments we need for sample quotes.
+    const quoteSubmissionIds = new Set<string>();
+    const selectionsByTopic = new Map<
+      string,
+      { submissionId: string; strength: number }[]
+    >();
+    for (const topic of topics) {
+      const assignments = assignmentsByTopic.get(topic.id) ?? [];
+      const ranked = assignments
+        .map((a) => {
+          const senti = sentimentBySubmission.get(a.submission.id);
+          return senti
+            ? { submissionId: a.submission.id, strength: senti.strength }
+            : null;
+        })
+        .filter(
+          (
+            x,
+          ): x is {
+            submissionId: string;
+            strength: number;
+          } => x !== null,
+        )
+        .sort((a, b) => b.strength - a.strength)
+        .slice(0, QUALITATIVE_SUMMARY_LIMITS.MAX_SAMPLE_QUOTES_PER_THEME);
+      selectionsByTopic.set(topic.id, ranked);
+      for (const r of ranked) quoteSubmissionIds.add(r.submissionId);
+    }
+
+    const submissionTextMap = new Map<string, string>();
+    if (quoteSubmissionIds.size > 0) {
+      const subs = await this.em.find(QuestionnaireSubmission, {
+        id: { $in: Array.from(quoteSubmissionIds) },
+      });
+      for (const s of subs) {
+        const text = s.cleanedComment ?? s.qualitativeComment ?? '';
+        if (text) submissionTextMap.set(s.id, text);
+      }
+    }
+
+    const themes: QualitativeThemeDto[] = topics
+      .map((topic) => {
+        const assignments = assignmentsByTopic.get(topic.id) ?? [];
+        const split = { positive: 0, neutral: 0, negative: 0 };
+        for (const ta of assignments) {
+          const senti = sentimentBySubmission.get(ta.submission.id);
+          if (!senti) continue;
+          if (senti.label === 'positive') split.positive++;
+          else if (senti.label === 'neutral') split.neutral++;
+          else if (senti.label === 'negative') split.negative++;
+        }
+
+        const selection = selectionsByTopic.get(topic.id) ?? [];
+        const sampleQuotes = selection
+          .map((s) => submissionTextMap.get(s.submissionId))
+          .filter((t): t is string => !!t)
+          .map((t) => scrubQuote(t));
+
+        return {
+          themeId: topic.id,
+          label: topic.label ?? topic.rawLabel,
+          count: assignments.length,
+          sentimentSplit: split,
+          sampleQuotes: sampleQuotes.length > 0 ? sampleQuotes : undefined,
+        };
+      })
+      .sort((a, b) => b.count - a.count);
+
+    return {
+      sentimentDistribution,
+      themes,
+    };
+  }
+
+  private emptyCommentsResponse(
+    page: number,
+    limit: number,
+  ): FacultyReportCommentsResponseDto {
+    return {
+      items: [],
+      meta: {
+        totalItems: 0,
+        itemCount: 0,
+        itemsPerPage: limit,
+        totalPages: 0,
+        currentPage: page,
+      } as PaginationMeta,
+    };
+  }
+
+  private async findLatestCompletedPipelineByScope(
+    facultyId: string,
+    semesterId: string,
+    questionnaireTypeCode: string,
+    courseId?: string,
+  ): Promise<AnalysisPipeline | null> {
+    const filter: Record<string, unknown> = {
+      status: PipelineStatus.COMPLETED,
+      faculty: facultyId,
+      semester: semesterId,
+      questionnaireVersion: {
+        questionnaire: { type: { code: questionnaireTypeCode } },
+      },
+    };
+    if (courseId) {
+      filter.course = courseId;
+    } else {
+      filter.course = null;
+    }
+
+    return this.em.findOne(AnalysisPipeline, filter, {
+      orderBy: { createdAt: 'DESC' },
+    });
+  }
+
+  private async resolvePipelineRuns(pipelineId: string): Promise<{
+    sentimentRun: SentimentRun | null;
+    topicModelRun: TopicModelRun | null;
+  }> {
+    const [sentimentRun, topicModelRun] = await Promise.all([
+      this.em.findOne(
+        SentimentRun,
+        { pipeline: pipelineId },
+        { orderBy: { createdAt: 'DESC' } },
+      ),
+      this.em.findOne(
+        TopicModelRun,
+        { pipeline: pipelineId },
+        { orderBy: { createdAt: 'DESC' } },
+      ),
+    ]);
+    return { sentimentRun, topicModelRun };
   }
 
   private async BuildFacultyReportData(

--- a/src/modules/analytics/dto/analytics-query.dto.ts
+++ b/src/modules/analytics/dto/analytics-query.dto.ts
@@ -6,11 +6,15 @@ import {
   IsNotEmpty,
   IsNumber,
   IsInt,
+  IsIn,
   Min,
   Max,
   MaxLength,
 } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
+
+export const SENTIMENT_LABELS = ['positive', 'neutral', 'negative'] as const;
+export type SentimentLabel = (typeof SENTIMENT_LABELS)[number];
 
 export class DepartmentOverviewQueryDto {
   @ApiProperty({ description: 'Semester UUID to query analytics for' })
@@ -109,4 +113,21 @@ export class FacultyReportCommentsQueryDto extends BaseFacultyReportQueryDto {
   @IsOptional()
   @Type(() => Number)
   limit?: number = 10;
+
+  @ApiPropertyOptional({
+    description: 'Filter comments by sentiment label',
+    enum: SENTIMENT_LABELS,
+  })
+  @IsIn(SENTIMENT_LABELS as readonly string[])
+  @IsOptional()
+  sentiment?: SentimentLabel;
+
+  @ApiPropertyOptional({
+    description: 'Filter comments by dominant topic assignment (theme UUID)',
+  })
+  @IsUUID()
+  @IsOptional()
+  themeId?: string;
 }
+
+export class QualitativeSummaryQueryDto extends BaseFacultyReportQueryDto {}

--- a/src/modules/analytics/dto/responses/faculty-report-comments.response.dto.ts
+++ b/src/modules/analytics/dto/responses/faculty-report-comments.response.dto.ts
@@ -1,5 +1,7 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { PaginationMeta } from 'src/modules/common/dto/pagination.dto';
+import { SENTIMENT_LABELS } from '../analytics-query.dto';
+import type { SentimentLabel } from '../analytics-query.dto';
 
 export class ReportCommentDto {
   @ApiProperty()
@@ -7,6 +9,15 @@ export class ReportCommentDto {
 
   @ApiProperty()
   submittedAt!: string;
+
+  @ApiPropertyOptional({ enum: SENTIMENT_LABELS })
+  sentiment?: SentimentLabel;
+
+  @ApiPropertyOptional({
+    type: [String],
+    description: 'Dominant topic ids (themeIds) for this submission',
+  })
+  themeIds?: string[];
 }
 
 export class FacultyReportCommentsResponseDto {

--- a/src/modules/analytics/dto/responses/qualitative-summary.response.dto.ts
+++ b/src/modules/analytics/dto/responses/qualitative-summary.response.dto.ts
@@ -1,0 +1,40 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class SentimentDistributionDto {
+  @ApiProperty()
+  positive!: number;
+
+  @ApiProperty()
+  neutral!: number;
+
+  @ApiProperty()
+  negative!: number;
+}
+
+export class QualitativeThemeDto {
+  @ApiProperty()
+  themeId!: string;
+
+  @ApiProperty()
+  label!: string;
+
+  @ApiProperty()
+  count!: number;
+
+  @ApiProperty({ type: SentimentDistributionDto })
+  sentimentSplit!: SentimentDistributionDto;
+
+  @ApiPropertyOptional({
+    type: [String],
+    description: 'Up to 3 representative, PII-scrubbed, length-capped quotes',
+  })
+  sampleQuotes?: string[];
+}
+
+export class QualitativeSummaryResponseDto {
+  @ApiProperty({ type: SentimentDistributionDto })
+  sentimentDistribution!: SentimentDistributionDto;
+
+  @ApiProperty({ type: [QualitativeThemeDto] })
+  themes!: QualitativeThemeDto[];
+}


### PR DESCRIPTION
…347)

Backend for the new theme-first qualitative analytics surface on FacultyReportScreen (dean / chairperson / campus-head views).

## New

- `GET /analytics/faculty/:facultyId/qualitative-summary` — aggregates sentiment distribution + themes (with sample quotes) for the latest completed pipeline in scope. Themes ordered by descending mention count. Sample quotes are PII-scrubbed (280-char cap, two-word capitalized-name regex redaction).

## Extended

- `GET /analytics/faculty/:facultyId/report/comments` now accepts optional `sentiment` and `themeId` filters plus returns per-row `sentiment` + `themeIds[]` annotations when a pipeline is resolved. Filter semantics: `is_dominant = true` only (dominance invariant).

## Pipeline scope tightening (prerequisite that landed alongside)

Context: faculty-page pipeline discovery was leaking/missing pipelines across roles because listPipelines used loose matching. Addressed here so the FAC-134 UI could be verified; formalized separately as FAC-136.

- ListPipelines filter now binds unspecified scope keys to null for aggregate queries (strict scope isolation), and leaves dept/program/campus unbound for faculty-level queries so the same faculty pipeline is discoverable across DEAN/CHAIRPERSON/CAMPUS_HEAD with a new assertFacultyInScope authorization check.
- CreatePipelineDto + ListPipelinesQueryDto now accept `questionnaireTypeCode`; server resolves to the latest ACTIVE version at create time.

## Tests

- 50 analytics.service.spec tests (24 new): GetQualitativeSummary, findLatestCompletedPipelineByScope, extended comments with sentiment /themeId filters
- 64 pipeline-orchestrator.service.spec tests (7 new): scope isolation, faculty-level query semantics, cross-role visibility

All passing. Lint clean.