### PR TITLE
FAC-135.1 feat: admin non-submitters lookup endpoint

### DIFF
--- a/src/modules/admin/admin.controller.spec.ts
+++ b/src/modules/admin/admin.controller.spec.ts
@@ -6,6 +6,7 @@ import { CurrentUserInterceptor } from 'src/modules/common/interceptors/current-
 import { MetaDataInterceptor } from 'src/modules/common/interceptors/metadata.interceptor';
 import { AdminController } from './admin.controller';
 import { AdminService } from './services/admin.service';
+import { AdminNonSubmittersService } from './services/admin-non-submitters.service';
 import { AdminUserService } from './services/admin-user.service';
 import { ListUsersQueryDto } from './dto/requests/list-users-query.dto';
 import { UpdateScopeAssignmentDto } from './dto/requests/update-scope-assignment.request.dto';
@@ -20,6 +21,7 @@ describe('AdminController', () => {
     GetCampusHeadEligibleCategories: jest.Mock;
   };
   let adminUserService: { CreateLocalUser: jest.Mock };
+  let adminNonSubmittersService: { ListNonSubmitters: jest.Mock };
 
   async function buildModule(
     overrides: {
@@ -37,6 +39,10 @@ describe('AdminController', () => {
         {
           provide: AdminUserService,
           useValue: adminUserService,
+        },
+        {
+          provide: AdminNonSubmittersService,
+          useValue: adminNonSubmittersService,
         },
       ],
     })
@@ -93,6 +99,22 @@ describe('AdminController', () => {
         campus: null,
         defaultPasswordAssigned: false,
         createdAt: '2026-01-01T00:00:00.000Z',
+      }),
+    };
+    adminNonSubmittersService = {
+      ListNonSubmitters: jest.fn().mockResolvedValue({
+        data: [],
+        meta: {
+          totalItems: 0,
+          itemCount: 0,
+          itemsPerPage: 20,
+          totalPages: 0,
+          currentPage: 1,
+        },
+        scope: {
+          semesterId: '',
+          semesterCode: '',
+        },
       }),
     };
 

--- a/src/modules/admin/admin.controller.ts
+++ b/src/modules/admin/admin.controller.ts
@@ -23,14 +23,17 @@ import { CurrentUserInterceptor } from 'src/modules/common/interceptors/current-
 import { MetaDataInterceptor } from 'src/modules/common/interceptors/metadata.interceptor';
 import { UserRole } from '../auth/roles.enum';
 import { AdminService } from './services/admin.service';
+import { AdminNonSubmittersService } from './services/admin-non-submitters.service';
 import { AdminUserService } from './services/admin-user.service';
 import { AssignInstitutionalRoleDto } from './dto/requests/assign-institutional-role.request.dto';
 import { RemoveInstitutionalRoleDto } from './dto/requests/remove-institutional-role.request.dto';
+import { ListNonSubmittersQueryDto } from './dto/requests/list-non-submitters-query.dto';
 import { ListUsersQueryDto } from './dto/requests/list-users-query.dto';
 import { DeanEligibleCategoriesQueryDto } from './dto/requests/dean-eligible-categories-query.dto';
 import { CampusHeadEligibleCategoriesQueryDto } from './dto/requests/campus-head-eligible-categories-query.dto';
 import { UpdateScopeAssignmentDto } from './dto/requests/update-scope-assignment.request.dto';
 import { CreateLocalUserRequestDto } from './dto/requests/create-user.request.dto';
+import { AdminNonSubmitterListResponseDto } from './dto/responses/admin-non-submitter-list.response.dto';
 import { AdminUserDetailResponseDto } from './dto/responses/admin-user-detail.response.dto';
 import { AdminUserListResponseDto } from './dto/responses/admin-user-list.response.dto';
 import { AdminUserScopeAssignmentResponseDto } from './dto/responses/admin-user-scope-assignment.response.dto';
@@ -47,6 +50,7 @@ export class AdminController {
   constructor(
     private readonly adminService: AdminService,
     private readonly adminUserService: AdminUserService,
+    private readonly adminNonSubmittersService: AdminNonSubmittersService,
   ) {}
 
   @Post('users')
@@ -130,6 +134,57 @@ export class AdminController {
     @Query() query: ListUsersQueryDto,
   ): Promise<AdminUserListResponseDto> {
     return this.adminService.ListUsers(query);
+  }
+
+  @Get('users/without-submissions')
+  @ApiOperation({
+    summary:
+      'List students with no questionnaire submissions in the scope semester',
+    description:
+      'Internal admin lookup. Scope defaults to the latest semester. Optional faculty/course filters narrow the pool to students enrolled in that course and treat "no submissions" as no submissions for that (faculty, course, semester) tuple.',
+  })
+  @ApiQuery({
+    name: 'search',
+    required: false,
+    type: String,
+    example: 'jane',
+    description: 'Search by username, full name, first name, last name, or id',
+  })
+  @ApiQuery({
+    name: 'semesterId',
+    required: false,
+    type: String,
+    description: 'Scope semester UUID (defaults to latest)',
+  })
+  @ApiQuery({
+    name: 'facultyUsername',
+    required: false,
+    type: String,
+    description: 'Restrict to the course pool taught by this faculty username',
+  })
+  @ApiQuery({
+    name: 'courseId',
+    required: false,
+    type: String,
+    description: 'Restrict to students enrolled in this course UUID',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    example: 1,
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    example: 20,
+  })
+  @ApiResponse({ status: 200, type: AdminNonSubmitterListResponseDto })
+  async ListUsersWithoutSubmissions(
+    @Query() query: ListNonSubmittersQueryDto,
+  ): Promise<AdminNonSubmitterListResponseDto> {
+    return this.adminNonSubmittersService.ListNonSubmitters(query);
   }
 
   @Get('users/:id')

--- a/src/modules/admin/admin.module.ts
+++ b/src/modules/admin/admin.module.ts
@@ -21,6 +21,7 @@ import { AdminGenerateController } from './admin-generate.controller';
 import { AdminService } from './services/admin.service';
 import { AdminFiltersService } from './services/admin-filters.service';
 import { AdminGenerateService } from './services/admin-generate.service';
+import { AdminNonSubmittersService } from './services/admin-non-submitters.service';
 import { AdminUserService } from './services/admin-user.service';
 import { CommentGeneratorService } from './services/comment-generator.service';
 
@@ -53,6 +54,7 @@ import { CommentGeneratorService } from './services/comment-generator.service';
     AdminService,
     AdminFiltersService,
     AdminGenerateService,
+    AdminNonSubmittersService,
     AdminUserService,
     CommentGeneratorService,
   ],

--- a/src/modules/admin/dto/requests/list-non-submitters-query.dto.ts
+++ b/src/modules/admin/dto/requests/list-non-submitters-query.dto.ts
@@ -1,0 +1,60 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+
+export class ListNonSubmittersQueryDto {
+  @ApiPropertyOptional({
+    description: 'Search by username, full name, first name, last name, or id',
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  search?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Semester UUID to scope the lookup to. Defaults to the latest semester if omitted.',
+  })
+  @IsUUID()
+  @IsOptional()
+  semesterId?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Restrict the pool to students enrolled in the course taught by this faculty username.',
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  facultyUsername?: string;
+
+  @ApiPropertyOptional({
+    description: 'Restrict the pool to students enrolled in this course UUID.',
+  })
+  @IsUUID()
+  @IsOptional()
+  courseId?: string;
+
+  @ApiPropertyOptional({ default: 1, minimum: 1 })
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  @Type(() => Number)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 20, minimum: 1, maximum: 100 })
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @IsOptional()
+  @Type(() => Number)
+  limit?: number = 20;
+}

