### PR TITLE
[STAGING] FAC-146 fix: order semesters by academic start_date (#383)

### DIFF
--- a/src/entities/semester.entity.ts
+++ b/src/entities/semester.entity.ts
@@ -25,6 +25,13 @@ export class Semester extends CustomBaseEntity {
   @Property({ nullable: true })
   academicYear?: string;
 
+  @Property()
+  @Index()
+  startDate!: Date;
+
+  @Property({ nullable: true })
+  endDate?: Date;
+
   @ManyToOne(() => Campus)
   campus!: Campus;
 

--- a/src/migrations/.snapshot-faculytics_db.json
+++ b/src/migrations/.snapshot-faculytics_db.json
@@ -5973,6 +5973,38 @@
           "comment": null,
           "enumItems": [],
           "mappedType": "string"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
         }
       },
       "name": "semester",
@@ -6007,6 +6039,16 @@
           "keyName": "semester_pkey",
           "unique": true,
           "primary": true
+        },
+        {
+          "columnNames": [
+            "start_date"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "semester_start_date_index",
+          "unique": false,
+          "primary": false
         }
       ],
       "checks": [],

--- a/src/migrations/Migration20260425120000_semester-start-end-dates.ts
+++ b/src/migrations/Migration20260425120000_semester-start-end-dates.ts
@@ -1,0 +1,60 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260425120000 extends Migration {
+  // Adds start_date/end_date to semester so analytics can order terms by
+  // academic chronology instead of DB insertion order. Backfills existing rows
+  // by parsing the `code` column (e.g. S22526 → Jan 20 – Jun 1 2026) using the
+  // same calendar as admin.faculytics/src/lib/constants.ts getSemesterDates()
+  // and the API-side parseSemesterCode() in moodle-category-sync.service.ts.
+  //
+  // Fallback: rows whose code doesn't match S{N}{YY1}{YY2} get start_date =
+  // created_at so the NOT NULL constraint holds. end_date stays NULL for
+  // unparseable rows — consumers treat it as "unknown."
+
+  override async up(): Promise<void> {
+    this.addSql(
+      `alter table "semester" add column "start_date" timestamptz null;`,
+    );
+    this.addSql(
+      `alter table "semester" add column "end_date" timestamptz null;`,
+    );
+
+    this.addSql(`
+      update "semester"
+      set
+        "start_date" = case
+          when "code" ~ '^S\\d{5}$' then
+            case substring("code" from 2 for 1)
+              when '1' then make_timestamptz(2000 + substring("code" from 3 for 2)::int,  8,  1, 0, 0, 0, 'UTC')
+              when '2' then make_timestamptz(2000 + substring("code" from 5 for 2)::int,  1, 20, 0, 0, 0, 'UTC')
+              when '3' then make_timestamptz(2000 + substring("code" from 5 for 2)::int,  6, 15, 0, 0, 0, 'UTC')
+              else          make_timestamptz(2000 + substring("code" from 3 for 2)::int,  8,  1, 0, 0, 0, 'UTC')
+            end
+          else "created_at"
+        end,
+        "end_date" = case
+          when "code" ~ '^S\\d{5}$' then
+            case substring("code" from 2 for 1)
+              when '1' then make_timestamptz(2000 + substring("code" from 3 for 2)::int, 12, 18, 0, 0, 0, 'UTC')
+              when '2' then make_timestamptz(2000 + substring("code" from 5 for 2)::int,  6,  1, 0, 0, 0, 'UTC')
+              when '3' then make_timestamptz(2000 + substring("code" from 5 for 2)::int,  7, 31, 0, 0, 0, 'UTC')
+              else null
+            end
+          else null
+        end;
+    `);
+
+    this.addSql(
+      `alter table "semester" alter column "start_date" set not null;`,
+    );
+    this.addSql(
+      `create index "semester_start_date_index" on "semester" ("start_date");`,
+    );
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop index if exists "semester_start_date_index";`);
+    this.addSql(`alter table "semester" drop column "end_date";`);
+    this.addSql(`alter table "semester" drop column "start_date";`);
+  }
+}

--- a/src/migrations/Migration20260425120100_mv-faculty-trends-by-start-date.ts
+++ b/src/migrations/Migration20260425120100_mv-faculty-trends-by-start-date.ts
@@ -1,0 +1,103 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260425120100 extends Migration {
+  // Rebuilds mv_faculty_trends so the per-faculty semester ordinal is driven
+  // by semester.start_date (academic chronology) rather than semester.created_at
+  // (DB insertion order). Without this change, backfilling a past semester AFTER
+  // the current semester silently flips every faculty's trend slope — an
+  // improving faculty reads as declining and vice versa.
+  //
+  // mv_faculty_semester_stats is untouched (it doesn't use semester ordering).
+
+  private readonly MV_FACULTY_TRENDS_BY_START_DATE = `
+    CREATE MATERIALIZED VIEW mv_faculty_trends AS
+    SELECT
+      sub.faculty_id,
+      sub.department_code_snapshot,
+      MODE() WITHIN GROUP (ORDER BY sub.faculty_name_snapshot) AS faculty_name_snapshot,
+      COUNT(*) AS semester_count,
+      (array_agg(sub.avg_normalized_score ORDER BY sub.ordinal DESC))[1] AS latest_avg_normalized_score,
+      (array_agg(sub.positive_rate ORDER BY sub.ordinal DESC))[1] AS latest_positive_rate,
+      regr_slope(sub.avg_normalized_score, sub.ordinal) AS score_slope,
+      regr_r2(sub.avg_normalized_score, sub.ordinal) AS score_r2,
+      regr_slope(sub.positive_rate, sub.ordinal) AS sentiment_slope,
+      regr_r2(sub.positive_rate, sub.ordinal) AS sentiment_r2
+    FROM (
+      SELECT
+        fss.faculty_id,
+        fss.department_code_snapshot,
+        fss.faculty_name_snapshot,
+        fss.avg_normalized_score,
+        fss.positive_count::float / NULLIF(fss.analyzed_count, 0) AS positive_rate,
+        ROW_NUMBER() OVER (
+          PARTITION BY fss.faculty_id, fss.department_code_snapshot
+          ORDER BY s.start_date
+        ) AS ordinal
+      FROM mv_faculty_semester_stats fss
+      JOIN semester s ON s.id = fss.semester_id AND s.deleted_at IS NULL
+    ) sub
+    GROUP BY sub.faculty_id, sub.department_code_snapshot;
+  `;
+
+  // Pre-FAC-startdate body — restores ordering by semester.created_at so down()
+  // returns to the FAC-130 semantics.
+  private readonly MV_FACULTY_TRENDS_BY_CREATED_AT = `
+    CREATE MATERIALIZED VIEW mv_faculty_trends AS
+    SELECT
+      sub.faculty_id,
+      sub.department_code_snapshot,
+      MODE() WITHIN GROUP (ORDER BY sub.faculty_name_snapshot) AS faculty_name_snapshot,
+      COUNT(*) AS semester_count,
+      (array_agg(sub.avg_normalized_score ORDER BY sub.ordinal DESC))[1] AS latest_avg_normalized_score,
+      (array_agg(sub.positive_rate ORDER BY sub.ordinal DESC))[1] AS latest_positive_rate,
+      regr_slope(sub.avg_normalized_score, sub.ordinal) AS score_slope,
+      regr_r2(sub.avg_normalized_score, sub.ordinal) AS score_r2,
+      regr_slope(sub.positive_rate, sub.ordinal) AS sentiment_slope,
+      regr_r2(sub.positive_rate, sub.ordinal) AS sentiment_r2
+    FROM (
+      SELECT
+        fss.faculty_id,
+        fss.department_code_snapshot,
+        fss.faculty_name_snapshot,
+        fss.avg_normalized_score,
+        fss.positive_count::float / NULLIF(fss.analyzed_count, 0) AS positive_rate,
+        ROW_NUMBER() OVER (
+          PARTITION BY fss.faculty_id, fss.department_code_snapshot
+          ORDER BY s.created_at
+        ) AS ordinal
+      FROM mv_faculty_semester_stats fss
+      JOIN semester s ON s.id = fss.semester_id AND s.deleted_at IS NULL
+    ) sub
+    GROUP BY sub.faculty_id, sub.department_code_snapshot;
+  `;
+
+  override async up(): Promise<void> {
+    this.addSql(`DROP MATERIALIZED VIEW IF EXISTS mv_faculty_trends;`);
+
+    this.addSql(this.MV_FACULTY_TRENDS_BY_START_DATE);
+    this.addSql(`CREATE UNIQUE INDEX uq_mv_faculty_trends
+      ON mv_faculty_trends (faculty_id, department_code_snapshot);`);
+    this.addSql(`CREATE INDEX idx_mv_ft_dept
+      ON mv_faculty_trends (department_code_snapshot);`);
+
+    // Invalidate stale freshness timestamp so /analytics reports null until
+    // the next scheduled refresh repopulates it.
+    this.addSql(
+      `DELETE FROM system_config WHERE key = 'analytics_last_refreshed_at';`,
+    );
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`DROP MATERIALIZED VIEW IF EXISTS mv_faculty_trends;`);
+
+    this.addSql(this.MV_FACULTY_TRENDS_BY_CREATED_AT);
+    this.addSql(`CREATE UNIQUE INDEX uq_mv_faculty_trends
+      ON mv_faculty_trends (faculty_id, department_code_snapshot);`);
+    this.addSql(`CREATE INDEX idx_mv_ft_dept
+      ON mv_faculty_trends (department_code_snapshot);`);
+
+    this.addSql(
+      `DELETE FROM system_config WHERE key = 'analytics_last_refreshed_at';`,
+    );
+  }
+}

--- a/src/modules/analytics/analytics.service.ts
+++ b/src/modules/analytics/analytics.service.ts
@@ -151,9 +151,9 @@ export class AnalyticsService {
     const prevSemRows: { id: string }[] = await this.em.execute(
       `SELECT s2.id FROM semester s2
          WHERE s2.campus_id = (SELECT s1.campus_id FROM semester s1 WHERE s1.id = ?)
-           AND s2.created_at < (SELECT s1.created_at FROM semester s1 WHERE s1.id = ?)
+           AND s2.start_date < (SELECT s1.start_date FROM semester s1 WHERE s1.id = ?)
            AND s2.deleted_at IS NULL
-         ORDER BY s2.created_at DESC LIMIT 1`,
+         ORDER BY s2.start_date DESC LIMIT 1`,
       [semesterId, semesterId],
     );
     const prevSemesterId = prevSemRows[0]?.id ?? null;
@@ -491,10 +491,12 @@ export class AnalyticsService {
     const minR2 = query.minR2 ?? 0.5;
 
     // Resolve scope — use provided semesterId or fall back to latest semester
+    // (ordered by academic start_date, not DB insertion time, so backfilled
+    // past semesters don't masquerade as the current term).
     let scopeSemesterId = query.semesterId;
     if (!scopeSemesterId) {
       const rows: { id: string }[] = await this.em.execute(
-        'SELECT id FROM semester WHERE deleted_at IS NULL ORDER BY created_at DESC LIMIT 1',
+        'SELECT id FROM semester WHERE deleted_at IS NULL ORDER BY start_date DESC LIMIT 1',
       );
       scopeSemesterId = rows[0]?.id;
     }

--- a/src/modules/moodle/services/moodle-category-sync.service.spec.ts
+++ b/src/modules/moodle/services/moodle-category-sync.service.spec.ts
@@ -19,28 +19,40 @@ describe('MoodleCategorySyncService', () => {
   });
 
   describe('parseSemesterCode', () => {
-    it('should parse S22526 as Semester 2, 2025-2026', () => {
+    it('should parse S22526 as Semester 2, 2025-2026 (Jan 20 – Jun 1 2026)', () => {
       const result = service['parseSemesterCode']('S22526');
       expect(result).toEqual({
         label: 'Semester 2',
         academicYear: '2025-2026',
+        startDate: new Date(Date.UTC(2026, 0, 20)),
+        endDate: new Date(Date.UTC(2026, 5, 1)),
       });
     });
 
-    it('should parse S12425 as Semester 1, 2024-2025', () => {
+    it('should parse S12425 as Semester 1, 2024-2025 (Aug 1 – Dec 18 2024)', () => {
       const result = service['parseSemesterCode']('S12425');
       expect(result).toEqual({
         label: 'Semester 1',
         academicYear: '2024-2025',
+        startDate: new Date(Date.UTC(2024, 7, 1)),
+        endDate: new Date(Date.UTC(2024, 11, 18)),
       });
     });
 
-    it('should parse S32627 as Semester 3, 2026-2027', () => {
+    it('should parse S32627 as Semester 3 intersession, 2026-2027 (Jun 15 – Jul 31 2027)', () => {
       const result = service['parseSemesterCode']('S32627');
       expect(result).toEqual({
         label: 'Semester 3',
         academicYear: '2026-2027',
+        startDate: new Date(Date.UTC(2027, 5, 15)),
+        endDate: new Date(Date.UTC(2027, 6, 31)),
       });
+    });
+
+    it('should place S1 before S2 within the same academic year', () => {
+      const s1 = service['parseSemesterCode']('S12526');
+      const s2 = service['parseSemesterCode']('S22526');
+      expect(s1.startDate!.getTime()).toBeLessThan(s2.startDate!.getTime());
     });
 
     it('should return undefined for non-matching codes', () => {
@@ -48,6 +60,8 @@ describe('MoodleCategorySyncService', () => {
       expect(result).toEqual({
         label: undefined,
         academicYear: undefined,
+        startDate: undefined,
+        endDate: undefined,
       });
     });
 
@@ -56,6 +70,8 @@ describe('MoodleCategorySyncService', () => {
       expect(result).toEqual({
         label: undefined,
         academicYear: undefined,
+        startDate: undefined,
+        endDate: undefined,
       });
     });
 
@@ -64,6 +80,8 @@ describe('MoodleCategorySyncService', () => {
       expect(result).toEqual({
         label: undefined,
         academicYear: undefined,
+        startDate: undefined,
+        endDate: undefined,
       });
     });
 
@@ -72,6 +90,8 @@ describe('MoodleCategorySyncService', () => {
       expect(result).toEqual({
         label: undefined,
         academicYear: undefined,
+        startDate: undefined,
+        endDate: undefined,
       });
     });
 
@@ -80,6 +100,8 @@ describe('MoodleCategorySyncService', () => {
       expect(result).toEqual({
         label: undefined,
         academicYear: undefined,
+        startDate: undefined,
+        endDate: undefined,
       });
     });
   });

--- a/src/modules/moodle/services/moodle-category-sync.service.ts
+++ b/src/modules/moodle/services/moodle-category-sync.service.ts
@@ -175,7 +175,8 @@ export class MoodleCategorySyncService {
       const campus = campusMap.get(parentCategory.moodleCategoryId);
       if (!campus) throw new Error('Missing campus in map');
 
-      const { label, academicYear } = this.parseSemesterCode(cat.name);
+      const { label, academicYear, startDate, endDate } =
+        this.parseSemesterCode(cat.name);
 
       const data = tx.create(
         Semester,
@@ -184,6 +185,8 @@ export class MoodleCategorySyncService {
           code: cat.name,
           label,
           academicYear,
+          startDate: startDate ?? new Date(),
+          endDate,
           description: this.stripHtml(cat.description),
           campus,
         },
@@ -196,6 +199,8 @@ export class MoodleCategorySyncService {
           'code',
           'label',
           'academicYear',
+          'startDate',
+          'endDate',
           'description',
           'campus',
           'updatedAt',
@@ -278,20 +283,57 @@ export class MoodleCategorySyncService {
   }
 
   /**
-   * Parses a semester code like "S22526" into label and academic year.
-   * Format: S{semester}{YY1}{YY2} → Semester {semester}, 20{YY1}-20{YY2}
+   * Parses a semester code like "S22526" into label, academic year, and dates.
+   * Format: S{semester}{YY1}{YY2} → Semester {semester}, 20{YY1}-20{YY2}.
+   *
+   * Calendar mirrors `admin.faculytics/src/lib/constants.ts` getSemesterDates():
+   *   Sem 1: Aug 1  – Dec 18 of startYear
+   *   Sem 2: Jan 20 – Jun 1  of endYear
+   *   Sem 3: Jun 15 – Jul 31 of endYear (intersession)
+   * Unknown semester numbers get a best-effort start of Aug 1 of startYear so
+   * ordering still places them sensibly within the academic year.
    */
   private parseSemesterCode(code: string): {
     label: string | undefined;
     academicYear: string | undefined;
+    startDate: Date | undefined;
+    endDate: Date | undefined;
   } {
     const match = code.match(/^S(\d)(\d{2})(\d{2})$/);
-    if (!match) return { label: undefined, academicYear: undefined };
+    if (!match) {
+      return {
+        label: undefined,
+        academicYear: undefined,
+        startDate: undefined,
+        endDate: undefined,
+      };
+    }
 
-    const [, semester, startYear, endYear] = match;
+    const [, semester, startYY, endYY] = match;
+    const startYear = 2000 + parseInt(startYY, 10);
+    const endYear = 2000 + parseInt(endYY, 10);
+
+    let startDate: Date;
+    let endDate: Date | undefined;
+    if (semester === '1') {
+      startDate = new Date(Date.UTC(startYear, 7, 1));
+      endDate = new Date(Date.UTC(startYear, 11, 18));
+    } else if (semester === '2') {
+      startDate = new Date(Date.UTC(endYear, 0, 20));
+      endDate = new Date(Date.UTC(endYear, 5, 1));
+    } else if (semester === '3') {
+      startDate = new Date(Date.UTC(endYear, 5, 15));
+      endDate = new Date(Date.UTC(endYear, 6, 31));
+    } else {
+      startDate = new Date(Date.UTC(startYear, 7, 1));
+      endDate = undefined;
+    }
+
     return {
       label: `Semester ${semester}`,
-      academicYear: `20${startYear}-20${endYear}`,
+      academicYear: `20${startYY}-20${endYY}`,
+      startDate,
+      endDate,
     };
   }
 

--- a/src/modules/semesters/dto/responses/semester-item.response.dto.ts
+++ b/src/modules/semesters/dto/responses/semester-item.response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsString, ValidateNested } from 'class-validator';
+import { IsDate, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 import { CampusShortResponseDto } from './campus-short.response.dto';
 
@@ -21,6 +21,17 @@ export class SemesterItemResponseDto {
   @IsString()
   @IsOptional()
   academicYear?: string;
+
+  @ApiProperty()
+  @IsDate()
+  @Type(() => Date)
+  startDate: Date;
+
+  @ApiPropertyOptional()
+  @IsDate()
+  @IsOptional()
+  @Type(() => Date)
+  endDate?: Date;
 
   @ApiProperty({ type: CampusShortResponseDto })
   @ValidateNested()

--- a/src/modules/semesters/semesters.service.spec.ts
+++ b/src/modules/semesters/semesters.service.spec.ts
@@ -22,12 +22,19 @@ describe('SemestersService', () => {
   });
 
   describe('listSemesters', () => {
+    const s2Start = new Date(Date.UTC(2026, 0, 20));
+    const s2End = new Date(Date.UTC(2026, 5, 1));
+    const s1Start = new Date(Date.UTC(2025, 7, 1));
+    const s1End = new Date(Date.UTC(2025, 11, 18));
+
     const mockSemesters = [
       {
         id: 'sem-1',
         code: 'S22526',
         label: 'Semester 2',
         academicYear: '2025-2026',
+        startDate: s2Start,
+        endDate: s2End,
         campus: { id: 'campus-1', code: 'UCMN', name: 'UC Main' },
       },
       {
@@ -35,11 +42,13 @@ describe('SemestersService', () => {
         code: 'S22526',
         label: 'Semester 2',
         academicYear: '2025-2026',
+        startDate: s2Start,
+        endDate: s2End,
         campus: { id: 'campus-2', code: 'UCB', name: 'UC Banilad' },
       },
     ];
 
-    it('should return all semesters with campus info', async () => {
+    it('should return all semesters with campus info and dates', async () => {
       em.find.mockResolvedValue(mockSemesters);
 
       const result = await service.listSemesters({});
@@ -50,12 +59,14 @@ describe('SemestersService', () => {
         code: 'S22526',
         label: 'Semester 2',
         academicYear: '2025-2026',
+        startDate: s2Start,
+        endDate: s2End,
         campus: { id: 'campus-1', code: 'UCMN', name: 'UC Main' },
       });
       expect(result.data[1].campus.code).toBe('UCB');
     });
 
-    it('should call find without campus filter when campusId is omitted', async () => {
+    it('should order by startDate DESC so the current academic term comes first', async () => {
       em.find.mockResolvedValue([]);
 
       await service.listSemesters({});
@@ -65,7 +76,7 @@ describe('SemestersService', () => {
         {},
         {
           populate: ['campus'],
-          orderBy: { createdAt: 'DESC' },
+          orderBy: { startDate: 'DESC' },
         },
       );
     });
@@ -80,11 +91,25 @@ describe('SemestersService', () => {
         { campus: 'campus-1' },
         {
           populate: ['campus'],
-          orderBy: { createdAt: 'DESC' },
+          orderBy: { startDate: 'DESC' },
         },
       );
       expect(result.data).toHaveLength(1);
       expect(result.data[0].campus.code).toBe('UCMN');
+    });
+
+    it('should pass through nullable endDate', async () => {
+      em.find.mockResolvedValue([
+        {
+          ...mockSemesters[0],
+          endDate: undefined,
+        },
+      ]);
+
+      const result = await service.listSemesters({});
+
+      expect(result.data[0].endDate).toBeUndefined();
+      expect(result.data[0].startDate).toEqual(s2Start);
     });
 
     it('should return empty data when no semesters exist', async () => {
@@ -93,6 +118,26 @@ describe('SemestersService', () => {
       const result = await service.listSemesters({});
 
       expect(result.data).toEqual([]);
+    });
+
+    it('should preserve backend ordering (S22526 before S12526 when S2 starts later)', async () => {
+      em.find.mockResolvedValue([
+        mockSemesters[0],
+        {
+          id: 'sem-3',
+          code: 'S12526',
+          label: 'Semester 1',
+          academicYear: '2025-2026',
+          startDate: s1Start,
+          endDate: s1End,
+          campus: { id: 'campus-1', code: 'UCMN', name: 'UC Main' },
+        },
+      ]);
+
+      const result = await service.listSemesters({});
+
+      expect(result.data[0].code).toBe('S22526');
+      expect(result.data[1].code).toBe('S12526');
     });
   });
 });

--- a/src/modules/semesters/semesters.service.ts
+++ b/src/modules/semesters/semesters.service.ts
@@ -18,7 +18,7 @@ export class SemestersService {
 
     const semesters = await this.em.find(Semester, filter, {
       populate: ['campus'],
-      orderBy: { createdAt: 'DESC' },
+      orderBy: { startDate: 'DESC' },
     });
 
     return {
@@ -27,6 +27,8 @@ export class SemestersService {
         code: s.code,
         label: s.label,
         academicYear: s.academicYear,
+        startDate: s.startDate,
+        endDate: s.endDate,
         campus: {
           id: s.campus.id,
           code: s.campus.code,


### PR DESCRIPTION
Semester.createdAt reflects DB insertion time, not academic chronology, so backfilling a past semester after the current one silently flips analytics that ordered by createdAt — including mv_faculty_trends, whose regr_slope(score, ordinal) would invert improving vs declining faculty. Introduce a first-class startDate on Semester and route every chronological ordering through it.

Schema
- Add startDate (NOT NULL, indexed) and endDate (nullable) to Semester.
- Migration20260425120000 adds columns, backfills existing rows by parsing the code (S22526 -> Jan 20 – Jun 1 2026) with the same calendar as admin.faculytics getSemesterDates(), and sets NOT NULL.
- Migration20260425120100 rebuilds mv_faculty_trends with ORDER BY s.start_date for the per-faculty ordinal; down() restores the FAC-130 ORDER BY s.created_at body.

Sync
- parseSemesterCode() now returns startDate/endDate; processSemesters() upserts them so re-syncs can correct backfilled values.

Query sites swapped from Semester.created_at to Semester.start_date
- analytics.service.ts GetDepartmentOverview previous-semester lookup
- analytics.service.ts GetFacultyTrends latest-semester fallback
- semesters.service.ts GET /semesters list ordering
- mv_faculty_trends ordinal window

DTO
- SemesterItemResponseDto now exposes startDate/endDate so the frontend switcher can eventually show academic dates.