### PR TITLE
[STAGING] FAC-135.2 feat: submission generator count cap and prompt theming (#355)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,8 @@ import { NestExpressApplication } from '@nestjs/platform-express';
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
   app.set('trust proxy', 1);
+  app.useBodyParser('json', { limit: '5mb' });
+  app.useBodyParser('urlencoded', { limit: '5mb', extended: true });
   ApplyConfigurations(app);
   await InitializeDatabase(app);
   app.enableShutdownHooks();

--- a/src/modules/admin/dto/requests/generate-preview.request.dto.ts
+++ b/src/modules/admin/dto/requests/generate-preview.request.dto.ts
@@ -1,5 +1,14 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString, IsUUID } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
 
 export class GeneratePreviewRequestDto {
   @ApiProperty({ description: 'Questionnaire version UUID' })
@@ -16,4 +25,26 @@ export class GeneratePreviewRequestDto {
   @IsString()
   @IsNotEmpty()
   courseShortname: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Optional cap on how many submissions to generate. If omitted or greater than available, all available students are used. Otherwise a random sample of the requested size is taken.',
+    minimum: 1,
+    maximum: 500,
+  })
+  @IsInt()
+  @Min(1)
+  @Max(500)
+  @IsOptional()
+  count?: number;
+
+  @ApiPropertyOptional({
+    description:
+      'Optional free-text guidance to bias the tone/topic of generated qualitative comments (e.g., "mostly positive, emphasizes teaching clarity"). Ignored when qualitative feedback is disabled on the version.',
+    maxLength: 500,
+  })
+  @IsString()
+  @IsOptional()
+  @MaxLength(500)
+  promptTheme?: string;
 }

--- a/src/modules/admin/services/admin-generate.service.ts
+++ b/src/modules/admin/services/admin-generate.service.ts
@@ -151,6 +151,12 @@ export class AdminGenerateService {
       );
     }
 
+    const availableCount = availableStudents.length;
+    const selectedStudents =
+      dto.count != null && dto.count < availableCount
+        ? this.SampleStudents(availableStudents, dto.count)
+        : availableStudents;
+
     // 9. Extract questions
     const questions = GetAllQuestionsWithSections(version.schemaSnapshot);
 
@@ -158,7 +164,7 @@ export class AdminGenerateService {
     const maxScore = version.schemaSnapshot.meta.maxScore;
 
     // 11. Generate answers
-    const answersPerStudent = availableStudents.map(() => {
+    const answersPerStudent = selectedStudents.map(() => {
       const tendency =
         1 + Math.random() * (maxScore - 1) * 0.6 + (maxScore - 1) * 0.3;
       const answers: Record<string, number> = {};
@@ -170,19 +176,20 @@ export class AdminGenerateService {
     });
 
     // 12. Generate comments (conditional)
-    let comments: (string | undefined)[] = availableStudents.map(
+    let comments: (string | undefined)[] = selectedStudents.map(
       () => undefined,
     );
     const qf = version.schemaSnapshot.qualitativeFeedback;
     if (qf?.enabled) {
       const generated = await this.commentGenerator.GenerateComments(
-        availableStudents.length,
+        selectedStudents.length,
         {
           courseName: course.fullname,
           facultyName:
             faculty.fullName ?? `${faculty.firstName} ${faculty.lastName}`,
           maxScore,
           maxLength: qf.maxLength,
+          promptTheme: dto.promptTheme,
         },
       );
       comments = generated;
@@ -190,7 +197,7 @@ export class AdminGenerateService {
 
     // 13. Build rows
     const now = Date.now();
-    const rows = availableStudents.map((enrollment, index) => ({
+    const rows = selectedStudents.map((enrollment, index) => ({
       externalId: `gen_${enrollment.user.userName}_${now}_${index}`,
       username: enrollment.user.userName,
       facultyUsername: dto.facultyUsername,
@@ -217,8 +224,8 @@ export class AdminGenerateService {
         maxScore,
         totalEnrolled: studentEnrollments.length,
         alreadySubmitted: submittedUserIds.size,
-        availableStudents: availableStudents.length,
-        generatingCount: availableStudents.length,
+        availableStudents: availableCount,
+        generatingCount: selectedStudents.length,
       },
       questions: questions.map((q) => ({
         id: q.id,
@@ -227,6 +234,16 @@ export class AdminGenerateService {
       })),
       rows,
     };
+  }
+
+  private SampleStudents<T>(pool: T[], count: number): T[] {
+    if (count >= pool.length) return pool;
+    const copy = [...pool];
+    for (let i = copy.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [copy[i], copy[j]] = [copy[j], copy[i]];
+    }
+    return copy.slice(0, count);
   }
 
   async CommitSubmissions(

--- a/src/modules/admin/services/comment-generator.service.ts
+++ b/src/modules/admin/services/comment-generator.service.ts
@@ -31,11 +31,17 @@ export class CommentGeneratorService {
       facultyName: string;
       maxScore: number;
       maxLength?: number;
+      promptTheme?: string;
     },
   ): Promise<string[]> {
     try {
       const maxLengthInstruction = context.maxLength
         ? `Each comment must be under ${context.maxLength} characters.`
+        : '';
+
+      const theme = context.promptTheme?.trim();
+      const themeInstruction = theme
+        ? `Thematic guidance (shape tone and topic accordingly, but preserve realism and the language distribution): "${theme}".`
         : '';
 
       const response = await this.openai.chat.completions.create(
@@ -56,7 +62,7 @@ export class CommentGeneratorService {
               content:
                 `Generate exactly ${count} student feedback comments for the course "${context.courseName}" ` +
                 `taught by "${context.facultyName}". The course uses a ${context.maxScore}-point scale. ` +
-                `${maxLengthInstruction} ` +
+                `${maxLengthInstruction} ${themeInstruction} ` +
                 `Return JSON: { "comments": ["comment1", "comment2", ...] }`,
             },
           ],


### PR DESCRIPTION
- Add optional count on GeneratePreviewRequestDto with Fisher-Yates random sampling when count < available
- Add optional promptTheme piped into the OpenAI user prompt for biased comment generation
- Raise Express body parser limit to 5MB to fix HTTP 413 on commit at 80+ rows