### PR TITLE
FAC-135.3 feat: audit logging for pipeline failures

### DIFF
--- a/src/modules/analysis/services/__tests__/pipeline-orchestrator.audit.spec.ts
+++ b/src/modules/analysis/services/__tests__/pipeline-orchestrator.audit.spec.ts
@@ -1,0 +1,269 @@
+import { PipelineStatus, PipelineTrigger } from '../../enums';
+import { PipelineOrchestratorService } from '../pipeline-orchestrator.service';
+import { AuditAction } from 'src/modules/audit/audit-action.enum';
+import type { AnalysisPipeline } from 'src/entities/analysis-pipeline.entity';
+import type { EmitParams } from 'src/modules/audit/dto/emit-params.dto';
+
+/**
+ * Covers the audit-emit path added for pipeline failures.
+ * Three surfaces under test:
+ *   - `OnStageFailed` (public) — guarded by TERMINAL_STATUSES, emits once.
+ *   - `emitPipelineFailAudit` (private) — metadata shape + scope inclusion.
+ *   - `failPipeline` (private) — "<stage>: <message>" prefix parsing.
+ */
+
+interface TestPipeline {
+  id: string;
+  status: PipelineStatus;
+  trigger: PipelineTrigger;
+  totalEnrolled: number;
+  submissionCount: number;
+  commentCount: number;
+  responseRate: number | string;
+  errorMessage?: string;
+  semester: { id: string };
+  triggeredBy?: { id: string };
+  faculty?: { id: string };
+  department?: { id: string };
+  program?: { id: string };
+  campus?: { id: string };
+  course?: { id: string };
+  questionnaireVersion?: { id: string };
+}
+
+function buildPipeline(overrides: Partial<TestPipeline> = {}): TestPipeline {
+  return {
+    id: 'pipeline-1',
+    status: PipelineStatus.SENTIMENT_ANALYSIS,
+    trigger: PipelineTrigger.USER,
+    totalEnrolled: 1033,
+    submissionCount: 856,
+    commentCount: 849,
+    responseRate: '0.8287',
+    semester: { id: 'sem-1' },
+    triggeredBy: { id: 'user-1' },
+    campus: { id: 'campus-1' },
+    ...overrides,
+  };
+}
+
+type EmitMock = jest.Mock<Promise<void>, [EmitParams]>;
+
+interface OrchestratorInternals {
+  OnStageFailed(
+    pipelineId: string,
+    stage: string,
+    error: string,
+  ): Promise<void>;
+  emitPipelineFailAudit(
+    pipeline: AnalysisPipeline,
+    stage: string,
+    errorMessage: string,
+  ): void;
+  failPipeline(
+    em: { flush: () => Promise<void> },
+    pipeline: AnalysisPipeline,
+    error: string,
+  ): Promise<void>;
+}
+
+function makeService(overrides: {
+  findOne?: jest.Mock;
+  flush?: jest.Mock;
+  emit?: EmitMock;
+}): {
+  service: OrchestratorInternals;
+  emit: EmitMock;
+  flush: jest.Mock;
+  findOne: jest.Mock;
+} {
+  const findOne = overrides.findOne ?? jest.fn();
+  const flush = overrides.flush ?? jest.fn().mockResolvedValue(undefined);
+  const emit: EmitMock =
+    overrides.emit ?? (jest.fn().mockResolvedValue(undefined) as EmitMock);
+
+  const fork = { findOne, flush };
+  const em = { fork: () => fork };
+  const auditService = { Emit: emit };
+
+  const Ctor = PipelineOrchestratorService as unknown as new (
+    ...args: unknown[]
+  ) => object;
+  const instance = new Ctor(
+    em,
+    {},
+    {},
+    {},
+    {},
+    {},
+    {},
+    auditService,
+    {},
+    {},
+    {},
+    {},
+  );
+  const service = instance as unknown as OrchestratorInternals;
+
+  return { service, emit, flush, findOne };
+}
+
+function firstEmitCall(emit: EmitMock): EmitParams {
+  expect(emit).toHaveBeenCalledTimes(1);
+  return emit.mock.calls[0][0];
+}
+
+describe('PipelineOrchestratorService — pipeline failure audit', () => {
+  describe('OnStageFailed', () => {
+    it('emits ANALYSIS_PIPELINE_FAIL with stage + errorMessage + scope metadata', async () => {
+      const pipeline = buildPipeline();
+      const { service, emit, flush, findOne } = makeService({
+        findOne: jest.fn().mockResolvedValue(pipeline),
+      });
+
+      await service.OnStageFailed(
+        pipeline.id,
+        'sentiment_analysis',
+        'HTTP 413',
+      );
+
+      expect(flush).toHaveBeenCalledTimes(1);
+      expect(pipeline.status).toBe(PipelineStatus.FAILED);
+      expect(pipeline.errorMessage).toBe('sentiment_analysis: HTTP 413');
+      expect(findOne).toHaveBeenCalledWith(expect.anything(), pipeline.id);
+
+      const call = firstEmitCall(emit);
+      expect(call.action).toBe(AuditAction.ANALYSIS_PIPELINE_FAIL);
+      expect(call.actorId).toBe('user-1');
+      expect(call.resourceType).toBe('analysis_pipeline');
+      expect(call.resourceId).toBe('pipeline-1');
+      expect(call.metadata).toEqual({
+        stage: 'sentiment_analysis',
+        errorMessage: 'HTTP 413',
+        trigger: PipelineTrigger.USER,
+        totalEnrolled: 1033,
+        submissionCount: 856,
+        commentCount: 849,
+        responseRate: 0.8287,
+        semesterId: 'sem-1',
+        campusId: 'campus-1',
+      });
+    });
+
+    it('does not emit when pipeline is already in a terminal status', async () => {
+      const pipeline = buildPipeline({ status: PipelineStatus.COMPLETED });
+      const { service, emit, flush } = makeService({
+        findOne: jest.fn().mockResolvedValue(pipeline),
+      });
+
+      await service.OnStageFailed(pipeline.id, 'sentiment_analysis', 'late');
+
+      expect(flush).not.toHaveBeenCalled();
+      expect(emit).not.toHaveBeenCalled();
+    });
+
+    it('does not emit when pipeline is not found', async () => {
+      const { service, emit } = makeService({
+        findOne: jest.fn().mockResolvedValue(null),
+      });
+
+      await service.OnStageFailed('missing', 'sentiment_analysis', 'err');
+
+      expect(emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('emitPipelineFailAudit (private)', () => {
+    it('includes every populated scope relation id in metadata', () => {
+      const pipeline = buildPipeline({
+        faculty: { id: 'fac-1' },
+        department: { id: 'dept-1' },
+        program: { id: 'prog-1' },
+        campus: { id: 'campus-1' },
+        course: { id: 'course-1' },
+        questionnaireVersion: { id: 'qv-1' },
+      });
+      const { service, emit } = makeService({});
+
+      service.emitPipelineFailAudit(
+        pipeline as unknown as AnalysisPipeline,
+        'topic_modeling',
+        'boom',
+      );
+
+      const metadata = firstEmitCall(emit).metadata!;
+      expect(metadata.facultyId).toBe('fac-1');
+      expect(metadata.departmentId).toBe('dept-1');
+      expect(metadata.programId).toBe('prog-1');
+      expect(metadata.campusId).toBe('campus-1');
+      expect(metadata.courseId).toBe('course-1');
+      expect(metadata.questionnaireVersionId).toBe('qv-1');
+    });
+
+    it('omits scope keys that are not set on the pipeline', () => {
+      const pipeline = buildPipeline({
+        campus: undefined,
+        department: { id: 'dept-1' },
+      });
+      const { service, emit } = makeService({});
+
+      service.emitPipelineFailAudit(
+        pipeline as unknown as AnalysisPipeline,
+        'sentiment_analysis',
+        'err',
+      );
+
+      const metadata = firstEmitCall(emit).metadata!;
+      expect(metadata).not.toHaveProperty('campusId');
+      expect(metadata).not.toHaveProperty('facultyId');
+      expect(metadata.departmentId).toBe('dept-1');
+    });
+
+    it('omits actorId when triggeredBy is absent', () => {
+      const pipeline = buildPipeline({ triggeredBy: undefined });
+      const { service, emit } = makeService({});
+
+      service.emitPipelineFailAudit(
+        pipeline as unknown as AnalysisPipeline,
+        'sentiment_analysis',
+        'err',
+      );
+
+      expect(firstEmitCall(emit).actorId).toBeUndefined();
+    });
+  });
+
+  describe('failPipeline stage parsing (private)', () => {
+    it('extracts stage from "<stage>: <message>" prefix', async () => {
+      const pipeline = buildPipeline();
+      const { service, emit } = makeService({});
+
+      await service.failPipeline(
+        { flush: jest.fn().mockResolvedValue(undefined) },
+        pipeline as unknown as AnalysisPipeline,
+        'sentiment_analysis: worker dropped all results',
+      );
+
+      const metadata = firstEmitCall(emit).metadata!;
+      expect(metadata.stage).toBe('sentiment_analysis');
+      expect(metadata.errorMessage).toBe('worker dropped all results');
+    });
+
+    it('falls back to stage="unknown" when error lacks a stage prefix', async () => {
+      const pipeline = buildPipeline();
+      const { service, emit } = makeService({});
+
+      await service.failPipeline(
+        { flush: jest.fn().mockResolvedValue(undefined) },
+        pipeline as unknown as AnalysisPipeline,
+        'No submissions with cleaned comments found',
+      );
+
+      const metadata = firstEmitCall(emit).metadata!;
+      expect(metadata.stage).toBe('unknown');
+      expect(metadata.errorMessage).toBe(
+        'No submissions with cleaned comments found',
+      );
+    });
+  });
+});

--- a/src/modules/analysis/services/pipeline-orchestrator.service.ts
+++ b/src/modules/analysis/services/pipeline-orchestrator.service.ts
@@ -86,6 +86,8 @@ import { TopicLabelService } from './topic-label.service';
 import { AnalysisAccessService } from './analysis-access.service';
 import { ScopeResolverService } from 'src/modules/common/services/scope-resolver.service';
 import { CurrentUserService } from 'src/modules/common/cls/current-user.service';
+import { AuditService } from 'src/modules/audit/audit.service';
+import { AuditAction } from 'src/modules/audit/audit-action.enum';
 
 interface CoverageStats {
   totalEnrolled: number;
@@ -137,6 +139,7 @@ export class PipelineOrchestratorService {
     private readonly scopeResolver: ScopeResolverService,
     private readonly currentUserService: CurrentUserService,
     private readonly schedulerRegistry: SchedulerRegistry,
+    private readonly auditService: AuditService,
     @InjectQueue(QueueName.SENTIMENT) private readonly sentimentQueue: Queue,
     @InjectQueue(QueueName.TOPIC_MODEL) private readonly topicModelQueue: Queue,
     @InjectQueue(QueueName.RECOMMENDATIONS)
@@ -974,6 +977,8 @@ export class PipelineOrchestratorService {
     await fork.flush();
 
     this.logger.error(`Pipeline ${pipelineId} failed at ${stage}: ${error}`);
+
+    this.emitPipelineFailAudit(pipeline, stage, error);
   }
 
   // --- Scope Authorization (FAC-132, adapted for aggregate scope rework) ---
@@ -1906,6 +1911,47 @@ export class PipelineOrchestratorService {
     pipeline.errorMessage = error;
     await em.flush();
     this.logger.error(`Pipeline ${pipeline.id} failed: ${error}`);
+
+    // `failPipeline` carries a single error string without an explicit stage
+    // (unlike OnStageFailed). Parse a leading "<stage>: <message>" prefix when
+    // the caller followed that convention; otherwise flag the stage as unknown
+    // so audit analytics can still aggregate these rows.
+    const match = /^([a-z_]+):\s+(.*)$/s.exec(error);
+    const [stage, message] = match ? [match[1], match[2]] : ['unknown', error];
+    this.emitPipelineFailAudit(pipeline, stage, message);
+  }
+
+  private emitPipelineFailAudit(
+    pipeline: AnalysisPipeline,
+    stage: string,
+    errorMessage: string,
+  ): void {
+    const metadata: Record<string, unknown> = {
+      stage,
+      errorMessage,
+      trigger: pipeline.trigger,
+      totalEnrolled: pipeline.totalEnrolled,
+      submissionCount: pipeline.submissionCount,
+      commentCount: pipeline.commentCount,
+      responseRate: Number(pipeline.responseRate),
+      semesterId: pipeline.semester.id,
+    };
+    if (pipeline.faculty) metadata.facultyId = pipeline.faculty.id;
+    if (pipeline.department) metadata.departmentId = pipeline.department.id;
+    if (pipeline.program) metadata.programId = pipeline.program.id;
+    if (pipeline.campus) metadata.campusId = pipeline.campus.id;
+    if (pipeline.course) metadata.courseId = pipeline.course.id;
+    if (pipeline.questionnaireVersion) {
+      metadata.questionnaireVersionId = pipeline.questionnaireVersion.id;
+    }
+
+    void this.auditService.Emit({
+      action: AuditAction.ANALYSIS_PIPELINE_FAIL,
+      actorId: pipeline.triggeredBy?.id,
+      resourceType: 'analysis_pipeline',
+      resourceId: pipeline.id,
+      metadata,
+    });
   }
 
   private getEmbeddingStageStatus(

--- a/src/modules/audit/audit-action.enum.ts
+++ b/src/modules/audit/audit-action.enum.ts
@@ -13,6 +13,7 @@ export const AuditAction = {
   ANALYSIS_PIPELINE_CREATE: 'analysis.pipeline.create',
   ANALYSIS_PIPELINE_CONFIRM: 'analysis.pipeline.confirm',
   ANALYSIS_PIPELINE_CANCEL: 'analysis.pipeline.cancel',
+  ANALYSIS_PIPELINE_FAIL: 'analysis.pipeline.fail',
   MOODLE_PROVISION_CATEGORIES: 'moodle.provision.categories',
   MOODLE_PROVISION_COURSES: 'moodle.provision.courses',
   MOODLE_PROVISION_QUICK_COURSE: 'moodle.provision.quick-course',


### PR DESCRIPTION
## Summary

- Emit an `AuditLog` row every time an analysis pipeline transitions to `FAILED` so we have a durable, queryable trail instead of relying on the pipeline's `errorMessage` field and one-shot logger output
- New `AuditAction.ANALYSIS_PIPELINE_FAIL = 'analysis.pipeline.fail'`
- Shared `emitPipelineFailAudit()` helper wired into both `OnStageFailed` (inside the `TERMINAL_STATUSES` guard so race-y double-failures don't double-emit) and `failPipeline` (parses the `"<stage>: <message>"` prefix used by dispatch paths, falls back to `stage='unknown'`)

## Context

Triggered by pipeline `cb35d982-ba99-4d60-b1a8-83f121a2c808` (Campus: UCMN, 856 submissions / 849 comments) failing at the sentiment stage with `HTTP 413` from the worker. The 413 itself is fixed on the worker side — see companion PR https://github.com/CtrlAltElite-Devs/sentiment.worker.temp.faculytics/pull/3. This change ensures future failures of any kind leave an auditable record for monitoring and post-mortem analytics.

## Audit metadata shape

| Field | Source |
|-------|--------|
| `action` | `ANALYSIS_PIPELINE_FAIL` |
| `actorId` | `pipeline.triggeredBy.id` (nullable for scheduler-driven pipelines) |
| `resourceType` | `'analysis_pipeline'` |
| `resourceId` | `pipeline.id` |
| `metadata.stage` | stage name (`sentiment_analysis`, `topic_modeling`, etc.) |
| `metadata.errorMessage` | raw error string |
| `metadata.trigger` | `USER` or `SCHEDULER` |
| `metadata.totalEnrolled` / `submissionCount` / `commentCount` / `responseRate` | coverage snapshot |
| `metadata.semesterId` | always set |
| `metadata.{faculty,department,program,campus,course,questionnaireVersion}Id` | whichever scope relations are populated on the pipeline |

## Out of scope

- `errorClass` taxonomy for GROUP-BY analytics (worker_http_4xx, validation, etc.) — deferred until vanilla emit is live and we see which buckets matter
- Client-side chunking of dispatch payloads — deferred until a real batch exceeds the worker's new 50MB ceiling
- `retryable` field in the audit row (tautology at emit time since status is always `FAILED`)

## Test plan

- [x] `npm run test -- --testPathPatterns=pipeline-orchestrator.audit` — 8 new focused tests pass
- [x] `npm run test -- --testPathPatterns=analysis` — full analysis suite (132 tests) still green
- [x] `npx tsc --noEmit` + `npm run lint` — clean on all changed files
- [ ] Post-merge: trigger a pipeline failure locally (mock-worker returning failure) and confirm an `audit_log` row lands with the right shape

Closes #357