### PR TITLE
FAC-144 feat: expose faculty profilePicture on faculty report DTO

### DIFF
--- a/src/modules/analytics/analytics.service.ts
+++ b/src/modules/analytics/analytics.service.ts
@@ -1148,14 +1148,22 @@ export class AnalyticsService {
     const [facultyRow, semesterRow] = await Promise.all([
       this.em
         .execute(
-          'SELECT u.first_name, u.last_name FROM "user" u WHERE u.id = ? AND u.deleted_at IS NULL',
+          'SELECT u.first_name, u.last_name, u.user_profile_picture FROM "user" u WHERE u.id = ? AND u.deleted_at IS NULL',
           [facultyId],
         )
-        .then((rows: { first_name: string; last_name: string }[]) => {
-          if (rows.length === 0)
-            throw new NotFoundException('Faculty not found');
-          return rows[0];
-        }),
+        .then(
+          (
+            rows: {
+              first_name: string;
+              last_name: string;
+              user_profile_picture: string | null;
+            }[],
+          ) => {
+            if (rows.length === 0)
+              throw new NotFoundException('Faculty not found');
+            return rows[0];
+          },
+        ),
       this.em
         .execute(
           'SELECT s.id, s.code, s.label, s.academic_year FROM semester s WHERE s.id = ? AND s.deleted_at IS NULL',
@@ -1180,6 +1188,7 @@ export class AnalyticsService {
     const facultyDto = {
       id: facultyId,
       name: `${facultyRow.first_name} ${facultyRow.last_name}`,
+      profilePicture: facultyRow.user_profile_picture || null,
     };
     const semesterDto = {
       id: semesterRow.id,

--- a/src/modules/analytics/dto/responses/faculty-report.response.dto.ts
+++ b/src/modules/analytics/dto/responses/faculty-report.response.dto.ts
@@ -6,6 +6,9 @@ export class ReportFacultyDto {
 
   @ApiProperty()
   name!: string;
+
+  @ApiPropertyOptional({ type: String, nullable: true })
+  profilePicture?: string | null;
 }
 
 export class ReportSemesterDto {


### PR DESCRIPTION
Closes #376

## Summary

- Added optional `profilePicture` field to `ReportFacultyDto`.
- Updated `AnalyticsService.BuildFacultyReportData` to select `u.user_profile_picture` and surface it on the returned faculty DTO (empty strings normalized to `null`).
- No DB migration — the `user.user_profile_picture` column already exists and is already populated by Moodle sync.

## Test plan

- [x] `npm run verify` (lint + 1107 unit tests + build) passes
- [ ] Manual: `GET /analytics/faculty/:id/report?semesterId=...&questionnaireTypeCode=...` response JSON includes `faculty.profilePicture` (string URL from Moodle, or `null`)
- [ ] Consumed successfully by the paired app PR (FAC-WEB)