### PR TITLE
docs: add modular sub-folder CLAUDE.md files

### DIFF
--- a/src/configurations/CLAUDE.md
+++ b/src/configurations/CLAUDE.md
@@ -1,0 +1,35 @@
+# Configurations
+
+Zod-validated environment config, app bootstrapping, logging, and DB wiring. Every env var read in the app should come through here — not from `process.env`.
+
+## File map
+
+- `index.config.ts` — top-level aggregator. **The** import path for validated env: `import { env } from 'src/configurations/index.config'`.
+- `env/` — one file per feature area, each exporting a Zod schema + parsed object:
+  - `server.env.ts`, `database.env.ts`, `redis.env.ts`, `jwt.env.ts`, `cors.env.ts`, `moodle.env.ts`, `bullmq.env.ts`, `openai.env.ts`, `admin.env.ts`, `r2.env.ts`, `report.env.ts`, `throttle.env.ts`.
+  - `env.validation.ts` — composes the schemas, runs at startup, fails fast on invalid config.
+  - `jwt-duration.util.ts` — parses duration strings (e.g. `"300s"`, `"30d"`).
+  - `index.ts` — re-exports.
+- `app/` — app-level factory/config.
+- `common/` — shared constants (queue names, etc.).
+- `database/` — MikroORM config glue.
+- `factory/` — module-factory helpers.
+- `lifecycle/` — app lifecycle hooks.
+- `logger/` — logger configuration.
+
+## Conventions
+
+- **Add a new env var**: pick (or create) a file in `env/`, add the Zod schema entry, then register in `env.validation.ts`. The value flows through `index.config.ts` automatically.
+- **Never read `process.env` directly** in feature code. If the value isn't in `env`, add it — future readers need a single source of truth.
+- **Failing fast at startup** is intentional: an invalid env should crash the process at boot, not surface later as a runtime error.
+- Duration-like env vars use `jwt-duration.util.ts` semantics (`"300s"`, `"30d"`). Don't reinvent parsing.
+
+## Gotchas
+
+- The env schema **runs before Nest builds the container** — if you add a new schema file, import it in `env.validation.ts` or the validation will silently skip it.
+- Defaults live in the schemas, not in feature code. If a feature needs a different default, override via env, not via a `??` fallback at the call site.
+- `r2.env.ts` + `report.env.ts` gate R2/report storage — they're optional but report generation will fail at runtime without them.
+
+## Pointers
+
+- Root `CLAUDE.md` — full env var reference (required + optional, with defaults).

--- a/src/crons/CLAUDE.md
+++ b/src/crons/CLAUDE.md
@@ -1,0 +1,41 @@
+# Crons
+
+Scheduled background jobs. The pattern here is custom (not just `@Cron()`): jobs participate in a boot-time startup phase and register their results for diagnostics.
+
+## File map
+
+- `base.job.ts` — abstract `BaseJob` class; every job extends this.
+- `startup-job-registry.ts` — static `StartupJobRegistry` that collects per-job results during bootstrap.
+- `index.jobs.ts` — aggregates job providers for module registration.
+- `jobs/analysis-jobs/` — `tiered-pipeline-scheduler.job.ts` + constants.
+- `jobs/auth-jobs/` — `refresh-token-cleanup.job.ts` + constants.
+
+## BaseJob contract
+
+Every job:
+
+1. Extends `BaseJob` and passes a stable `jobName` to the constructor.
+2. Implements `protected runStartupTask(): Promise<JobRecordType>`.
+3. Calls `executeStartup()` during bootstrap — this runs `runStartupTask()`, records the result in `StartupJobRegistry`, and logs failures without crashing the app.
+4. Uses `schedulerRegistry` (injected `SchedulerRegistry`) for any cron it owns; jobs with fixed schedules can also decorate methods with `@Cron()`.
+5. Gets free graceful-shutdown logging via `onApplicationShutdown()`.
+
+## Active jobs
+
+- **RefreshTokenCleanupJob** (`jobs/auth-jobs/`) — every 12 hours, purges refresh tokens older than the 7-day retention window.
+- **TieredPipelineSchedulerJob** (`jobs/analysis-jobs/`) — three independent `@Cron` methods that enqueue pipelines for active scopes with new submissions:
+  - FACULTY tier: Sun 01:00 UTC
+  - DEPARTMENT tier: Sun 02:00 UTC
+  - CAMPUS tier: Sun 03:00 UTC
+  - Each tier has its own `isRunning` guard; scopes with no new submissions since their last completed pipeline are skipped.
+  - Pipelines created here are tagged `trigger=SCHEDULER` and attributed to the seeded SUPER_ADMIN.
+
+## Gotchas
+
+- `executeStartup()` **swallows failures** by design — a failed startup check won't crash the app, but it WILL be visible in the boot summary. Don't rely on an exception propagating.
+- The per-tier `isRunning` guard prevents overlapping runs but is per-process — in a multi-instance deploy you'd need a distributed lock. We currently run single-instance.
+- `JobRecordType` is a status + details shape; return it explicitly, don't just `return;`.
+
+## Pointers
+
+- Root `CLAUDE.md` — quick listing of active jobs (this file expands on the mechanism).

