### PR TITLE
chore(docs): sync docs/CLAUDE.md/README for FAC-134 + FAC-135.x

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ npx mikro-orm migration:list     # Check migration status
 The app uses a split between **Infrastructure** and **Application** modules (`src/modules/index.module.ts`):
 
 - **InfrastructureModules**: ConfigModule, PassportModule, MikroOrmModule, JwtModule, ScheduleModule, BullModule, TerminusModule
-- **ApplicationModules**: HealthModule, MoodleModule, AuthModule, ChatKitModule, EnrollmentsModule, QuestionnaireModule, AnalysisModule
+- **ApplicationModules**: HealthModule, MoodleModule, AuthModule, ChatKitModule, EnrollmentsModule, QuestionnaireModule, AnalysisModule, AnalyticsModule, AuditModule, FacultyModule, CurriculumModule, DimensionsModule, AdminModule, ReportsModule
 
 ### Key Patterns
 
@@ -73,6 +73,8 @@ The app uses a split between **Infrastructure** and **Application** modules (`sr
 - Jobs register results in `StartupJobRegistry` for boot summary
 - **Active jobs:**
   - `RefreshTokenCleanupJob`: Purges expired refresh tokens every 12 hours (7-day retention)
+  - `TieredPipelineSchedulerJob`: Auto-enqueues analysis pipelines for active scopes with new submissions. Three independent `@Cron` methods (FACULTY Sun 01:00 UTC, DEPARTMENT Sun 02:00, CAMPUS Sun 03:00) with per-tier `isRunning` guards. Skips scopes with no new submissions since their last completed pipeline. Pipelines created this way are tagged `trigger=SCHEDULER` and attributed to the seeded SUPER_ADMIN.
+  - `ReportCleanupJob`: Daily at 03:00 — purges expired report jobs and R2 objects.
 
 **Moodle Sync Scheduling** (`src/modules/moodle/schedulers/`):
 
@@ -86,9 +88,11 @@ The app uses a split between **Infrastructure** and **Application** modules (`sr
 
 BullMQ on Redis provides async job processing for AI analysis tasks:
 
-- **Queue-per-type pattern**: Each analysis type (sentiment, topic model, embeddings) gets its own BullMQ queue and processor
+- **Queue-per-type pattern**: Each analysis type (sentiment, topic model, embeddings, recommendations) gets its own BullMQ queue and processor
 - **Entry points**: `AnalysisService.EnqueueJob()` and `EnqueueBatch()` — other modules use these to dispatch analysis jobs
 - **BaseAnalysisProcessor**: Abstract base class handling HTTP dispatch to external workers, Zod validation of responses, retry/error handling, and observability events
+- **Sentiment chunking**: `PipelineOrchestratorService.dispatchSentiment()` splits a run into N chunks of `SENTIMENT_CHUNK_SIZE` (default 50) and enqueues one job per chunk. `SentimentRun.expectedChunks/completedChunks` counters track completion atomically with row inserts; the last chunk advances the pipeline.
+- **vLLM-primary dispatch**: When the `SENTIMENT_VLLM_CONFIG` system-config row is enabled, the orchestrator snapshots it once per dispatch and attaches `vllmConfig` to every chunk envelope. Admin endpoint `GET/PUT /admin/sentiment/vllm-config` (SUPER_ADMIN) manages it; production enable is gated by `ALLOW_SENTIMENT_VLLM_ENABLED_IN_PROD=true`.
 - **Mock worker**: `mock-worker/` directory contains a Hono HTTP server mimicking worker responses for local dev
 - **Local dev**: `docker compose up` starts Redis and mock worker
 
@@ -172,4 +176,6 @@ Optional:
 - `BULLMQ_HTTP_TIMEOUT_MS`: HTTP request timeout in ms (default: `90000`)
 - `BULLMQ_SENTIMENT_CONCURRENCY`: Sentiment processor concurrency (default: `3`)
 - `SENTIMENT_WORKER_URL`: RunPod/mock worker URL for sentiment analysis
+- `SENTIMENT_CHUNK_SIZE`: Submissions per sentiment chunk dispatched to the worker (default: `50`)
+- `ALLOW_SENTIMENT_VLLM_ENABLED_IN_PROD`: Production safety gate — required to enable vLLM dispatch when `NODE_ENV=production` (default: `false`)
 - `MOODLE_SYNC_INTERVAL_MINUTES`: Sync schedule interval in minutes (min `30`; defaults per env: dev=60, staging=360, prod=180)

--- a/README.md
+++ b/README.md
@@ -50,18 +50,21 @@ cp .env.sample .env
 
 **Optional Variables:**
 
-| Variable                           | Default       | Description                                         |
-| ---------------------------------- | ------------- | --------------------------------------------------- |
-| `PORT`                             | `5200`        | Server port                                         |
-| `NODE_ENV`                         | `development` | `development` \| `production` \| `test`             |
-| `OPENAPI_MODE`                     | `false`       | Set to `"true"` to enable Swagger docs              |
-| `SUPER_ADMIN_USERNAME`             | `superadmin`  | Default super admin username                        |
-| `SUPER_ADMIN_PASSWORD`             | `password123` | Default super admin password                        |
-| `SYNC_ON_STARTUP`                  | `false`       | Run course and enrollment sync on startup           |
-| `DISABLE_SYNC_CATEGORY_ON_STARTUP` | `false`       | Skip category sync on startup (faster dev restarts) |
-| `MOODLE_SYNC_CONCURRENCY`          | `3`           | Max concurrent Moodle HTTP calls during sync (1-20) |
+| Variable                               | Default       | Description                                                                                |
+| -------------------------------------- | ------------- | ------------------------------------------------------------------------------------------ |
+| `PORT`                                 | `5200`        | Server port                                                                                |
+| `NODE_ENV`                             | `development` | `development` \| `production` \| `test`                                                    |
+| `OPENAPI_MODE`                         | `false`       | Set to `"true"` to enable Swagger docs                                                     |
+| `SUPER_ADMIN_USERNAME`                 | `superadmin`  | Default super admin username (also used by the tiered scheduler for system attribution)    |
+| `SUPER_ADMIN_PASSWORD`                 | `password123` | Default super admin password                                                               |
+| `SYNC_ON_STARTUP`                      | `false`       | Run course and enrollment sync on startup                                                  |
+| `DISABLE_SYNC_CATEGORY_ON_STARTUP`     | `false`       | Skip category sync on startup (faster dev restarts)                                        |
+| `MOODLE_SYNC_CONCURRENCY`              | `3`           | Max concurrent Moodle HTTP calls during sync (1-20)                                        |
+| `SENTIMENT_WORKER_URL`                 | —             | RunPod/mock worker URL for sentiment analysis                                              |
+| `SENTIMENT_CHUNK_SIZE`                 | `50`          | Submissions per sentiment chunk dispatched to the worker                                   |
+| `ALLOW_SENTIMENT_VLLM_ENABLED_IN_PROD` | `false`       | Production safety gate — must be `true` to enable vLLM dispatch when `NODE_ENV=production` |
 
-See `.env.sample` for the full list including BullMQ and analysis worker options.
+See `.env.sample` for the full list including BullMQ, embeddings, topic-model, and recommendation worker options.
 
 ### 3. Database Initialization
 

--- a/docs/architecture/ai-inference-pipeline.md
+++ b/docs/architecture/ai-inference-pipeline.md
@@ -163,24 +163,26 @@ Single Redis instance for development/staging. In production, split into two:
 
 ## 7. Environment Variables
 
-| Variable                             | Default       | Description                                     |
-| ------------------------------------ | ------------- | ----------------------------------------------- |
-| `SENTIMENT_WORKER_URL`               | —             | RunPod/mock URL for sentiment analysis          |
-| `EMBEDDINGS_WORKER_URL`              | —             | URL for embedding generation                    |
-| `TOPIC_MODEL_WORKER_URL`             | —             | URL for topic modeling                          |
-| `RECOMMENDATIONS_WORKER_URL`         | —             | Deprecated — recommendations now use direct LLM |
-| `RECOMMENDATIONS_MODEL`              | `gpt-4o-mini` | OpenAI model for recommendation generation      |
-| `BULLMQ_SENTIMENT_CONCURRENCY`       | 3             | Sentiment processor concurrency                 |
-| `EMBEDDINGS_CONCURRENCY`             | 3             | Embedding processor concurrency                 |
-| `TOPIC_MODEL_CONCURRENCY`            | 1             | Topic model processor concurrency               |
-| `RECOMMENDATIONS_CONCURRENCY`        | 1             | Recommendations processor concurrency           |
-| `BULLMQ_DEFAULT_ATTEMPTS`            | 3             | Job retry attempts                              |
-| `BULLMQ_DEFAULT_BACKOFF_MS`          | 5000          | Initial backoff delay                           |
-| `BULLMQ_HTTP_TIMEOUT_MS`             | 90000         | HTTP request timeout (default)                  |
-| `BULLMQ_TOPIC_MODEL_HTTP_TIMEOUT_MS` | 300000        | Topic model HTTP timeout (5 min)                |
-| `BULLMQ_STALLED_INTERVAL_MS`         | 30000         | Stall detection interval                        |
-| `BULLMQ_MAX_STALLED_COUNT`           | 2             | Max stalled retries before failure              |
-| `RUNPOD_API_KEY`                     | —             | RunPod API key for serverless workers           |
+| Variable                               | Default       | Description                                                                 |
+| -------------------------------------- | ------------- | --------------------------------------------------------------------------- |
+| `SENTIMENT_WORKER_URL`                 | —             | RunPod/mock URL for sentiment analysis                                      |
+| `SENTIMENT_CHUNK_SIZE`                 | 50            | Submissions per sentiment chunk (see §14)                                   |
+| `ALLOW_SENTIMENT_VLLM_ENABLED_IN_PROD` | `false`       | Production safety gate — required to enable vLLM dispatch in prod (see §15) |
+| `EMBEDDINGS_WORKER_URL`                | —             | URL for embedding generation                                                |
+| `TOPIC_MODEL_WORKER_URL`               | —             | URL for topic modeling                                                      |
+| `RECOMMENDATIONS_WORKER_URL`           | —             | Deprecated — recommendations now use direct LLM                             |
+| `RECOMMENDATIONS_MODEL`                | `gpt-4o-mini` | OpenAI model for recommendation generation                                  |
+| `BULLMQ_SENTIMENT_CONCURRENCY`         | 3             | Sentiment processor concurrency                                             |
+| `EMBEDDINGS_CONCURRENCY`               | 3             | Embedding processor concurrency                                             |
+| `TOPIC_MODEL_CONCURRENCY`              | 1             | Topic model processor concurrency                                           |
+| `RECOMMENDATIONS_CONCURRENCY`          | 1             | Recommendations processor concurrency                                       |
+| `BULLMQ_DEFAULT_ATTEMPTS`              | 3             | Job retry attempts                                                          |
+| `BULLMQ_DEFAULT_BACKOFF_MS`            | 5000          | Initial backoff delay                                                       |
+| `BULLMQ_HTTP_TIMEOUT_MS`               | 90000         | HTTP request timeout (default)                                              |
+| `BULLMQ_TOPIC_MODEL_HTTP_TIMEOUT_MS`   | 300000        | Topic model HTTP timeout (5 min)                                            |
+| `BULLMQ_STALLED_INTERVAL_MS`           | 30000         | Stall detection interval                                                    |
+| `BULLMQ_MAX_STALLED_COUNT`             | 2             | Max stalled retries before failure                                          |
+| `RUNPOD_API_KEY`                       | —             | RunPod API key for serverless workers                                       |
 
 ## 8. Vector Storage
 
@@ -327,7 +329,59 @@ Actions follow the `RecommendedActionItem` schema:
 | `RECOMMENDATIONS_MODEL` | `gpt-4o-mini` | OpenAI model for generation    |
 | `OPENAI_API_KEY`        | —             | Required (shared with ChatKit) |
 
-## 13. Adding a New Analysis Type
+## 13. Chunked Sentiment Dispatch
+
+`PipelineOrchestratorService.dispatchSentiment()` splits in-scope submissions into N chunks of `SENTIMENT_CHUNK_SIZE` (default `50`) using `chunkSubmissionsForSentiment()` and enqueues one BullMQ job per chunk. Each chunk receives the same `BatchAnalysisJobMessage` envelope plus optional `metadata.chunkIndex` (0-based) and `metadata.chunkCount` (total chunks for the run). The envelope schema is `.strict()` — any drift fails validation at dispatch.
+
+`SentimentRun` carries `expectedChunks` and `completedChunks` integer counters. Each chunk's `Persist()` runs in a single transaction:
+
+1. Insert `SentimentResult` rows for the chunk's submissions.
+2. `UPDATE sentiment_run SET completed_chunks = completed_chunks + 1`.
+3. Read `(completedChunks, expectedChunks)`. When saturated, mark the run `COMPLETED` and call `OnSentimentComplete()`.
+
+The transactional context is passed via `tx.getTransactionContext()` so the row inserts and the counter bump commit atomically — partial chunk failures retry per-chunk without rolling back peers.
+
+If a chunk's BullMQ ack fails after commit, the retry hits the run's full unique index on `(run_id, submission_id)` (converted from a partial index in migration `20260417120000_sentiment-chunk-counters.ts`) and is treated as `duplicate-swallowed`. The processor re-reads the counter and re-fires `OnSentimentComplete()` only when the run is genuinely saturated, so completion is at-least-once but the downstream effect is idempotent.
+
+For workflow detail and job log fields, see [Analysis Job Processing — Chunked Sentiment Dispatch](../workflows/analysis-job-processing.md#chunked-sentiment-dispatch).
+
+## 14. vLLM-Primary Sentiment Dispatch
+
+The sentiment worker can route requests through a self-hosted vLLM model (primary) with the existing OpenAI path as fallback. The choice is runtime-configurable via a single `SystemConfig` row keyed `SENTIMENT_VLLM_CONFIG`:
+
+```typescript
+{
+  url: string;
+  model: string;
+  enabled: boolean;
+}
+```
+
+### Snapshot-once dispatch
+
+`PipelineOrchestratorService.dispatchSentiment()` calls `SentimentConfigService.readConfig()` **once** per run, then attaches the resolved config to every chunk envelope as the optional `vllmConfig` field — but only when `enabled === true && url !== ''`. Reading once per dispatch (rather than per chunk) prevents a config flip mid-run from straddling the two paths and producing inconsistent `servedBy` provenance across the chunks of a single run.
+
+The optional `servedBy: 'vllm' | 'openai'` field on each result item lets the worker tell the API which path actually served the request. The processor stores this in `SentimentResult.rawResult` JSONB for provenance — no schema change to the result table.
+
+### Admin config endpoint
+
+`AdminSentimentConfigController` (`/admin/sentiment/vllm-config`, SUPER_ADMIN only) exposes `GET` and `PUT`:
+
+| Method | Path                           | Body                                 | Behavior                                                                   |
+| ------ | ------------------------------ | ------------------------------------ | -------------------------------------------------------------------------- |
+| GET    | `/admin/sentiment/vllm-config` | —                                    | Returns the current `{url, model, enabled}` (or defaults if unset)         |
+| PUT    | `/admin/sentiment/vllm-config` | `{url?, model?, enabled?}` (partial) | Patches the row, validates, returns the post-write `{url, model, enabled}` |
+
+Validation rules enforced by `SentimentConfigService.updateConfig()`:
+
+- `url` must start with `https://` (SSRF mitigation against compromised admin sessions). Non-https values reject with 400 at the DTO layer.
+- `enabled = true` with empty `url` or empty `model` rejects with 400.
+
+The controller adds a production gate: when `NODE_ENV === 'production'` and `ALLOW_SENTIMENT_VLLM_ENABLED_IN_PROD !== true`, a `PUT` with `enabled: true` returns 400. Operators must set the env var explicitly to flip vLLM on in production.
+
+`updateConfig()` returns `{previous, next}` from a single read, and the controller emits `admin.sentiment-vllm-config.update` with both sides as audit metadata. This avoids a TOCTOU window between a separate read and the write. See [Audit Trail — admin.sentiment-vllm-config.update](./audit-trail.md#adminsentiment-vllm-configupdate).
+
+## 15. Adding a New Analysis Type
 
 1. Create `NewTypeProcessor extends BaseBatchProcessor` (or `RunPodBatchProcessor` for RunPod workers) in `src/modules/analysis/processors/`
 2. Add `NEW_TYPE_WORKER_URL` and `NEW_TYPE_CONCURRENCY` to `src/configurations/env/bullmq.env.ts`

--- a/docs/architecture/analytics.md
+++ b/docs/architecture/analytics.md
@@ -130,3 +130,74 @@ When callers pass `programCode` on `overview` or `attention`, the service valida
 The silent short-circuit avoids leaking existence information (a 403 tells the caller "that program exists but you can't see it"; an empty result does not). Chairpersons already cannot enumerate programs outside their scope via `/curriculum/programs` — that endpoint applies the same `ResolveProgramIds` filter.
 
 `GetAttentionList` adds `AND program_code_snapshot = ?` to the `mv_faculty_semester_stats` source of the consistency-gap and skipped-signals subqueries. The trend-based signal joins `mv_faculty_trends` against `mv_faculty_semester_stats` on `(faculty_id, department_code_snapshot)` so trend rows can be filtered by the per-semester program snapshot — trend rows are not scoped to a single program by themselves.
+
+## Faculty Report Endpoints
+
+A separate set of endpoints serves the per-faculty evaluation report — they read live submission/answer data rather than the materialized views and are the only analytics endpoints that allow the FACULTY role.
+
+| Method | Path                                                | Required query                                                                                         | Description                                                          |
+| ------ | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| GET    | `/analytics/faculty/:facultyId/report`              | `semesterId`, `questionnaireTypeCode` (+ optional `courseId`)                                          | Per-section/question averages, dimension averages, overall rating    |
+| GET    | `/analytics/faculty/:facultyId/report/comments`     | `semesterId`, `questionnaireTypeCode` (+ optional `courseId`, `page`, `limit`, `sentiment`, `themeId`) | Paginated qualitative comments with sentiment and theme annotations  |
+| GET    | `/analytics/faculty/:facultyId/qualitative-summary` | `semesterId`, `questionnaireTypeCode` (+ optional `courseId`)                                          | Aggregated sentiment distribution + ranked themes with sample quotes |
+| GET    | `/analytics/faculty/:facultyId/questionnaire-types` | `semesterId`                                                                                           | Questionnaire types that have submissions for this faculty/semester  |
+
+### Faculty Self-View Authorization
+
+Class-level `@UseJwtGuard(DEAN, CHAIRPERSON, CAMPUS_HEAD, SUPER_ADMIN)` restricts the controller, but each faculty endpoint widens with a method-level `@UseJwtGuard(... , FACULTY)` and then calls `assertFacultySelfScope(currentUser, facultyId)`. FACULTY may only request their own `facultyId` — any other id throws `ForbiddenException`. Non-FACULTY roles are unaffected by the helper.
+
+### Quantitative Distributions
+
+`GET /analytics/faculty/:facultyId/report` returns three quantitative shapes computed in-memory from a single per-question aggregation query:
+
+- `sections[].questions[].ratingCounts: Record<string, number>` — counts keyed by raw numeric value (`"1".."5"` for Likert-5, `"0"/"1"` for YES_NO). Bucketed by raw value, not by interpretation label.
+- `sections[].responseCount` — total answered responses summed across the section's questions.
+- `dimensions[]: { code, displayName, average, responseCount, interpretation }` — response-count-weighted averages grouped by the schema's `dimensionCode`. Display names resolve against the `Dimension` registry.
+
+Dimension display names come from the registry rather than the schema so that a future questionnaire revision keeps the same dimension labels (and the registry is the canonical source for dimension copy).
+
+### Qualitative Summary
+
+`GET /analytics/faculty/:facultyId/qualitative-summary` returns:
+
+```typescript
+{
+  sentimentDistribution: {
+    positive: number;
+    neutral: number;
+    negative: number;
+  }
+  themes: Array<{
+    themeId: string;
+    label: string;
+    count: number;
+    sentimentSplit: { positive; neutral; negative };
+    sampleQuotes?: string[]; // up to 3, PII-scrubbed, length-capped
+  }>;
+}
+```
+
+Sample quotes are truncated to ~280 characters and run through name redaction before being returned. Themes are ranked by `count` desc.
+
+### Comments Filtering
+
+`GET /analytics/faculty/:facultyId/report/comments` accepts optional `sentiment` (`positive | neutral | negative`) and `themeId` filters. Each row in the response is annotated with its `sentiment` label and `themeIds[]`. The `themeId` filter matches on the comment's **dominant** theme assignment.
+
+## Voice Breakdown & Facet Tagging
+
+When a pipeline aggregates multiple questionnaire types into one analysis (DEPARTMENT or CAMPUS scope), each `RecommendedAction` is tagged with a `facet` to help readers attribute the recommendation back to a primary questionnaire dimension.
+
+| Questionnaire code         | Facet             |
+| -------------------------- | ----------------- |
+| `FACULTY_FEEDBACK`         | `facultyFeedback` |
+| `FACULTY_IN_CLASSROOM`     | `inClassroom`     |
+| `FACULTY_OUT_OF_CLASSROOM` | `outOfClassroom`  |
+| anything else / mixed      | `overall`         |
+
+`RecommendationGenerationService.deriveFacetFromTypeCodeCounts()` counts how many of an action's contributing submissions came from each primary questionnaire-type code. The top code is assigned only when its share is `≥ FACET_DOMINANCE_THRESHOLD` (currently `0.6`); below that, the action falls back to `overall`. The threshold is intentionally a code constant (no env flag) — tuning it is a code-review decision because it changes evidence semantics.
+
+Pipeline status responses also surface a per-facet `voiceBreakdown` (counts of contributing submissions per questionnaire code) so the frontend can render attribution alongside the action list.
+
+### Faculty Self-View Redaction
+
+`AnalysisAccessService.RedactIfFacultySelfView()` strips `sampleQuotes[]` from every `TopicSource` in `recommendations.actions[].supportingEvidence.sources` when the requester is a FACULTY user reading their **own** pipeline. Non-faculty roles see the full payload; ownership is determined by `pipeline.faculty.id === requester.id`. Adding any new endpoint that returns verbatim student text must call this helper or implement equivalent redaction.

--- a/docs/architecture/audit-trail.md
+++ b/docs/architecture/audit-trail.md
@@ -59,12 +59,16 @@ export const AuditAction = {
   AUTH_TOKEN_REFRESH: 'auth.token.refresh',
   ADMIN_SYNC_TRIGGER: 'admin.sync.trigger',
   ADMIN_SYNC_SCHEDULE_UPDATE: 'admin.sync-schedule.update',
+  ADMIN_SENTIMENT_VLLM_CONFIG_UPDATE: 'admin.sentiment-vllm-config.update',
+  ADMIN_USER_SCOPE_UPDATE: 'admin.user.scope.update',
+  ADMIN_USER_CREATE: 'admin.user.create',
   QUESTIONNAIRE_SUBMIT: 'questionnaire.submit',
   QUESTIONNAIRE_INGEST: 'questionnaire.ingest',
   QUESTIONNAIRE_SUBMISSIONS_WIPE: 'questionnaire.submissions.wipe',
   ANALYSIS_PIPELINE_CREATE: 'analysis.pipeline.create',
   ANALYSIS_PIPELINE_CONFIRM: 'analysis.pipeline.confirm',
   ANALYSIS_PIPELINE_CANCEL: 'analysis.pipeline.cancel',
+  ANALYSIS_PIPELINE_FAIL: 'analysis.pipeline.fail',
   MOODLE_PROVISION_CATEGORIES: 'moodle.provision.categories',
   MOODLE_PROVISION_COURSES: 'moodle.provision.courses',
   MOODLE_PROVISION_QUICK_COURSE: 'moodle.provision.quick-course',
@@ -74,6 +78,42 @@ export const AuditAction = {
 ```
 
 The `moodle.provision.*` actions are emitted by the Moodle seeding toolkit — see [Moodle Provisioning](../moodle/provisioning.md).
+
+### `analysis.pipeline.fail`
+
+Emitted directly from `PipelineOrchestratorService` (no `@Audited` decorator) on every terminal failure transition. Both `OnStageFailed()` and `failPipeline()` route through `emitPipelineFailAudit()`, which is guarded by `TERMINAL_STATUSES` so a race between the two paths cannot double-audit. The metadata payload captures operational context for post-mortem:
+
+| Field          | Description                                                                                                                       |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `stage`        | Failing stage (`sentiment_analysis`, `topic_modeling`, `recommendations`, etc.)                                                   |
+| `errorMessage` | Sanitized error string. `failPipeline()` parses the `"<stage>: <message>"` prefix when set.                                       |
+| `trigger`      | `USER` or `SCHEDULER` — same value as `AnalysisPipeline.trigger`                                                                  |
+| `coverage`     | `{ totalEnrolled, submissionCount, commentCount, responseRate }` snapshot at failure time                                         |
+| `semesterId`   | UUID                                                                                                                              |
+| `scope`        | FK ids snapshotted from the pipeline (`facultyId`, `departmentId`, `programId`, `campusId`, `courseId`, `questionnaireVersionId`) |
+
+`actorId` is `pipeline.triggeredBy.id`; `resourceType = 'analysis_pipeline'`; `resourceId = pipeline.id`. Failures from scheduler-driven pipelines surface as `actorId = SUPER_ADMIN.id` with `metadata.trigger = 'SCHEDULER'`.
+
+### `admin.sentiment-vllm-config.update`
+
+Emitted directly from `AdminSentimentConfigController.UpdateConfig()` (not via the interceptor) so the metadata can carry both sides of the transition:
+
+```typescript
+metadata: {
+  previous: {
+    url: string;
+    model: string;
+    enabled: boolean;
+  }
+  next: {
+    url: string;
+    model: string;
+    enabled: boolean;
+  }
+}
+```
+
+`SentimentConfigService.updateConfig()` returns `{previous, next}` from a single read so there is no TOCTOU window between an interceptor-side read and the service-side write. `resourceType = 'SystemConfig'`, `resourceId = 'SENTIMENT_VLLM_CONFIG'`. The handler does **not** apply `@Audited()` — using both paths would double-emit on every URL rotation.
 
 ## Interceptor Path Detail
 

--- a/docs/architecture/scope-resolution.md
+++ b/docs/architecture/scope-resolution.md
@@ -156,6 +156,14 @@ When a user holds multiple roles, the highest-priority role wins:
 
 Analysis-pipeline authorization (create/confirm/cancel/read) reuses `ResolveDepartmentIds`, `ResolveProgramIds`, and `ResolveCampusIds`. Pipeline-specific rules — required axis per role, list default-fill, FACULTY auto-override, 404-before-403 ordering, and the active-scope unique index — live in [analysis-pipeline.md §Access Control](../workflows/analysis-pipeline.md#access-control). `PipelineOrchestratorService` calls these resolvers before any DB write or flush so a foreign caller cannot cause side effects.
 
+### Faculty self-view on analytics endpoints
+
+The faculty report endpoints (`/analytics/faculty/:facultyId/report`, `.../report/comments`, `.../qualitative-summary`, `.../questionnaire-types`) are the only analytics surfaces that admit the FACULTY role. The `AnalyticsController` declares its class-level allowlist as `(DEAN, CHAIRPERSON, CAMPUS_HEAD, SUPER_ADMIN)`; each faculty endpoint widens with a per-method `@UseJwtGuard(... , FACULTY)` and then calls `assertFacultySelfScope(currentUser, facultyId)`.
+
+`assertFacultySelfScope` (`src/modules/analytics/lib/faculty-scope.util.ts`) is a no-op for non-FACULTY roles and throws `ForbiddenException` if a FACULTY user requests a `facultyId` other than their own. Use the same helper on any future analytics surface that exposes per-faculty data to FACULTY users — equality of `user.id === facultyId` is the canonical ownership check (faculty users do not have a separate FacultyProfile entity).
+
+For pipeline read access, FACULTY ownership is checked via `pipeline.faculty.id === user.id` inside `PipelineOrchestratorService.assertCanAccessPipeline`; verbatim student text in the recommendations response is then redacted by `AnalysisAccessService.RedactIfFacultySelfView` regardless of which role-coincidence path admitted the request. See [Analytics — Faculty Self-View Redaction](./analytics.md#faculty-self-view-redaction).
+
 ## Source Files
 
 | File                                                          | Purpose                                                      |

--- a/docs/decisions/decisions.md
+++ b/docs/decisions/decisions.md
@@ -342,6 +342,58 @@ The filter set deliberately separates exact-match filters (AND'd together) from 
 
 See [Audit Trail — Query API](../architecture/audit-trail.md#query-api).
 
+## 45. Pipeline Scope Collapsed to `{scopeType, scopeId}` Without Entity Schema Change
+
+The pipeline create DTO surface was collapsed from a multi-FK shape (`facultyId`/`departmentId`/`campusId`/`programId`/`courseId`/`questionnaireTypeCode`) to a canonical `{scopeType ∈ {FACULTY, DEPARTMENT, CAMPUS}, scopeId}` pair. The `AnalysisPipeline` entity still stores the legacy nullable FK columns per tier — there is no migration on the entity itself.
+
+- **Rationale:** Three tiers cover all real analytical scopes (`FACULTY`, `DEPARTMENT`, `CAMPUS`). The other FK columns were optional refinements that were never used in scheduler-driven runs and confused the API surface. A pure-DTO change keeps the entity stable across deployments — no destructive backfill, no new index churn — while the orchestrator translates the canonical pair to the appropriate FK column internally.
+- **Legacy bridge:** A `bridgeLegacyCreatePipelineInput` Zod preprocessor keeps the previous shape working for one PR cycle (Phase A → Phase C), logging `deprecated_field_used` for every translated input. PR-3 deletes the bridge and switches the schema to `.strict()`.
+- **Trade-off:** The entity is now wider than the DTO — readers must know that `pipeline.faculty/department/campus` are mutually exclusive nullable FKs whose populated tier matches `scope`. Acceptable because the alternative (renaming a column on every deployed schema) carried more operational risk than the dead-column ambiguity.
+
+## 46. Tiered Pipeline Scheduler with Per-Tier Concurrency Isolation
+
+`TieredPipelineSchedulerJob` exposes three independent `@Cron` methods (FACULTY 01:00, DEPARTMENT 02:00, CAMPUS 03:00 UTC, all Sunday) instead of a single multiplexed scheduler.
+
+- **Per-tier `running[tier]` flag:** A long-running faculty tier does not block the department or campus tier that follows. Each tier has its own concurrency guard.
+- **Skip-check by `lastPipelineCompletedAt`:** `submissionRepository.FindChangedSince(scope, lastCompletedAt)` short-circuits scopes with no new submissions — avoids re-running unchanged DEPARTMENT pipelines every Sunday at 02:00.
+- **System-user attribution:** Scheduler-driven pipelines need a non-null `triggeredBy`. The job resolves the seeded SUPER_ADMIN by `env.SUPER_ADMIN_USERNAME` rather than maintaining a synthetic system user — fewer moving parts, and audit metadata still includes `trigger=SCHEDULER` to disambiguate from a manual SUPER_ADMIN action.
+- **Trade-off:** Three cron decorators instead of one. Acceptable because each tier has distinct semantics (frequency of new data, expected coverage, who consumes the output) and folding them under a multiplexer would re-introduce a global lock.
+
+## 47. Facet Dominance Threshold for Aggregate Recommendations
+
+When a DEPARTMENT or CAMPUS pipeline aggregates submissions across multiple primary questionnaire types, each `RecommendedAction` is tagged with a `facet ∈ {overall, facultyFeedback, inClassroom, outOfClassroom}` derived by `deriveFacetFromTypeCodeCounts()`. The top contributing questionnaire-type code wins **only** when its share of the action's contributing submissions is `≥ 0.6`; otherwise the action falls back to `overall`.
+
+- **Why 60%, not >50%:** Strict majority is too fragile for BERTopic mixed clusters — a 51% lead on a 20-comment cluster is noise. 60% is a usable signal floor while still tolerating the natural blending that happens when one topic spans related questionnaires.
+- **Code constant, not env flag:** Tuning the threshold changes evidence semantics (which submissions appear under which facet) and should go through code review, not an operator runtime knob. `FACET_DOMINANCE_THRESHOLD = 0.6` in `recommendation-generation.service.ts` is the source of truth.
+- **Trade-off:** A few honest minority-facet actions get rolled into `overall` instead of being properly attributed. Acceptable because misattribution would erode trust in the tagging system more than a slightly broader `overall` bucket does.
+
+## 48. Sentiment Chunked Dispatch with Counter-Based Completion
+
+`PipelineOrchestratorService.dispatchSentiment()` splits a run into N chunks of `SENTIMENT_CHUNK_SIZE` (default 50) and enqueues one BullMQ job per chunk. `SentimentRun` carries `expectedChunks`/`completedChunks` counters; each chunk's `Persist()` inserts its rows and increments the counter atomically, then triggers `OnSentimentComplete()` when saturated.
+
+- **Why chunk:** A campus-tier pipeline with 800+ comments routinely exceeded the worker's 90s HTTP timeout in a single batch. Chunking caps each request's wall time at a predictable multiple of `SENTIMENT_CHUNK_SIZE`.
+- **Why counters, not BullMQ FlowProducer:** A simple `expectedChunks/completedChunks` pair on the run row keeps the completion logic auditable from the database alone — operators can answer "is run X stuck?" with a single SELECT, without grovelling through Redis. Atomic UPDATE in the same transaction as the insert prevents the race where the last chunk crashes between persist and counter bump.
+- **Full unique index requirement:** `sentiment_result(run_id, submission_id)` was converted from a partial index (`WHERE deleted_at IS NULL`) to a full index in migration `20260417120000` so that retried chunks land as `duplicate-swallowed` rather than re-inserting against soft-deleted siblings. The migration includes a preflight duplicate check that aborts if any duplicate pairs exist across live + soft-deleted rows.
+- **Trade-off:** More BullMQ traffic per run; counter race conditions need careful transactional design. Acceptable because the alternative (longer timeouts + retry-the-whole-batch) wasted significantly more worker GPU time on partial failures.
+
+## 49. Single-Read Update + Snapshot-Once Dispatch for vLLM Config
+
+`SentimentConfigService.updateConfig()` returns `{previous, next}` from a single read+write path; the controller emits `admin.sentiment-vllm-config.update` with both sides as audit metadata. `PipelineOrchestratorService.dispatchSentiment()` reads the config **once per run** and attaches the resolved `vllmConfig` to every chunk envelope.
+
+- **Why single-read update:** Splitting the read into two calls (controller-side for audit, service-side for the write) opens a TOCTOU window where a concurrent admin could change the value between the audit snapshot and the persisted write — the audit log would record a transition that never happened. Returning both sides from one transaction closes that window.
+- **Why snapshot-once dispatch:** A config flip mid-run could otherwise straddle chunks of the same `SentimentRun`, producing inconsistent `servedBy` provenance and silently breaking the assumption that a single run uses a single backend. One read per dispatch keeps every chunk on the same path.
+- **Why a production gate (`ALLOW_SENTIMENT_VLLM_ENABLED_IN_PROD`):** A SuperAdmin session could otherwise enable a self-hosted endpoint in production without ops being in the loop. The env var requires a deploy-time decision to flip the toggle on.
+- **Trade-off:** Mid-run config changes have to wait for the next run to take effect. Acceptable because runs are short and the alternative is provenance ambiguity in audit + result rows.
+
+## 50. FACULTY Self-View on Analytics Endpoints via Method-Level Widening
+
+`AnalyticsController` declares its class-level allowlist as `(DEAN, CHAIRPERSON, CAMPUS_HEAD, SUPER_ADMIN)`; each faculty endpoint (`report`, `report/comments`, `qualitative-summary`, `questionnaire-types`) widens with a per-method `@UseJwtGuard(..., FACULTY)` and calls `assertFacultySelfScope(currentUser, facultyId)`.
+
+- **Rationale:** FACULTY needs to see their own report data on the same surface as administrators, but the class-level allowlist is the right default for scoped roles. Widening per-method (rather than dropping FACULTY into the class allowlist) keeps the dean-side endpoints (`overview`, `attention`, `trends`) closed to FACULTY without per-method exclusions.
+- **Self-equality is the ownership check:** Faculty users do not have a separate FacultyProfile entity — `User.id` is the same id `AnalysisPipeline.faculty_id` points to. `assertFacultySelfScope` enforces `user.id === facultyId` and is a no-op for non-FACULTY roles. Future analytics surfaces that admit FACULTY must use the same helper.
+- **Verbatim redaction layered separately:** Faculty self-views still receive an extra `AnalysisAccessService.RedactIfFacultySelfView` pass on the recommendations response to strip `sampleQuotes[]`. The split keeps "who can read" and "what shape is returned" as independent concerns.
+- **Trade-off:** Two layers of FACULTY-specific code (the per-method widening + the helper). Acceptable — the alternative (a separate `/me/...` controller) would duplicate query logic and double the test surface.
+
 ## 30. Semester Code Parsing for Display Labels
 
 The Moodle category sync now parses semester codes (e.g., `S22526`) into human-readable `label` ("Semester 2") and `academicYear` ("2025-2026") fields on the `Semester` entity.

--- a/docs/worker-contracts/sentiment-worker.md
+++ b/docs/worker-contracts/sentiment-worker.md
@@ -22,20 +22,37 @@
   ],
   "metadata": {
     "pipelineId": "uuid-string",
-    "runId": "uuid-string"
+    "runId": "uuid-string",
+    "chunkIndex": 0,
+    "chunkCount": 17
+  },
+  "vllmConfig": {
+    "url": "https://vllm.internal.example/v1",
+    "model": "llama-3.1-8b-instruct",
+    "enabled": true
   }
 }
 ```
 
 ### Fields
 
-| Field                  | Type           | Required | Description                     |
-| ---------------------- | -------------- | -------- | ------------------------------- |
-| `items`                | array          | Yes      | Array of submissions to analyze |
-| `items[].submissionId` | string         | Yes      | Unique submission identifier    |
-| `items[].text`         | string (min 1) | Yes      | Qualitative comment text        |
-| `metadata.pipelineId`  | string         | Yes      | Parent pipeline ID              |
-| `metadata.runId`       | string         | Yes      | Current sentiment run ID        |
+| Field                  | Type           | Required        | Description                                                                             |
+| ---------------------- | -------------- | --------------- | --------------------------------------------------------------------------------------- |
+| `items`                | array          | Yes             | Array of submissions to analyze                                                         |
+| `items[].submissionId` | string         | Yes             | Unique submission identifier                                                            |
+| `items[].text`         | string (min 1) | Yes             | Qualitative comment text                                                                |
+| `metadata.pipelineId`  | string         | Yes             | Parent pipeline ID                                                                      |
+| `metadata.runId`       | string         | Yes             | Current sentiment run ID                                                                |
+| `metadata.chunkIndex`  | int (≥ 0)      | No              | 0-based index of this chunk within the run (omitted on legacy single-batch dispatch)    |
+| `metadata.chunkCount`  | int (≥ 1)      | No              | Total chunks for this run                                                               |
+| `vllmConfig`           | object         | No              | When present + `enabled=true`, the worker should route through the vLLM URL/model below |
+| `vllmConfig.url`       | string (https) | If `vllmConfig` | Must start with `https://` (SSRF mitigation)                                            |
+| `vllmConfig.model`     | string         | If `vllmConfig` | Model identifier passed to vLLM                                                         |
+| `vllmConfig.enabled`   | boolean        | If `vllmConfig` | When `false`, worker may treat the request as if `vllmConfig` was omitted               |
+
+### Chunked Dispatch
+
+The API splits each pipeline run into N chunks of `SENTIMENT_CHUNK_SIZE` (default 50) and sends one request per chunk. Workers should treat each chunk independently and return results only for the `items` in that request — counter-based completion tracking on the API side reassembles the run. See [AI Inference Pipeline — Chunked Sentiment Dispatch](../architecture/ai-inference-pipeline.md#13-chunked-sentiment-dispatch).
 
 ## Response
 
@@ -63,17 +80,18 @@
 
 ### Fields
 
-| Field                    | Type         | Required   | Description                           |
-| ------------------------ | ------------ | ---------- | ------------------------------------- |
-| `version`                | string       | Yes        | Worker/model version identifier       |
-| `status`                 | enum         | Yes        | `completed` or `failed`               |
-| `results`                | array        | On success | Per-submission sentiment scores       |
-| `results[].submissionId` | string       | Yes        | Matches input submissionId            |
-| `results[].positive`     | number (0-1) | Yes        | Positive sentiment score              |
-| `results[].neutral`      | number (0-1) | Yes        | Neutral sentiment score               |
-| `results[].negative`     | number (0-1) | Yes        | Negative sentiment score              |
-| `error`                  | string       | On failure | Error message when status is `failed` |
-| `completedAt`            | ISO datetime | Yes        | Processing completion timestamp       |
+| Field                    | Type             | Required   | Description                                                                                   |
+| ------------------------ | ---------------- | ---------- | --------------------------------------------------------------------------------------------- |
+| `version`                | string           | Yes        | Worker/model version identifier                                                               |
+| `status`                 | enum             | Yes        | `completed` or `failed`                                                                       |
+| `results`                | array            | On success | Per-submission sentiment scores                                                               |
+| `results[].submissionId` | string           | Yes        | Matches input submissionId                                                                    |
+| `results[].positive`     | number (0-1)     | Yes        | Positive sentiment score                                                                      |
+| `results[].neutral`      | number (0-1)     | Yes        | Neutral sentiment score                                                                       |
+| `results[].negative`     | number (0-1)     | Yes        | Negative sentiment score                                                                      |
+| `results[].servedBy`     | `vllm \| openai` | No         | Which path actually served this item; persisted on `SentimentResult.rawResult` for provenance |
+| `error`                  | string           | On failure | Error message when status is `failed`                                                         |
+| `completedAt`            | ISO datetime     | Yes        | Processing completion timestamp                                                               |
 
 ## Error Response
 

--- a/docs/workflows/analysis-job-processing.md
+++ b/docs/workflows/analysis-job-processing.md
@@ -107,7 +107,46 @@ flowchart TD
 
 Pipeline jobs use deterministic IDs: `${pipelineId}--${type}`. Ad-hoc jobs use: `${submissionId}--${type}`. If the same pipeline/submission + analysis type is enqueued twice, BullMQ silently rejects the duplicate.
 
-> **Note:** BullMQ does not allow `:` in custom job IDs. The `--` separator is used instead.
+> **Note:** BullMQ does not allow `:` in custom job IDs. The `--` separator is used instead. Chunked sentiment jobs append the chunk index — see [§ Chunked Sentiment Dispatch](#chunked-sentiment-dispatch).
+
+## Chunked Sentiment Dispatch
+
+When a pipeline confirms, the orchestrator splits the in-scope submissions into N chunks of `SENTIMENT_CHUNK_SIZE` (default `50`) using `chunkSubmissionsForSentiment()` and enqueues one BullMQ job per chunk. This avoids 504 timeouts on large scopes (e.g., 800+ comments at the campus tier) — the previous single-batch dispatch could exceed the worker's HTTP timeout in a single request.
+
+### Job envelope
+
+Each chunk job carries the same `BatchAnalysisJobMessage` envelope, with two additional optional metadata fields:
+
+```typescript
+{
+  // ...standard fields
+  metadata: {
+    pipelineId: string;
+    runId: string;
+    chunkIndex?: number;  // 0-based
+    chunkCount?: number;  // total chunks for this run
+  },
+  vllmConfig?: { url, model, enabled };  // optional, see ai-inference-pipeline.md
+}
+```
+
+The envelope is `.strict()` — any unexpected key fails validation at dispatch.
+
+### Counter-based completion
+
+`SentimentRun` gains two columns: `expectedChunks` (set when the run is created) and `completedChunks` (incremented per chunk). Each chunk's `Persist()`:
+
+1. Inserts its `SentimentResult` rows.
+2. `UPDATE sentiment_run SET completed_chunks = completed_chunks + 1` — atomic counter increment in the same transaction.
+3. If `completedChunks === expectedChunks`, marks the run `COMPLETED` and calls `OnSentimentComplete()` to advance the pipeline.
+
+The processor passes `tx.getTransactionContext()` into `execute()` so the entity insert and the counter bump commit together. Partial chunk failures retry per-chunk; a failed chunk does not roll back its peers.
+
+### Duplicate-swallowed retry safety
+
+If `OnSentimentComplete()` succeeds but the BullMQ job's post-commit acknowledgment fails (e.g., Redis hiccup), the chunk retries. The retry's insert hits the run's full unique index (`(run_id, submission_id)` — converted from a partial index in migration `20260417120000` so soft-deleted rows are also de-duplicated) and is treated as `duplicate-swallowed`. The processor re-reads the counter and re-fires `OnSentimentComplete()` only when the run is genuinely saturated, so completion is at-least-once but the downstream effect is idempotent.
+
+The unique-index conversion required a preflight duplicate check in the migration — if any `(run_id, submission_id)` pairs exist across live + soft-deleted rows, the migration aborts so the operator can investigate before re-running.
 
 ## Resilience
 

--- a/docs/workflows/analysis-pipeline.md
+++ b/docs/workflows/analysis-pipeline.md
@@ -10,17 +10,16 @@ An analysis pipeline processes all qualitative feedback for a given scope (semes
 
 **Endpoint:** `POST /analysis/pipelines`
 
-The caller provides a scope:
+The caller provides a scope using the canonical `{scopeType, scopeId}` pair. Only three tiers are supported — `FACULTY`, `DEPARTMENT`, `CAMPUS`.
 
-| Parameter                | Required | Description                         |
-| ------------------------ | -------- | ----------------------------------- |
-| `semesterId`             | Yes      | Target semester                     |
-| `facultyId`              | No       | Filter to a specific faculty member |
-| `questionnaireVersionId` | No       | Filter to a specific version        |
-| `departmentId`           | No       | Filter to a department              |
-| `programId`              | No       | Filter to a program                 |
-| `campusId`               | No       | Filter to a campus                  |
-| `courseId`               | No       | Filter to a course                  |
+| Parameter                | Required      | Description                                                                                       |
+| ------------------------ | ------------- | ------------------------------------------------------------------------------------------------- |
+| `semesterId`             | Yes           | Target semester                                                                                   |
+| `scopeType`              | Auto-fillable | One of `FACULTY`, `DEPARTMENT`, `CAMPUS`. Auto-filled for callers with exactly one assigned scope |
+| `scopeId`                | Auto-fillable | UUID of the faculty/department/campus matching `scopeType`                                        |
+| `questionnaireVersionId` | No            | Optional version pin; omitted means "all active versions in scope"                                |
+
+> **Legacy bridge.** A transient preprocessor (`bridgeLegacyCreatePipelineInput`) maps the old multi-FK shape (`facultyId`/`departmentId`/`campusId`/`programId`/`courseId`/`questionnaireTypeCode`) onto the canonical pair and logs `deprecated_field_used`. PR-3 deletes this preprocessor and switches the schema to `.strict()` — clients must migrate before then.
 
 The orchestrator:
 
@@ -28,6 +27,8 @@ The orchestrator:
 2. **Computes coverage stats** — Counts submissions, comments, and enrollments within scope. Calculates response rate.
 3. **Generates warnings** — Flags low response rate (< 25%), insufficient submissions (< 30), insufficient comments (< 10), or stale enrollment data (> 24h since last sync).
 4. Returns the pipeline in `AWAITING_CONFIRMATION` status.
+
+The `AnalysisPipeline.trigger` column records how the pipeline was created — `USER` for human-initiated calls (default for any HTTP-driven create) and `SCHEDULER` for tiered-scheduler firings (see [§ Tiered Scheduler](#tiered-scheduler)).
 
 ## 2. Confirm Pipeline
 
@@ -244,3 +245,33 @@ A partial unique index (`uq_analysis_pipeline_active_scope`) enforces one active
 ### Scope drift mid-pipeline
 
 A DEAN who triggers a pipeline and is then reassigned to a different department mid-execution loses read access to their own pipeline. This mirrors `/analytics/*` behavior and is intentional — the scope check evaluates against current assignments, not historical ones.
+
+## Tiered Scheduler
+
+`TieredPipelineSchedulerJob` (`src/crons/jobs/analysis-jobs/tiered-pipeline-scheduler.job.ts`) auto-enqueues pipelines for active scopes that have new submissions since the last completed run. It runs three independent tiers, each with its own `@Cron` decorator and its own `isRunning` flag:
+
+| Tier         | Cron expression | Cron name                                      |
+| ------------ | --------------- | ---------------------------------------------- |
+| `FACULTY`    | `0 1 * * 0`     | `TieredPipelineSchedulerJob.RunFacultyTier`    |
+| `DEPARTMENT` | `0 2 * * 0`     | `TieredPipelineSchedulerJob.RunDepartmentTier` |
+| `CAMPUS`     | `0 3 * * 0`     | `TieredPipelineSchedulerJob.RunCampusTier`     |
+
+Cron names and expressions are exported from `tiered-scheduler.constants.ts` so the orchestrator can introspect the next firing without a circular import.
+
+### Per-tier flow
+
+For each scope returned by `orchestrator.FindActiveScopesForTier(tier)`:
+
+1. **Skip-check** — `submissionRepository.FindChangedSince(scopeFilter, lastPipelineCompletedAt)` counts submissions created after the previous completed pipeline. Zero new submissions ⇒ skip (logged at `debug`).
+2. **Enqueue** — Otherwise, `orchestrator.CreateAndConfirmPipeline({...scope, triggeredById: systemUserId})` bypasses the human gate and dispatches sentiment immediately. The pipeline is tagged `trigger=SCHEDULER`.
+3. **Per-tier exclusion** — `running[tier]` short-circuits the next firing if the previous one is still in progress. Tiers are independent so a long faculty run does not block the department or campus tier that follows an hour later.
+
+If a scheduler-driven pipeline cannot satisfy coverage requirements at firing time, it still completes (rather than failing) but persists `warnings: ['insufficient_coverage_at_schedule_time']` for transparency.
+
+### System-user attribution
+
+Scheduler-driven pipelines need an `actorId` for audit metadata. `resolveSystemUserId()` looks up the seeded SUPER_ADMIN by `env.SUPER_ADMIN_USERNAME` and uses its UUID. If the lookup fails, the tier returns `failed` and emits an error log — no pipelines are enqueued, since attribution would otherwise be lost.
+
+### Next-run surfacing
+
+`GET /analysis/pipelines/:id/status` returns `nextScheduledRunAt` (ISO 8601 UTC) so the frontend can render "next refresh in N hours" copy. The value is computed by `getNextScheduledRunAt(tier)` via `SchedulerRegistry` + `cron-parser`, falling back to a parsed cron expression when the registry has not yet registered the job (e.g., during boot).


### PR DESCRIPTION
## Summary

Brings `docs/`, `CLAUDE.md`, and `README.md` in line with the eight PRs landed on `develop` since FAC-132 (FAC-134, FAC-135, FAC-135.1–135.5). No source changes.

- **architecture/analytics.md** — faculty report endpoints (`report`, `report/comments`, `qualitative-summary`, `questionnaire-types`), `assertFacultySelfScope` self-view auth, quantitative distributions (dimensions/ratingCounts/responseCount), voice breakdown + facet derivation, faculty self-view redaction.
- **workflows/analysis-pipeline.md** — canonical `{scopeType, scopeId}` create DTO + legacy bridge note; new Tiered Scheduler section (cron table, skip-check, system-user attribution, `nextScheduledRunAt`).
- **workflows/analysis-job-processing.md** — chunked sentiment dispatch (envelope, `expectedChunks`/`completedChunks`, retry safety, full unique index migration).
- **architecture/audit-trail.md** — new `analysis.pipeline.fail` and `admin.sentiment-vllm-config.update` actions with metadata payload shape; expanded `AuditAction` listing.
- **architecture/ai-inference-pipeline.md** — adds `SENTIMENT_CHUNK_SIZE` and `ALLOW_SENTIMENT_VLLM_ENABLED_IN_PROD` env vars; new §13 Chunked Sentiment Dispatch and §14 vLLM-Primary Sentiment Dispatch.
- **worker-contracts/sentiment-worker.md** — documents `metadata.chunkIndex/chunkCount`, optional `vllmConfig` request field, optional `servedBy` on result items.
- **architecture/scope-resolution.md** — faculty self-view layering via `assertFacultySelfScope` and `RedactIfFacultySelfView`.
- **decisions/decisions.md** — ADRs #45 scope DTO collapse, #46 tiered scheduler, #47 facet dominance threshold, #48 chunked sentiment, #49 vLLM single-read snapshot, #50 FACULTY analytics self-view.
- **CLAUDE.md** — module list expanded; `TieredPipelineSchedulerJob` + `ReportCleanupJob` listed; analysis-queue notes for chunking + vLLM; new env vars in optional section.
- **README.md** — optional env table extended with `SENTIMENT_WORKER_URL`, `SENTIMENT_CHUNK_SIZE`, `ALLOW_SENTIMENT_VLLM_ENABLED_IN_PROD`; `SUPER_ADMIN_USERNAME` annotated as scheduler attribution source.

## Test plan

- [ ] Skim each updated doc end-to-end for grammar/format
- [ ] Spot-check internal links (`#tiered-scheduler`, `#13-chunked-sentiment-dispatch`, `#faculty-self-view-redaction`, `#adminsentiment-vllm-configupdate`) render in GitHub
- [ ] Confirm no doc claims contradict current source (endpoints, env var names/defaults, audit action codes, cron expressions)