### PR TITLE
[STAGING] FAC 135.5 feat: expose per-dimension averages, rating distributions, and section response counts on faculty report (#363)

### DIFF
--- a/src/modules/analytics/analytics.service.spec.ts
+++ b/src/modules/analytics/analytics.service.spec.ts
@@ -642,11 +642,13 @@ describe('AnalyticsService', () => {
       schema: QuestionnaireSchemaSnapshot,
       aggRows: Record<string, unknown>[],
       countResult: number,
+      ratingRows: Record<string, unknown>[] = [],
+      dimensionRows: Record<string, unknown>[] = [],
     ) {
       // Super admin: scope returns null (no validateFacultyScope execute call)
       // 1. resolveVersionIds: phase 1 (type check), phase 2 (versions)
       // 2. BuildFacultyReportData: faculty metadata + semester metadata (parallel)
-      // 3. aggregation + submission count (parallel)
+      // 3. agg + ratingDist + count + dimensionRegistry (parallel)
       mockExecute
         // phase 1: type check
         .mockResolvedValueOnce([{ id: 'type-1', name: 'Student Evaluation' }])
@@ -671,8 +673,12 @@ describe('AnalyticsService', () => {
         ])
         // aggregation query
         .mockResolvedValueOnce(aggRows)
+        // rating distribution query
+        .mockResolvedValueOnce(ratingRows)
         // submission count
-        .mockResolvedValueOnce([{ count: countResult }]);
+        .mockResolvedValueOnce([{ count: countResult }])
+        // dimension registry
+        .mockResolvedValueOnce(dimensionRows);
     }
 
     it('should return full report for super admin', async () => {

--- a/src/modules/analytics/analytics.service.ts
+++ b/src/modules/analytics/analytics.service.ts
@@ -1086,6 +1086,7 @@ export class AnalyticsService {
         sections: [],
         overallRating: null,
         overallInterpretation: null,
+        dimensions: [],
       };
     }
 
@@ -1119,6 +1120,20 @@ export class AnalyticsService {
       GROUP BY qa.question_id, qa.section_id
     `;
 
+    const ratingDistSql = `
+      SELECT qa.question_id, qa.section_id,
+             qa.numeric_value AS rating,
+             COUNT(*) AS cnt
+      FROM questionnaire_answer qa
+      JOIN questionnaire_submission qs ON qs.id = qa.submission_id
+      WHERE qs.faculty_id = ?
+        AND qs.semester_id = ?
+        AND qs.questionnaire_version_id = ANY(?)
+        AND qs.deleted_at IS NULL
+        AND qa.deleted_at IS NULL${courseFilter}
+      GROUP BY qa.question_id, qa.section_id, qa.numeric_value
+    `;
+
     const countSql = `
       SELECT COUNT(DISTINCT qs.id) AS count
       FROM questionnaire_submission qs
@@ -1128,9 +1143,21 @@ export class AnalyticsService {
         AND qs.deleted_at IS NULL${courseFilter}
     `;
 
-    const [aggRows, countRows] = await Promise.all([
+    const dimensionRegistrySql = `
+      SELECT d.code, d.display_name
+      FROM dimension d
+      JOIN questionnaire_type qt ON qt.id = d.questionnaire_type_id
+      WHERE qt.code = ?
+        AND d.active = true
+        AND d.deleted_at IS NULL
+        AND qt.deleted_at IS NULL
+    `;
+
+    const [aggRows, ratingRows, countRows, dimensionRows] = await Promise.all([
       this.em.execute(aggSql, aggParams),
+      this.em.execute(ratingDistSql, aggParams),
       this.em.execute(countSql, aggParams),
+      this.em.execute(dimensionRegistrySql, [query.questionnaireTypeCode]),
     ]);
 
     const submissionCount = Number(countRows[0]?.count ?? 0);
@@ -1145,6 +1172,26 @@ export class AnalyticsService {
         average: Number(row.average),
         responseCount: Number(row.response_count),
       });
+    }
+
+    // Build rating distribution lookup: key = "questionId::sectionId" →
+    // ratingCounts keyed by the stringified numeric_value ("0"/"1" for
+    // YES_NO, "1".."5" for Likert).
+    const ratingCountsMap = new Map<string, Record<string, number>>();
+    for (const row of ratingRows) {
+      const key = `${row.question_id}::${row.section_id}`;
+      const ratingKey = String(Number(row.rating));
+      const existing = ratingCountsMap.get(key) ?? {};
+      existing[ratingKey] = (existing[ratingKey] ?? 0) + Number(row.cnt);
+      ratingCountsMap.set(key, existing);
+    }
+
+    const dimensionDisplayNames = new Map<string, string>();
+    for (const row of dimensionRows as {
+      code: string;
+      display_name: string;
+    }[]) {
+      dimensionDisplayNames.set(row.code, row.display_name);
     }
 
     // Assemble sections
@@ -1169,6 +1216,8 @@ export class AnalyticsService {
               average: score.average,
               responseCount: score.responseCount,
               interpretation: getInterpretation(score.average),
+              ratingCounts:
+                ratingCountsMap.get(`${questionId}::${sectionId}`) ?? {},
             };
           })
           .filter((q): q is NonNullable<typeof q> => q !== null);
@@ -1182,6 +1231,11 @@ export class AnalyticsService {
               100,
           ) / 100;
 
+        const responseCount = questions.reduce(
+          (sum, q) => sum + q.responseCount,
+          0,
+        );
+
         return {
           sectionId,
           title: meta.title,
@@ -1190,9 +1244,46 @@ export class AnalyticsService {
           questions,
           sectionAverage,
           sectionInterpretation: getInterpretation(sectionAverage),
+          responseCount,
         };
       })
       .filter((s): s is NonNullable<typeof s> => s !== null);
+
+    // Per-dimension aggregation: response-count-weighted mean of per-question
+    // averages, which is mathematically identical to AVG(numeric_value) over
+    // all answers in the dimension. Skip dimensions with 0 responses.
+    const dimensionAggregate = new Map<
+      string,
+      { weightedSum: number; responseCount: number }
+    >();
+    for (const row of aggRows) {
+      const qm = questionMap.get(row.question_id as string);
+      if (!qm || !qm.dimensionCode) continue;
+      const avg = Number(row.average);
+      const count = Number(row.response_count);
+      if (!Number.isFinite(avg) || count <= 0) continue;
+      const existing = dimensionAggregate.get(qm.dimensionCode) ?? {
+        weightedSum: 0,
+        responseCount: 0,
+      };
+      existing.weightedSum += avg * count;
+      existing.responseCount += count;
+      dimensionAggregate.set(qm.dimensionCode, existing);
+    }
+
+    const dimensions = [...dimensionAggregate.entries()]
+      .map(([code, { weightedSum, responseCount }]) => {
+        const average =
+          Math.round((weightedSum / responseCount) * 100) / 100;
+        return {
+          code,
+          displayName: dimensionDisplayNames.get(code) ?? code,
+          average,
+          responseCount,
+          interpretation: getInterpretation(average),
+        };
+      })
+      .sort((a, b) => a.displayName.localeCompare(b.displayName));
 
     // Overall weighted rating
     let overallRating: number | null = null;
@@ -1243,6 +1334,7 @@ export class AnalyticsService {
       sections,
       overallRating,
       overallInterpretation,
+      dimensions,
     };
   }
 

--- a/src/modules/analytics/dto/responses/faculty-report.response.dto.ts
+++ b/src/modules/analytics/dto/responses/faculty-report.response.dto.ts
@@ -59,6 +59,14 @@ export class ReportQuestionDto {
 
   @ApiProperty()
   interpretation!: string;
+
+  @ApiProperty({
+    type: 'object',
+    additionalProperties: { type: 'number' },
+    description:
+      'Counts of responses keyed by numeric value (e.g. "1"..."5" for Likert-5, "0"/"1" for YES_NO).',
+  })
+  ratingCounts!: Record<string, number>;
 }
 
 export class ReportSectionDto {
@@ -82,6 +90,26 @@ export class ReportSectionDto {
 
   @ApiProperty()
   sectionInterpretation!: string;
+
+  @ApiProperty({ description: 'Total answered responses across the section.' })
+  responseCount!: number;
+}
+
+export class ReportDimensionDto {
+  @ApiProperty()
+  code!: string;
+
+  @ApiProperty()
+  displayName!: string;
+
+  @ApiProperty()
+  average!: number;
+
+  @ApiProperty()
+  responseCount!: number;
+
+  @ApiProperty()
+  interpretation!: string;
 }
 
 export class FacultyReportResponseDto {
@@ -108,4 +136,7 @@ export class FacultyReportResponseDto {
 
   @ApiPropertyOptional({ type: String, nullable: true })
   overallInterpretation!: string | null;
+
+  @ApiProperty({ type: [ReportDimensionDto] })
+  dimensions!: ReportDimensionDto[];
 }


### PR DESCRIPTION
Adds three quantitative fields to GET /analytics/faculty/:id/report to power new charts on the Faculty Analysis Scores tab:

- `dimensions[]` - response-count-weighted averages grouped by the schema's `dimensionCode`, resolved against the Dimension registry for display names. Enables a competency radar chart on the client.
- `sections[].questions[].ratingCounts` - counts of responses per raw numeric value ("1".."5" for Likert-5, "0"/"1" for YES_NO). Enables stacked rating-distribution bars per section.
- `sections[].responseCount` - total answered responses in the section, summed from its questions. Used for scatter-chart bubble sizing.

Aggregation piggybacks on the existing faculty-report query: one extra GROUP BY on `(question_id, section_id, numeric_value)` for distribution, one lookup against the Dimension registry for display names, and the rest computed in-memory from the existing `aggRows`. Tests updated to mock the two new parallel queries.