--- a/src/entities/CLAUDE.md
+++ b/src/entities/CLAUDE.md
@@ -1,0 +1,35 @@
+# Entities
+
+MikroORM entity definitions. All domain state lives here.
+
+## Conventions
+
+- **Base class**: every entity extends `CustomBaseEntity` (`base.entity.ts`) — UUID `id`, `createdAt`, `updatedAt`, nullable `deletedAt`, and a `SoftDelete()` method.
+- **Naming**: `{domain}.entity.ts` (kebab-case). One entity per file.
+- **Soft delete is global**: a MikroORM filter registered in `mikro-orm.config.ts` hides rows where `deletedAt IS NOT NULL` by default. To include deleted rows, pass `filters: { softDelete: false }` on the query.
+- **Custom repository wiring**: entities that need extra repo methods declare it inline — `@Entity({ repository: () => XRepository })`. The repo class lives in `src/repositories/`.
+- **`index.entity.ts`** aggregates entities for MikroORM config discovery — add new entities here.
+
+## Exception: SyncLog
+
+`sync-log.entity.ts` does **NOT** extend `CustomBaseEntity` — it has no `deletedAt` column. Any query touching `SyncLog` must pass `filters: { softDelete: false }` or the global filter will reference a missing column and fail.
+
+## Domain clusters
+
+- **Academic structure**: `campus`, `department`, `program`, `section`, `course`, `semester`, `user-institutional-role`.
+- **Identity / auth**: `user`, `refresh-token`, `moodle-token`.
+- **Moodle mirror**: `moodle-category`, `sync-log`.
+- **Questionnaires**: `questionnaire`, `questionnaire-type`, `questionnaire-version`, `questionnaire-draft`, `questionnaire-submission`, `questionnaire-answer`.
+- **Analysis pipeline**: `analysis-pipeline`, `sentiment-run`, `sentiment-result`, `topic-model-run`, `topic`, `topic-assignment`, `submission-embedding`, `recommendation-run`, `recommended-action`.
+- **Cross-cutting**: `audit-log`, `system-config`, `dimension`, `enrollment`, `report-job`, `chatkit-thread`, `chatkit-thread-item`.
+
+## Gotchas
+
+- Adding a new entity requires registering it in `index.entity.ts` AND creating a migration (`npx mikro-orm migration:create`). Forgetting the migration silently diverges the dev DB from production.
+- Relation decorators (`@ManyToOne`, `@OneToMany`) need matching inverse sides or MikroORM will silently drop joins.
+- When writing new repos, prefer `em.fork()` + query builder inside the repo — don't leak query building into services.
+
+## Pointers
+
+- `docs/architecture/data-model.md` — ER overview.
+- `src/repositories/CLAUDE.md` — repository layer conventions.