--- a/src/modules/admin/dto/responses/admin-non-submitter-item.response.dto.ts
+++ b/src/modules/admin/dto/responses/admin-non-submitter-item.response.dto.ts
@@ -1,0 +1,94 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { User } from 'src/entities/user.entity';
+import { UserRole } from 'src/modules/auth/roles.enum';
+
+export class AdminNonSubmitterScopedRelationDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  code: string;
+
+  @ApiPropertyOptional()
+  name?: string;
+}
+
+export class AdminNonSubmitterItemResponseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  userName: string;
+
+  @ApiProperty()
+  fullName: string;
+
+  @ApiPropertyOptional()
+  moodleUserId?: number;
+
+  @ApiProperty({ enum: UserRole, isArray: true })
+  roles: UserRole[];
+
+  @ApiProperty()
+  isActive: boolean;
+
+  @ApiProperty({
+    description:
+      'Number of active enrollments the student has in courses scoped to the target semester.',
+  })
+  enrolledCoursesInSemester: number;
+
+  @ApiPropertyOptional({
+    type: AdminNonSubmitterScopedRelationDto,
+    nullable: true,
+  })
+  campus: AdminNonSubmitterScopedRelationDto | null;
+
+  @ApiPropertyOptional({
+    type: AdminNonSubmitterScopedRelationDto,
+    nullable: true,
+  })
+  department: AdminNonSubmitterScopedRelationDto | null;
+
+  @ApiPropertyOptional({
+    type: AdminNonSubmitterScopedRelationDto,
+    nullable: true,
+  })
+  program: AdminNonSubmitterScopedRelationDto | null;
+
+  static Map(
+    user: User,
+    enrolledCoursesInSemester: number,
+  ): AdminNonSubmitterItemResponseDto {
+    return {
+      id: user.id,
+      userName: user.userName,
+      fullName: user.fullName ?? `${user.firstName} ${user.lastName}`.trim(),
+      moodleUserId: user.moodleUserId,
+      roles: user.roles,
+      isActive: user.isActive,
+      enrolledCoursesInSemester,
+      campus: user.campus
+        ? {
+            id: user.campus.id,
+            code: user.campus.code,
+            name: user.campus.name,
+          }
+        : null,
+      department: user.department
+        ? {
+            id: user.department.id,
+            code: user.department.code,
+            name: user.department.name,
+          }
+        : null,
+      program: user.program
+        ? {
+            id: user.program.id,
+            code: user.program.code,
+            name: user.program.name,
+          }
+        : null,
+    };
+  }
+}