--- a/src/modules/analysis/CLAUDE.md
+++ b/src/modules/analysis/CLAUDE.md
@@ -1,0 +1,39 @@
+# Analysis Module
+
+AI analysis pipeline orchestration: sentiment, topic modeling, embeddings, and recommendations. All heavy work runs async via BullMQ and dispatches to external HTTP workers.
+
+## File map
+
+- `analysis.service.ts` — public entry points: `EnqueueJob()` and `EnqueueBatch()`. Other modules use these — do NOT reach directly into processors.
+- `analysis.module.ts` — wires queues, processors, services.
+- `constants.ts` — queue names, default timeouts.
+- `controllers/` — `admin-sentiment-config.controller.ts` handles `GET/PUT /admin/sentiment/vllm-config` (SUPER_ADMIN only).
+- `dto/` — request/response contracts, Zod-validated worker payloads.
+- `enums/` — `PipelineStatus`, `RunStatus`, `Trigger` (`MANUAL` | `SCHEDULER`).
+- `lib/` — helpers (chunking, scheduling math).
+- `processors/` — one BullMQ processor per analysis type; all extend `BaseAnalysisProcessor` (`base.processor.ts`) or `BaseBatchProcessor` (`base-batch.processor.ts`). `runpod-batch.processor.ts` is the RunPod dispatch variant.
+- `services/pipeline-orchestrator.service.ts` — **the** source of truth for pipeline advancement (>2k lines). Every state transition goes through this.
+- `services/sentiment-config.service.ts` — reads/writes the `SENTIMENT_VLLM_CONFIG` system-config row.
+- `services/recommendation-generation.service.ts`, `topic-label.service.ts`, `analysis-access.service.ts` — supporting services.
+
+## Key patterns
+
+- **Queue-per-type**: sentiment, topic-model, embedding, recommendations each have their own BullMQ queue and processor. Names come from `constants.ts`.
+- **BaseAnalysisProcessor** handles: HTTP dispatch, Zod validation of worker responses, retry/backoff (via BullMQ env vars), observability events.
+- **Sentiment chunking**: `PipelineOrchestratorService.dispatchSentiment()` splits a run into chunks of `SENTIMENT_CHUNK_SIZE` (default 50) and enqueues one job per chunk. `SentimentRun.expectedChunks` / `completedChunks` counters are updated atomically with row inserts; the orchestrator advances the pipeline when `completedChunks === expectedChunks`.
+- **vLLM snapshot dispatch**: when `SENTIMENT_VLLM_CONFIG` is enabled, the orchestrator snapshots the config once at dispatch time and attaches `vllmConfig` to every chunk envelope — so a mid-run config edit cannot split a run across two configs.
+- **Trigger tagging**: pipelines enqueued by the scheduler get `trigger=SCHEDULER` and are attributed to the seeded SUPER_ADMIN; user-triggered runs get `trigger=MANUAL`.
+
+## Gotchas
+
+- **Production vLLM gate**: enabling `SENTIMENT_VLLM_CONFIG` with `NODE_ENV=production` requires `ALLOW_SENTIMENT_VLLM_ENABLED_IN_PROD=true` — the admin endpoint will refuse otherwise.
+- Don't bypass `PipelineOrchestratorService` for state changes. Writing statuses directly from a processor will desync chunk counters.
+- Worker responses must pass Zod validation; malformed responses are retried by BullMQ, not silently accepted.
+- Mock worker at `mock-worker/` (Hono server) stands in for RunPod/vLLM in local dev (`docker compose up`).
+
+## Pointers
+
+- `docs/architecture/ai-inference-pipeline.md` — end-to-end pipeline narrative.
+- `docs/workflows/analysis-pipeline.md` — sequence flows.
+- `docs/workflows/analysis-job-processing.md` — processor-level flows.
+- `docs/worker-contracts/{sentiment,topic-modeling,recommendations}-worker.md` — authoritative worker HTTP contracts.

--- a/src/modules/auth/CLAUDE.md
+++ b/src/modules/auth/CLAUDE.md
@@ -1,0 +1,36 @@
+# Auth Module
+
+Login, refresh, and logout. Uses a priority-based Strategy pattern so multiple authentication sources (local passwords, Moodle tokens, future providers) compose cleanly.
+
+## File map
+
+- `auth.module.ts`, `auth.controller.ts`, `auth.service.ts` — module wiring + HTTP surface.
+- `roles.enum.ts` — `UserRole` enum (SUPER_ADMIN, ADMIN, FACULTY, etc.) consumed by `@Roles()` in `src/security/`.
+- `dto/` — login/refresh request + response DTOs.
+- `strategies/`
+  - `login-strategy.interface.ts` — defines `LoginStrategy` + `LoginStrategyResult` + `LOGIN_STRATEGIES` DI symbol.
+  - `local-login.strategy.ts` — priority `10`, bcrypt password check.
+  - `moodle-login.strategy.ts` — priority `100`, Moodle token auth + user hydration on first login.
+  - `index.ts` — exports + registration helpers.
+
+## Key patterns
+
+- **Strategy interface**: `priority: number`, `CanHandle(localUser, body): boolean`, `Execute(em, localUser, body): Promise<LoginStrategyResult>`.
+- **Priority ranges**:
+  - `0–99` — core auth (local passwords).
+  - `100–199` — external providers (Moodle, LDAP, OAuth).
+  - `200+` — fallbacks.
+- **DI**: all strategies are registered under the `LOGIN_STRATEGIES` injection token as an array. `AuthService` sorts by `priority` and asks each `CanHandle()` in order until one matches.
+- **Transactional execution**: `Execute()` receives an `EntityManager` — strategies must do all reads/writes through it, never spawn their own context.
+- **Moodle hydration**: `MoodleLoginStrategy` creates/updates the local `User` from Moodle site-info on first login. Treat the local user as a cached projection, not the source of truth.
+
+## Gotchas
+
+- Strategies are tried in priority order and the **first `CanHandle` match wins** — once you add a new strategy, verify it can't shadow an existing one.
+- Don't throw generic errors from `Execute()`; use `UnauthorizedException` so the controller maps it correctly.
+- `moodleToken` on `LoginStrategyResult` is only set by `MoodleLoginStrategy` — consuming code should treat it as optional.
+
+## Pointers
+
+- `docs/workflows/auth-hydration.md` — Moodle hydration flow and user-record reconciliation.
+- `src/security/CLAUDE.md` — guards, decorators, and Passport strategies that consume the tokens issued here.