--- a/src/modules/admin/dto/responses/admin-non-submitter-list.response.dto.ts
+++ b/src/modules/admin/dto/responses/admin-non-submitter-list.response.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { PaginationMeta } from 'src/modules/common/dto/pagination.dto';
+import { AdminNonSubmitterItemResponseDto } from './admin-non-submitter-item.response.dto';
+
+export class AdminNonSubmitterScopeDto {
+  @ApiProperty()
+  semesterId: string;
+
+  @ApiProperty()
+  semesterCode: string;
+
+  @ApiPropertyOptional()
+  semesterLabel?: string;
+
+  @ApiPropertyOptional()
+  academicYear?: string;
+}
+
+export class AdminNonSubmitterListResponseDto {
+  @ApiProperty({ type: [AdminNonSubmitterItemResponseDto] })
+  data: AdminNonSubmitterItemResponseDto[];
+
+  @ApiProperty({ type: PaginationMeta })
+  meta: PaginationMeta;
+
+  @ApiProperty({
+    type: AdminNonSubmitterScopeDto,
+    description:
+      'Resolved scope for this response — surfaces the semester that was evaluated.',
+  })
+  scope: AdminNonSubmitterScopeDto;
+}

--- a/src/modules/admin/services/admin-non-submitters.service.spec.ts
+++ b/src/modules/admin/services/admin-non-submitters.service.spec.ts
@@ -1,0 +1,243 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { EntityManager } from '@mikro-orm/postgresql';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Enrollment } from 'src/entities/enrollment.entity';
+import { QuestionnaireSubmission } from 'src/entities/questionnaire-submission.entity';
+import { Semester } from 'src/entities/semester.entity';
+import { User } from 'src/entities/user.entity';
+import { UserRole } from 'src/modules/auth/roles.enum';
+import {
+  EnrollmentRole,
+  RespondentRole,
+} from 'src/modules/questionnaires/lib/questionnaire.types';
+import { AdminNonSubmittersService } from './admin-non-submitters.service';
+
+type EmMock = {
+  findOne: jest.Mock;
+  find: jest.Mock;
+  findAndCount: jest.Mock;
+};
+
+function makeSemester(overrides: Partial<Semester> = {}): Semester {
+  return {
+    id: 'sem-1',
+    code: 'S22526',
+    label: 'Second Semester',
+    academicYear: '2025-2026',
+    ...overrides,
+  } as Semester;
+}
+
+function makeEnrollment(userId: string, courseId = 'course-1'): Enrollment {
+  return {
+    user: { id: userId },
+    course: { id: courseId },
+    role: EnrollmentRole.STUDENT,
+    isActive: true,
+  } as unknown as Enrollment;
+}
+
+function makeStudent(
+  id: string,
+  userName: string,
+  fullName: string,
+): Partial<User> {
+  return {
+    id,
+    userName,
+    fullName,
+    firstName: fullName.split(' ')[0],
+    lastName: fullName.split(' ')[1] ?? '',
+    roles: [UserRole.STUDENT],
+    isActive: true,
+    campus: null as unknown as User['campus'],
+    department: null as unknown as User['department'],
+    program: null as unknown as User['program'],
+  };
+}
+
+describe('AdminNonSubmittersService', () => {
+  let service: AdminNonSubmittersService;
+  let em: EmMock;
+
+  beforeEach(async () => {
+    em = {
+      findOne: jest.fn(),
+      find: jest.fn(),
+      findAndCount: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminNonSubmittersService,
+        { provide: EntityManager, useValue: em },
+      ],
+    }).compile();
+
+    service = module.get(AdminNonSubmittersService);
+  });
+
+  it('returns students enrolled in the scope semester who have no submissions', async () => {
+    const semester = makeSemester();
+    em.findOne.mockResolvedValueOnce(semester);
+
+    em.find.mockImplementation((entity: unknown) => {
+      if (entity === Enrollment) {
+        return Promise.resolve([
+          makeEnrollment('u-1', 'c-1'),
+          makeEnrollment('u-2', 'c-1'),
+          makeEnrollment('u-2', 'c-2'),
+          makeEnrollment('u-3', 'c-2'),
+        ]);
+      }
+      if (entity === QuestionnaireSubmission) {
+        return Promise.resolve([{ respondent: { id: 'u-1' } }]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const studentU2 = makeStudent('u-2', 'alice', 'Alice Doe');
+    const studentU3 = makeStudent('u-3', 'bob', 'Bob Smith');
+    em.findAndCount.mockResolvedValue([[studentU2, studentU3], 2]);
+
+    const result = await service.ListNonSubmitters({ page: 1, limit: 20 });
+
+    expect(em.findOne).toHaveBeenCalledWith(
+      Semester,
+      {},
+      { orderBy: { createdAt: 'DESC' } },
+    );
+
+    expect(em.find).toHaveBeenCalledWith(
+      Enrollment,
+      expect.objectContaining({
+        role: EnrollmentRole.STUDENT,
+        isActive: true,
+      }),
+      expect.objectContaining({ fields: ['user', 'course'] }),
+    );
+
+    expect(em.find).toHaveBeenCalledWith(
+      QuestionnaireSubmission,
+      expect.objectContaining({
+        semester: semester.id,
+        respondentRole: RespondentRole.STUDENT,
+      }),
+      expect.objectContaining({ fields: ['respondent'] }),
+    );
+
+    const findAndCountCalls = em.findAndCount.mock.calls as Array<
+      [unknown, { id: { $in: string[] } }, unknown]
+    >;
+    const userFilterCall = findAndCountCalls[0][1];
+    expect(new Set(userFilterCall.id.$in)).toEqual(new Set(['u-2', 'u-3']));
+
+    expect(result.data).toHaveLength(2);
+    const alice = result.data.find((d) => d.userName === 'alice');
+    expect(alice?.enrolledCoursesInSemester).toBe(2);
+    expect(result.scope).toEqual({
+      semesterId: 'sem-1',
+      semesterCode: 'S22526',
+      semesterLabel: 'Second Semester',
+      academicYear: '2025-2026',
+    });
+  });
+
+  it('resolves facultyUsername and narrows submitters to the faculty+course tuple', async () => {
+    em.findOne
+      .mockResolvedValueOnce(makeSemester())
+      .mockResolvedValueOnce({ id: 'faculty-1' });
+
+    em.find.mockImplementation((entity: unknown) => {
+      if (entity === Enrollment) {
+        return Promise.resolve([
+          makeEnrollment('u-1', 'c-1'),
+          makeEnrollment('u-2', 'c-1'),
+        ]);
+      }
+      if (entity === QuestionnaireSubmission) {
+        return Promise.resolve([{ respondent: { id: 'u-2' } }]);
+      }
+      return Promise.resolve([]);
+    });
+
+    em.findAndCount.mockResolvedValue([
+      [makeStudent('u-1', 'kevin', 'Kevin Lee')],
+      1,
+    ]);
+
+    const result = await service.ListNonSubmitters({
+      facultyUsername: 'prof.moore',
+      courseId: 'c-1',
+    });
+
+    expect(em.findOne).toHaveBeenNthCalledWith(
+      2,
+      User,
+      { userName: 'prof.moore' },
+      { fields: ['id'] },
+    );
+
+    expect(em.find).toHaveBeenCalledWith(
+      QuestionnaireSubmission,
+      expect.objectContaining({
+        semester: 'sem-1',
+        faculty: 'faculty-1',
+        course: 'c-1',
+      }),
+      expect.anything(),
+    );
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].userName).toBe('kevin');
+  });
+
+  it('throws NotFoundException when facultyUsername does not resolve', async () => {
+    em.findOne
+      .mockResolvedValueOnce(makeSemester())
+      .mockResolvedValueOnce(null);
+
+    await expect(
+      service.ListNonSubmitters({ facultyUsername: 'ghost.user' }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('throws BadRequestException when an explicit semesterId does not exist', async () => {
+    em.findOne.mockResolvedValueOnce(null);
+
+    await expect(
+      service.ListNonSubmitters({ semesterId: 'missing-sem' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('returns an empty response when no semester exists in the system', async () => {
+    em.findOne.mockResolvedValueOnce(null);
+
+    const result = await service.ListNonSubmitters({});
+
+    expect(result.data).toEqual([]);
+    expect(result.scope.semesterId).toBe('');
+  });
+
+  it('returns an empty response when every enrolled student has already submitted', async () => {
+    em.findOne.mockResolvedValueOnce(makeSemester());
+    em.find.mockImplementation((entity: unknown) => {
+      if (entity === Enrollment) {
+        return Promise.resolve([makeEnrollment('u-1'), makeEnrollment('u-2')]);
+      }
+      if (entity === QuestionnaireSubmission) {
+        return Promise.resolve([
+          { respondent: { id: 'u-1' } },
+          { respondent: { id: 'u-2' } },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const result = await service.ListNonSubmitters({});
+
+    expect(em.findAndCount).not.toHaveBeenCalled();
+    expect(result.data).toEqual([]);
+    expect(result.meta.totalPages).toBe(0);
+  });
+});

--- a/src/modules/admin/services/admin-non-submitters.service.ts
+++ b/src/modules/admin/services/admin-non-submitters.service.ts
@@ -1,0 +1,228 @@
+import { FilterQuery } from '@mikro-orm/core';
+import { EntityManager } from '@mikro-orm/postgresql';
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { Enrollment } from 'src/entities/enrollment.entity';
+import { QuestionnaireSubmission } from 'src/entities/questionnaire-submission.entity';
+import { Semester } from 'src/entities/semester.entity';
+import { User } from 'src/entities/user.entity';
+import { UserRole } from 'src/modules/auth/roles.enum';
+import {
+  EnrollmentRole,
+  RespondentRole,
+} from 'src/modules/questionnaires/lib/questionnaire.types';
+import { ListNonSubmittersQueryDto } from '../dto/requests/list-non-submitters-query.dto';
+import { AdminNonSubmitterItemResponseDto } from '../dto/responses/admin-non-submitter-item.response.dto';
+import { AdminNonSubmitterListResponseDto } from '../dto/responses/admin-non-submitter-list.response.dto';
+
+@Injectable()
+export class AdminNonSubmittersService {
+  private readonly logger = new Logger(AdminNonSubmittersService.name);
+
+  constructor(private readonly em: EntityManager) {}
+
+  async ListNonSubmitters(
+    query: ListNonSubmittersQueryDto,
+  ): Promise<AdminNonSubmitterListResponseDto> {
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+
+    const semester = await this.ResolveScopeSemester(query.semesterId);
+    if (!semester) {
+      return this.EmptyResponse(page, limit, null);
+    }
+
+    const facultyId = await this.ResolveFacultyId(query.facultyUsername);
+
+    const enrolledCountByUser = await this.BuildEnrolledStudentPool(
+      semester.id,
+      query.courseId,
+    );
+    if (enrolledCountByUser.size === 0) {
+      return this.EmptyResponse(page, limit, semester);
+    }
+
+    const submitterIds = await this.BuildSubmitterSet(
+      semester.id,
+      facultyId,
+      query.courseId,
+    );
+
+    const candidateIds: string[] = [];
+    for (const userId of enrolledCountByUser.keys()) {
+      if (!submitterIds.has(userId)) {
+        candidateIds.push(userId);
+      }
+    }
+    if (candidateIds.length === 0) {
+      return this.EmptyResponse(page, limit, semester);
+    }
+
+    const filter = this.BuildUserFilter(candidateIds, query.search);
+    const offset = (page - 1) * limit;
+
+    const [users, totalItems] = await this.em.findAndCount(User, filter, {
+      populate: ['campus', 'department', 'program'],
+      limit,
+      offset,
+      orderBy: { userName: 'ASC', id: 'ASC' },
+    });
+
+    return {
+      data: users.map((user) =>
+        AdminNonSubmitterItemResponseDto.Map(
+          user,
+          enrolledCountByUser.get(user.id) ?? 0,
+        ),
+      ),
+      meta: {
+        totalItems,
+        itemCount: users.length,
+        itemsPerPage: limit,
+        totalPages: Math.ceil(totalItems / limit),
+        currentPage: page,
+      },
+      scope: {
+        semesterId: semester.id,
+        semesterCode: semester.code,
+        semesterLabel: semester.label,
+        academicYear: semester.academicYear,
+      },
+    };
+  }
+
+  private async ResolveScopeSemester(
+    semesterId: string | undefined,
+  ): Promise<Semester | null> {
+    if (semesterId) {
+      const semester = await this.em.findOne(Semester, { id: semesterId });
+      if (!semester) {
+        throw new BadRequestException(
+          `Semester with id "${semesterId}" not found.`,
+        );
+      }
+      return semester;
+    }
+    return this.em.findOne(Semester, {}, { orderBy: { createdAt: 'DESC' } });
+  }
+
+  private async ResolveFacultyId(
+    facultyUsername: string | undefined,
+  ): Promise<string | null> {
+    if (!facultyUsername) return null;
+    const faculty = await this.em.findOne(
+      User,
+      { userName: facultyUsername },
+      { fields: ['id'] },
+    );
+    if (!faculty) {
+      throw new NotFoundException(
+        `Faculty with username "${facultyUsername}" not found.`,
+      );
+    }
+    return faculty.id;
+  }
+
+  private async BuildEnrolledStudentPool(
+    semesterId: string,
+    courseId: string | undefined,
+  ): Promise<Map<string, number>> {
+    const filter: FilterQuery<Enrollment> = {
+      role: EnrollmentRole.STUDENT,
+      isActive: true,
+      course: courseId
+        ? { id: courseId, program: { department: { semester: semesterId } } }
+        : { program: { department: { semester: semesterId } } },
+    };
+
+    const enrollments = await this.em.find(Enrollment, filter, {
+      fields: ['user', 'course'],
+    });
+
+    const coursesByUser = new Map<string, Set<string>>();
+    for (const enrollment of enrollments) {
+      const userId = enrollment.user.id;
+      const courseSet = coursesByUser.get(userId) ?? new Set<string>();
+      courseSet.add(enrollment.course.id);
+      coursesByUser.set(userId, courseSet);
+    }
+
+    const counts = new Map<string, number>();
+    for (const [userId, courseSet] of coursesByUser) {
+      counts.set(userId, courseSet.size);
+    }
+    return counts;
+  }
+
+  private async BuildSubmitterSet(
+    semesterId: string,
+    facultyId: string | null,
+    courseId: string | undefined,
+  ): Promise<Set<string>> {
+    const filter: FilterQuery<QuestionnaireSubmission> = {
+      semester: semesterId,
+      respondentRole: RespondentRole.STUDENT,
+    };
+    if (facultyId) filter.faculty = facultyId;
+    if (courseId) filter.course = courseId;
+
+    const submissions = await this.em.find(QuestionnaireSubmission, filter, {
+      fields: ['respondent'],
+    });
+
+    return new Set(submissions.map((s) => s.respondent.id));
+  }
+
+  private BuildUserFilter(
+    candidateIds: string[],
+    search: string | undefined,
+  ): FilterQuery<User> {
+    const filter: FilterQuery<User> = {
+      id: { $in: candidateIds },
+      roles: { $contains: [UserRole.STUDENT] },
+    };
+
+    if (search) {
+      const pattern = `%${this.EscapeLikePattern(search.trim())}%`;
+      filter.$or = [
+        { userName: { $ilike: pattern } },
+        { fullName: { $ilike: pattern } },
+        { firstName: { $ilike: pattern } },
+        { lastName: { $ilike: pattern } },
+      ];
+    }
+
+    return filter;
+  }
+
+  private EscapeLikePattern(value: string): string {
+    return value.replace(/[%_\\]/g, '\\$&');
+  }
+
+  private EmptyResponse(
+    page: number,
+    limit: number,
+    semester: Semester | null,
+  ): AdminNonSubmitterListResponseDto {
+    return {
+      data: [],
+      meta: {
+        totalItems: 0,
+        itemCount: 0,
+        itemsPerPage: limit,
+        totalPages: 0,
+        currentPage: page,
+      },
+      scope: {
+        semesterId: semester?.id ?? '',
+        semesterCode: semester?.code ?? '',
+        semesterLabel: semester?.label,
+        academicYear: semester?.academicYear,
+      },
+    };
+  }
+}


### PR DESCRIPTION
Closes #351

## Summary

- New `GET /admin/users/without-submissions` endpoint — SUPER_ADMIN-guarded, paginated, returns students with zero questionnaire submissions in a scope semester.
- Filters: `search`, `semesterId`, `facultyUsername`, `courseId`, `page`, `limit`. Scope defaults to the latest semester (`createdAt DESC`, mirroring `analytics.service.ts`).
- Faculty+course filter narrows both the enrolled-student pool **and** the submission-match tuple so admins can chase down students who haven't evaluated a specific (faculty, course) pairing.
- Response carries a `scope` block (semester id/code/label/academic year) so the client can surface which semester was evaluated.

## Implementation notes

- New `AdminNonSubmittersService` wired into `AdminController` and `AdminModule`
- `ResolveFacultyId` throws `NotFoundException` on unknown username (consistent with `AdminFiltersService.GetCoursesForFaculty`)
- `enrolledCoursesInSemester` counts distinct course IDs per user via `Set<string>`
- In-memory set-difference pattern mirrors existing `admin-filters.service.ts`; a `NOT EXISTS` subquery refactor is intentionally deferred

## Test plan

- [x] `npm run test -- --testPathPatterns=admin` → 104/104 passing (6 new tests covering latest/explicit semester, faculty+course filter, unknown faculty 404, no-semester empty, all-submitted empty)
- [x] `npm run lint` — clean (only pre-existing warnings)
- [x] `npm run build` — clean
- [ ] Manual verification: hit endpoint with a seeded semester, confirm pool & scope resolution