--- a/src/modules/moodle/CLAUDE.md
+++ b/src/modules/moodle/CLAUDE.md
@@ -1,0 +1,37 @@
+# Moodle Module
+
+Communication with the Moodle LMS: users, courses, categories, enrollments. Includes the MoodleClient HTTP wrapper, a suite of sync services, and a dynamic scheduler.
+
+## File map
+
+- `moodle.module.ts`, `moodle.controller.ts`, `moodle.service.ts` — module wiring + top-level HTTP surface.
+- `services/`
+  - `moodle-sync.service.ts` — orchestrates a full sync run.
+  - `moodle-{user-hydration,category,course,enrollment,provisioning,startup}-sync.service.ts` — per-entity sync services.
+  - `moodle-course-transform.service.ts`, `moodle-csv-parser.service.ts` — data shaping helpers.
+  - `scope-derivation.helper.ts` (+ `.convergence.spec.ts`) — resolves a user's institutional scope (campus → department → faculty) from Moodle cohort/category data. Convergence spec exists because scope derivation is iterative.
+- `schedulers/moodle-sync.scheduler.ts` — dynamic cron via `SchedulerRegistry` (no static `@Cron()` decorator).
+- `schedulers/moodle-sync.constants.ts` — per-env default intervals.
+- `processors/` — BullMQ processor for async sync jobs.
+- `controllers/` — HTTP endpoints for sync control, provisioning.
+- `lib/` — Moodle API types, constants, provisioning/sync result types.
+- `dto/` — 38 request/response DTOs covering the Moodle API surface we use.
+
+## Key patterns
+
+- **Dynamic cron**: interval resolves in order: DB (`SystemConfig`) → env (`MOODLE_SYNC_INTERVAL_MINUTES`) → per-env default. Admins change it at runtime via `PUT /moodle/sync/schedule` (minimum 30 minutes).
+- **MoodleClient** (inside `services/`) enforces a 10-second timeout on every Moodle API call. Network/timeout errors are wrapped in `MoodleConnectivityError` and surface as HTTP 401 to the caller.
+- **SyncLog** tracks every run with per-phase metrics (fetched / inserted / updated / deactivated). It is used for both observability and scheduler decisions.
+
+## Gotchas
+
+- **`SyncLog` does NOT extend `CustomBaseEntity`** — it has no soft-delete column, so queries must pass `filters: { softDelete: false }` or the global filter will try to reference a missing `deletedAt` and explode.
+- Connectivity failures → 401 (not 502/504) so clients treat Moodle being unreachable the same as invalid credentials. Don't change this without coordinating with the frontend.
+- `SYNC_ON_STARTUP=true` runs course + enrollment sync during boot — expensive in production; leave disabled unless intentionally backfilling.
+- Scope derivation is iterative (convergence test exists for a reason) — changes here need the convergence spec re-run.
+
+## Pointers
+
+- `docs/workflows/institutional-sync.md` — end-to-end sync flow.
+- `docs/moodle/provisioning.md` — provisioning workflow.
+- `docs/moodle/moodle_api_index.md` — index of Moodle API endpoints we consume.

--- a/src/modules/questionnaires/CLAUDE.md
+++ b/src/modules/questionnaires/CLAUDE.md
@@ -1,0 +1,46 @@
+# Questionnaires Module
+
+Questionnaire definitions, versions, drafts, submissions, and the universal ingestion engine for bulk-loading submissions from CSV/Excel.
+
+## File map
+
+- `questionnaires.module.ts`, `questionnaire.controller.ts`, `questionnaire-type.controller.ts` — module wiring + HTTP surface.
+- `services/`
+  - `questionnaire.service.ts`, `questionnaire-type.service.ts` — core CRUD + lifecycle (draft → submitted).
+  - `questionnaire-schema.validator.ts` — validates questionnaire JSON schema (question shape, constraints).
+  - `scoring.service.ts` — computes aggregate scores from answers.
+- `ingestion/` — the universal ingestion engine (see below).
+- `validators/` — custom class-validator rules (e.g. date-window constraints).
+- `dto/` — request/response contracts for submissions, drafts, versions.
+- `lib/` — domain helpers.
+- `utils/` — generic helpers.
+
+## Ingestion engine
+
+Lives in `ingestion/` and is the opinionated way to load records in bulk from external files.
+
+- `adapters/` — `base-stream.adapter.ts` defines the `SourceAdapter` contract: an async generator `extract()` that yields rows. `csv.adapter.ts` and `excel.adapter.ts` are the concrete implementations.
+- `interfaces/` — engine + adapter interfaces.
+- `services/` — `IngestionEngine` drives the extraction: p-limit concurrency, dry-run support, timeout handling.
+- `factories/` — adapter factory so callers pick an adapter by file type.
+- `dto/` — `IngestionResult`, `RawSubmissionData`.
+- `constants/`, `types/`, `utils/` — supporting code.
+- `IngestionMapperService` (in `services/`) — maps raw rows to domain entities.
+
+## Key patterns
+
+- **Streaming**: adapters are async generators — they don't load the whole file into memory. Respect this when adding a new adapter.
+- **Dry-run**: the engine accepts a `dryRun` flag that runs validation + mapping without persisting. Useful for frontend preview flows.
+- **Concurrency**: controlled via p-limit inside `IngestionEngine`. Don't introduce your own `Promise.all` over a whole stream.
+
+## Gotchas
+
+- Streaming means **partial failures are possible**: some rows may be persisted before the engine aborts. Callers should treat a failure as "some work may have landed" and use the `IngestionResult` to reconcile.
+- Dry-run still runs Zod/entity validation — it only skips the database write.
+- New adapters must extend `BaseStreamAdapter` and implement `extract()`; do not subclass individual CSV/Excel adapters.
+
+## Pointers
+
+- `docs/architecture/universal-ingestion.md` — ingestion architecture.
+- `docs/architecture/questionnaire-management.md` — questionnaire lifecycle.
+- `docs/workflows/questionnaire-submission.md` — end-to-end submission flow.

--- a/src/repositories/CLAUDE.md
+++ b/src/repositories/CLAUDE.md
@@ -1,0 +1,26 @@
+# Repositories
+
+One custom MikroORM repository per entity. Most are thin, but this is where query logic belongs — keep services free of raw query builders.
+
+## Conventions
+
+- **Naming**: `{entity}.repository.ts`, one per entity.
+- **Wiring**: entities opt in via `@Entity({ repository: () => XRepository })`; MikroORM returns an `XRepository` instance from `em.getRepository(X)`.
+- **Base**: most repos extend MikroORM's `EntityRepository<T>` (or a local `BaseRepository`) and add 1–2 domain-specific methods.
+- **Forking**: when a method needs its own transactional scope, `em.fork()` inside the repo method. Do NOT leak forked EMs back to the caller.
+- **Query builder over raw SQL**: prefer `qb = this.createQueryBuilder()`; only drop to raw SQL for set-based operations that the QB can't express.
+
+## Notable repos
+
+Most repos are near-empty wrappers. Places with real logic:
+
+- `moodle-token.repository.ts` — token lookup/refresh plumbing for Moodle sessions.
+- `questionnaire-submission.repository.ts` — scoped fetches that drive the analysis pipeline.
+- `refresh-token.repository.ts` — token lifecycle queries used by `RefreshTokenCleanupJob`.
+- `report-job.repository.ts` — report lifecycle, including cleanup support for `ReportCleanupJob`.
+
+## Gotchas
+
+- The global soft-delete filter applies here too — pass `filters: { softDelete: false }` when you intentionally need deleted rows (e.g., the refresh-token cleanup path or `SyncLog` queries).
+- Don't put business rules in repo methods — repos return data, services decide what to do with it.
+- `__tests__/` holds repo-level specs; prefer adding repo-only tests here rather than exercising query shape from a service test.

--- a/src/security/CLAUDE.md
+++ b/src/security/CLAUDE.md
@@ -1,0 +1,36 @@
+# Security
+
+Authentication + authorization primitives: JWT guards, role checks, throttling, and Passport strategies.
+
+## File map
+
+- `decorators/`
+  - `roles.decorator.ts` — `@Roles(...roles)` attaches metadata consumed by `RolesGuard`.
+  - `index.ts` — also exports `@UseJwtGuard()` (the one-decorator-to-rule-them-all for protected endpoints).
+  - `use-jwt-guard.decorator.spec.ts` — verifies composition.
+- `guards/`
+  - `jwt-auth.guard.ts` — validates access tokens via the `jwt` Passport strategy.
+  - `refresh-jwt-auth.guard.ts` — validates refresh tokens via the `refresh-jwt` strategy.
+  - `roles.guard.ts` — reads `@Roles(...)` metadata and checks the authenticated user's role(s).
+  - `throttle.guard.ts` — custom throttling (wraps `@nestjs/throttler`).
+- `passport-strategys/` *(note the spelling)*
+  - `jwt.strategy.ts` — access-token strategy.
+  - `refresh-jwt.strategy.ts` — refresh-token strategy.
+
+## Conventions
+
+- **Protect endpoints with `@UseJwtGuard()`** from `decorators/`. It composes the JWT guard; don't sprinkle raw `@UseGuards(JwtAuthGuard)` everywhere.
+- **Role-gated endpoints**: stack `@UseJwtGuard()` + `@Roles(UserRole.SUPER_ADMIN, ...)`. `RolesGuard` runs AFTER auth — ordering matters.
+- **Refresh endpoint**: use `RefreshJwtAuthGuard` directly (the refresh flow is distinct enough that it doesn't reuse `@UseJwtGuard()`).
+- Role values live in `src/modules/auth/roles.enum.ts`.
+
+## Gotchas
+
+- **Folder is `passport-strategys` (not `strategies`)** — historical typo that's now load-bearing; imports and spec files reference it as-is. Don't silently rename.
+- `RolesGuard` needs `@Roles(...)` metadata; without it the guard short-circuits to allow — i.e. forgetting `@Roles` on a "SUPER_ADMIN only" endpoint silently opens it to every authenticated user.
+- The `ThrottleGuard` has its own config; don't assume `@Throttle()` from `@nestjs/throttler` alone covers it.
+
+## Pointers
+
+- `src/modules/auth/CLAUDE.md` — how login issues the tokens these guards validate.
+- Root `CLAUDE.md` — JWT env vars (`JWT_SECRET`, `REFRESH_SECRET`, `JWT_ACCESS_TOKEN_EXPIRY`, etc.).


### PR DESCRIPTION
## Summary

Adds quick-reference `CLAUDE.md` files to high-complexity modules and cross-cutting `src/` directories so Claude Code surfaces localized context automatically when reading files in those areas — instead of relying on the single root `CLAUDE.md` for everything.

**9 new files** (~330 lines total, avg ~35 lines each):

- `src/modules/analysis/` — pipeline orchestrator, sentiment chunking, vLLM dispatch, trigger tags
- `src/modules/moodle/` — dynamic scheduler, `MoodleClient` timeout/error wrapping, `SyncLog` soft-delete gotcha
- `src/modules/questionnaires/` — ingestion engine (`SourceAdapter`, streaming, dry-run)
- `src/modules/auth/` — `LoginStrategy` priority chain + `LOGIN_STRATEGIES` token
- `src/entities/` — `CustomBaseEntity` conventions, `SyncLog` exception, domain clusters
- `src/repositories/` — custom repo pattern, notable repos with real logic
- `src/crons/` — `BaseJob` contract, `StartupJobRegistry`, active job schedules
- `src/security/` — guards, decorators, the `passport-strategys` folder
- `src/configurations/` — Zod env validation, per-feature `env/` files

Each file follows the same quick-reference template: Purpose → File map → Key patterns → Gotchas → Pointers (to `/docs/` for deeper narrative). No duplication with the root `CLAUDE.md`, which stays intact as the high-level project map.

## Test plan

- [ ] Root `CLAUDE.md` is unchanged (`git diff develop..HEAD -- CLAUDE.md` shows no changes)
- [ ] Each new `CLAUDE.md` is ≤ ~100 lines and follows the template
- [ ] Open a file deep under `src/modules/analysis/` in a fresh Claude Code session and confirm the nested `CLAUDE.md` surfaces via hierarchical memory
- [ ] Spot-check cross-references: the `/docs/` filenames referenced in each sub-file actually exist

https://claude.ai/code/session_01UTq7zrRxmuQaK1zrdbfrwN