### PR TITLE
[STAGING] fix: use enrollment-driven scope check for faculty access across seme…

### DIFF
--- a/src/modules/analytics/analytics.service.spec.ts
+++ b/src/modules/analytics/analytics.service.spec.ts
@@ -14,6 +14,7 @@ describe('AnalyticsService', () => {
   let mockScopeResolver: {
     ResolveDepartmentIds: jest.Mock;
     ResolveProgramCodes: jest.Mock;
+    IsFacultyInSemesterScope: jest.Mock;
   };
 
   beforeEach(async () => {
@@ -32,6 +33,7 @@ describe('AnalyticsService', () => {
     mockScopeResolver = {
       ResolveDepartmentIds: jest.fn().mockResolvedValue(null),
       ResolveProgramCodes: jest.fn().mockResolvedValue(null),
+      IsFacultyInSemesterScope: jest.fn().mockResolvedValue(true),
     };
 
     // FACULTY-self short-circuit checks `currentUserService.get()`. Default
@@ -827,15 +829,11 @@ describe('AnalyticsService', () => {
       mockScopeResolver.ResolveDepartmentIds.mockResolvedValue([
         'dept-allowed',
       ]);
-      // validateFacultyScope: user query (includes name fields now)
+      // Faculty exists, but no in-scope enrollments for this semester.
       mockExecute.mockResolvedValueOnce([
-        {
-          id: facultyId,
-          department_id: 'dept-other',
-          first_name: 'John',
-          last_name: 'Doe',
-        },
+        { id: facultyId, first_name: 'John', last_name: 'Doe' },
       ]);
+      mockScopeResolver.IsFacultyInSemesterScope.mockResolvedValueOnce(false);
 
       await expect(
         service.GetFacultyReport(facultyId, baseQuery),
@@ -1218,15 +1216,10 @@ describe('AnalyticsService', () => {
       mockScopeResolver.ResolveDepartmentIds.mockResolvedValue([
         'dept-allowed',
       ]);
-      // validateFacultyScope: user query
       mockExecute.mockResolvedValueOnce([
-        {
-          id: facultyId,
-          department_id: 'dept-other',
-          first_name: 'John',
-          last_name: 'Doe',
-        },
+        { id: facultyId, first_name: 'John', last_name: 'Doe' },
       ]);
+      mockScopeResolver.IsFacultyInSemesterScope.mockResolvedValueOnce(false);
 
       await expect(
         service.GetFacultyReportComments(facultyId, baseQuery),
@@ -1472,13 +1465,9 @@ describe('AnalyticsService', () => {
         'dept-allowed',
       ]);
       mockExecute.mockResolvedValueOnce([
-        {
-          id: facultyId,
-          department_id: 'dept-other',
-          first_name: 'John',
-          last_name: 'Doe',
-        },
+        { id: facultyId, first_name: 'John', last_name: 'Doe' },
       ]);
+      mockScopeResolver.IsFacultyInSemesterScope.mockResolvedValueOnce(false);
 
       await expect(
         service.GetQualitativeSummary(facultyId, baseQuery),

--- a/src/modules/analytics/analytics.service.ts
+++ b/src/modules/analytics/analytics.service.ts
@@ -1780,11 +1780,10 @@ export class AnalyticsService {
 
     const userRows: {
       id: string;
-      department_id: string;
       first_name: string;
       last_name: string;
     }[] = await this.em.execute(
-      'SELECT u.id, u.department_id, u.first_name, u.last_name FROM "user" u WHERE u.id = ? AND u.deleted_at IS NULL',
+      'SELECT u.id, u.first_name, u.last_name FROM "user" u WHERE u.id = ? AND u.deleted_at IS NULL',
       [facultyId],
     );
 
@@ -1792,7 +1791,13 @@ export class AnalyticsService {
       throw new NotFoundException('Faculty not found');
     }
 
-    if (!deptIds.includes(userRows[0].department_id)) {
+    const inScope = await this.scopeResolver.IsFacultyInSemesterScope(
+      facultyId,
+      semesterId,
+      deptIds,
+    );
+
+    if (!inScope) {
       throw new ForbiddenException(
         'You do not have access to this faculty member',
       );

--- a/src/modules/common/services/scope-resolver.service.spec.ts
+++ b/src/modules/common/services/scope-resolver.service.spec.ts
@@ -8,7 +8,7 @@ import { User } from 'src/entities/user.entity';
 
 describe('ScopeResolverService', () => {
   let service: ScopeResolverService;
-  let em: { find: jest.Mock; findOne: jest.Mock };
+  let em: { find: jest.Mock; findOne: jest.Mock; execute: jest.Mock };
   let currentUserService: { getOrFail: jest.Mock };
 
   const semesterId = 'semester-1';
@@ -17,7 +17,7 @@ describe('ScopeResolverService', () => {
     ({ id, roles }) as unknown as User;
 
   beforeEach(async () => {
-    em = { find: jest.fn(), findOne: jest.fn() };
+    em = { find: jest.fn(), findOne: jest.fn(), execute: jest.fn() };
     currentUserService = {
       getOrFail: jest.fn(),
     };
@@ -388,6 +388,65 @@ describe('ScopeResolverService', () => {
 
       expect(result).toBeNull();
       expect(em.find).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── IsFacultyInSemesterScope ────────────────────────────────────
+
+  describe('IsFacultyInSemesterScope', () => {
+    const facultyId = 'faculty-1';
+
+    it('returns true for super-admin (null allowedDepartmentIds) without hitting the DB', async () => {
+      const result = await service.IsFacultyInSemesterScope(
+        facultyId,
+        semesterId,
+        null,
+      );
+
+      expect(result).toBe(true);
+      expect(em.execute).not.toHaveBeenCalled();
+    });
+
+    it('returns false for empty allowedDepartmentIds without hitting the DB', async () => {
+      const result = await service.IsFacultyInSemesterScope(
+        facultyId,
+        semesterId,
+        [],
+      );
+
+      expect(result).toBe(false);
+      expect(em.execute).not.toHaveBeenCalled();
+    });
+
+    it('returns true when the enrollment-join query yields any row', async () => {
+      em.execute.mockResolvedValueOnce([{ hit: 1 }]);
+
+      const result = await service.IsFacultyInSemesterScope(
+        facultyId,
+        semesterId,
+        ['dept-a', 'dept-b'],
+      );
+
+      expect(result).toBe(true);
+      expect(em.execute).toHaveBeenCalledTimes(1);
+      const [sql, params] = em.execute.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain('FROM enrollment e');
+      expect(sql).toContain("e.role IN ('editingteacher', 'teacher')");
+      expect(sql).toContain('d.semester_id = ?');
+      expect(sql).toContain('d.id IN (?, ?)');
+      expect(params).toEqual([facultyId, semesterId, 'dept-a', 'dept-b']);
+    });
+
+    it('returns false when the enrollment-join query yields no rows', async () => {
+      em.execute.mockResolvedValueOnce([]);
+
+      const result = await service.IsFacultyInSemesterScope(
+        facultyId,
+        semesterId,
+        ['dept-a'],
+      );
+
+      expect(result).toBe(false);
     });
   });
 });

--- a/src/modules/common/services/scope-resolver.service.ts
+++ b/src/modules/common/services/scope-resolver.service.ts
@@ -146,6 +146,51 @@ export class ScopeResolverService {
     );
   }
 
+  /**
+   * Returns true iff the faculty has at least one active TEACHER /
+   * EDITING_TEACHER enrollment in a course whose owning Department belongs to
+   * `semesterId` AND is contained in `allowedDepartmentIds`.
+   *
+   * `allowedDepartmentIds === null` means unrestricted (super-admin) — always
+   * true. Empty array = caller has no scope for this semester — always false.
+   *
+   * Why: `Department` is per-semester, but `User.department` is single-valued
+   * and points to the user's enrollment-majority semester. Comparing
+   * `User.department.id` against `ResolveDepartmentIds(otherSemesterId)`
+   * silently excludes carryover faculty. Use this enrollment-driven check at
+   * every "is faculty X in scope for semester Y?" guard.
+   */
+  async IsFacultyInSemesterScope(
+    facultyId: string,
+    semesterId: string,
+    allowedDepartmentIds: string[] | null,
+  ): Promise<boolean> {
+    if (allowedDepartmentIds === null) return true;
+    if (allowedDepartmentIds.length === 0) return false;
+
+    const placeholders = allowedDepartmentIds.map(() => '?').join(', ');
+    const rows: { hit: number }[] = await this.em.execute(
+      `SELECT 1 AS hit
+         FROM enrollment e
+         INNER JOIN course c ON c.id = e.course_id
+         INNER JOIN program p ON p.id = c.program_id
+         INNER JOIN department d ON d.id = p.department_id
+        WHERE e.user_id = ?
+          AND e.role IN ('editingteacher', 'teacher')
+          AND e.is_active = true
+          AND e.deleted_at IS NULL
+          AND c.is_active = true
+          AND c.deleted_at IS NULL
+          AND p.deleted_at IS NULL
+          AND d.deleted_at IS NULL
+          AND d.semester_id = ?
+          AND d.id IN (${placeholders})
+        LIMIT 1`,
+      [facultyId, semesterId, ...allowedDepartmentIds],
+    );
+    return rows.length > 0;
+  }
+
   private async resolveCampusHeadCampusIds(
     userId: string,
     semesterId: string,

--- a/src/modules/faculty/services/faculty.service.spec.ts
+++ b/src/modules/faculty/services/faculty.service.spec.ts
@@ -25,7 +25,10 @@ describe('FacultyService', () => {
     count: jest.Mock;
     getConnection: jest.Mock;
   };
-  let scopeResolver: { ResolveDepartmentIds: jest.Mock };
+  let scopeResolver: {
+    ResolveDepartmentIds: jest.Mock;
+    IsFacultyInSemesterScope: jest.Mock;
+  };
   let currentUserService: { getOrFail: jest.Mock };
   let executeMock: jest.Mock;
 
@@ -79,6 +82,7 @@ describe('FacultyService', () => {
 
     scopeResolver = {
       ResolveDepartmentIds: jest.fn(),
+      IsFacultyInSemesterScope: jest.fn().mockResolvedValue(true),
     };
 
     currentUserService = {
@@ -104,45 +108,42 @@ describe('FacultyService', () => {
     em.findOne.mockResolvedValue({ id: semesterId });
   }
 
-  function call(mock: jest.Mock, callIndex = 0): unknown[] {
-    return (mock.mock.calls[callIndex] ?? []) as unknown[];
-  }
-
-  function filterOf(mock: jest.Mock, callIndex = 0): Record<string, unknown> {
-    return (call(mock, callIndex)[1] ?? {}) as Record<string, unknown>;
-  }
-
-  function optsOf(mock: jest.Mock, callIndex = 0): Record<string, unknown> {
-    return (call(mock, callIndex)[2] ?? {}) as Record<string, unknown>;
-  }
-
   /**
-   * Prime `findAndCount` (primary user query) and `em.find` (subjects
-   * enrichment). The enrichment query only fires when users.length > 0.
+   * Prime the raw-SQL listing path: count query, paginated user-id query,
+   * then the user + enrollment hydration (`em.find` calls).
+   *
+   * Enrollment-driven listing means a "no rows" outcome can short-circuit
+   * before the user-id query — call `primeListingEmpty()` for that branch.
    */
-  function primePrimary(
-    users: User[],
-    totalCount: number,
-    enrollments: ReturnType<typeof mockEnrollment>[] = [],
-  ) {
-    em.findAndCount.mockResolvedValueOnce([users, totalCount]);
-    if (users.length > 0) {
-      em.find.mockResolvedValueOnce(enrollments);
-    }
+  function primeListingEmpty() {
+    executeMock.mockResolvedValueOnce([{ count: '0' }]);
   }
 
-  describe('super admin sees all faculty', () => {
-    it('returns all faculty, excluding NULL home dept', async () => {
+  function primeListing(
+    userIds: string[],
+    totalCount: number,
+    users: User[],
+    enrollments: ReturnType<typeof mockEnrollment>[],
+  ) {
+    executeMock
+      .mockResolvedValueOnce([{ count: String(totalCount) }])
+      .mockResolvedValueOnce(userIds.map((id) => ({ user_id: id })));
+    em.find.mockResolvedValueOnce(users).mockResolvedValueOnce(enrollments);
+  }
+
+  describe('ListFaculty', () => {
+    it('returns enrollment-driven faculty list with subjects[] for super admin (null scope)', async () => {
       setupSemesterFound();
       scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
 
-      const user1 = mockUser('u1', 'John Doe', 'John', 'Doe', 'pic.jpg');
-      const user2 = mockUser('u2', 'Jane Smith', 'Jane', 'Smith', 'pic2.jpg');
-
-      primePrimary([user1, user2], 2, [
-        mockEnrollment('u1', 'FREAI'),
-        mockEnrollment('u2', 'ELEMSYS'),
-      ]);
+      const user1 = mockUser('u1', 'Alice', 'Alice', 'Smith', 'pic1.jpg');
+      const user2 = mockUser('u2', 'Bob', 'Bob', 'Jones', 'pic2.jpg');
+      primeListing(
+        ['u1', 'u2'],
+        2,
+        [user1, user2],
+        [mockEnrollment('u1', 'CS101'), mockEnrollment('u2', 'CS201')],
+      );
 
       const result = await service.ListFaculty(baseQuery);
 
@@ -152,109 +153,123 @@ describe('FacultyService', () => {
         semesterId,
       );
 
-      expect(filterOf(em.findAndCount)).toMatchObject({
-        roles: { $contains: [UserRole.FACULTY] },
-        isActive: true,
-        department: { $ne: null },
-      });
-      expect(optsOf(em.findAndCount).orderBy).toEqual({
-        fullName: QueryOrder.ASC_NULLS_LAST,
-        id: QueryOrder.ASC,
-      });
+      // Generated SQL is enrollment-join based and includes the per-semester
+      // department predicate. The cross-dept-only predicates must NOT appear
+      // (this endpoint includes both home-dept and cross-dept teachers).
+      const [countSql] = executeMock.mock.calls[0] as [string, unknown[]];
+      const normalized = countSql.replace(/\s+/g, ' ');
+      expect(normalized).toContain('FROM enrollment e');
+      expect(normalized).toContain('d.semester_id = ?');
+      expect(normalized).not.toContain('u.department_id <> d.id');
     });
-  });
 
-  describe('dean sees only faculty in their department scope', () => {
-    it('scopes department to $in', async () => {
+    it('includes carryover faculty (home dept in another semester) — the FAC bug fix', async () => {
+      // Faculty user has user.department pointing to a previous semester's
+      // Department row, but they have a TEACHER enrollment in the requested
+      // semester's courses. Old (home-dept-driven) listing excluded them; the
+      // new enrollment-driven listing must include them.
       setupSemesterFound();
       scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
 
-      const user1 = mockUser('u1', 'John Doe', 'John', 'Doe', 'pic.jpg');
-      primePrimary([user1], 1, [mockEnrollment('u1', 'FREAI')]);
+      const carryoverFaculty = mockUser(
+        'u-carryover',
+        'Carryover Faculty',
+        'Carryover',
+        'Faculty',
+        '',
+      );
+      primeListing(
+        ['u-carryover'],
+        1,
+        [carryoverFaculty],
+        [mockEnrollment('u-carryover', 'CS101')],
+      );
 
       const result = await service.ListFaculty(baseQuery);
 
       expect(result.data).toHaveLength(1);
-      expect(result.data[0].fullName).toBe('John Doe');
+      expect(result.data[0].subjects).toEqual(['CS101']);
 
-      expect(filterOf(em.findAndCount).department).toEqual({ $in: [deptId] });
+      // Sanity: the count query passed semesterId + scoped deptIds as params.
+      const [, countParams] = executeMock.mock.calls[0] as [string, unknown[]];
+      expect(countParams[0]).toBe(semesterId);
+      expect(countParams).toContain(deptId);
     });
-  });
 
-  describe('cross-dept leak prevented on primary list (AC 2)', () => {
-    it('filters by home department — SOE-home teaching CCS is absent from CCS dean', async () => {
-      // A CCS dean's scope is [CCS]. A SOE-home faculty teaching a CCS course
-      // exists in the DB, but the home-dept filter excludes them outright.
-      // We simulate this by asserting (a) the filter sent to findAndCount
-      // narrows department to CCS, and (b) when the mock DB obeys that filter
-      // and returns no rows, the SOE-home user does NOT appear in the response.
+    it('short-circuits when scope resolves to [] (dean with no scope)', async () => {
       setupSemesterFound();
-      const ccsDept = 'ccs';
-      scopeResolver.ResolveDepartmentIds.mockResolvedValue([ccsDept]);
-
-      // Mock DB honors the `department: { $in: [ccs] }` predicate -> 0 rows.
-      primePrimary([], 0);
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue([]);
 
       const result = await service.ListFaculty(baseQuery);
 
-      expect(filterOf(em.findAndCount).department).toEqual({ $in: [ccsDept] });
       expect(result.data).toEqual([]);
-      // Contrast with legacy enrollment-join semantics: under the old query,
-      // the SOE-home faculty teaching the CCS course would leak in. Here they
-      // cannot — the DB is never asked for non-CCS-home users.
-    });
-  });
-
-  describe('pagination', () => {
-    it('returns correct PaginationMeta', async () => {
-      setupSemesterFound();
-      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
-
-      const users = Array.from({ length: 5 }, (_, i) =>
-        mockUser(`u${i}`, `User ${i}`, 'First', 'Last', ''),
-      );
-      primePrimary(
-        users,
-        12,
-        users.map((u) => mockEnrollment(u.id, 'CS101')),
-      );
-
-      const result = await service.ListFaculty({
-        ...baseQuery,
-        page: 2,
-        limit: 5,
-      });
-
       expect(result.meta).toEqual({
-        totalItems: 12,
-        itemCount: 5,
-        itemsPerPage: 5,
-        totalPages: 3,
-        currentPage: 2,
+        totalItems: 0,
+        itemCount: 0,
+        itemsPerPage: 20,
+        totalPages: 0,
+        currentPage: 1,
       });
-
-      const opts = optsOf(em.findAndCount);
-      expect(opts.limit).toBe(5);
-      expect(opts.offset).toBe(5);
+      expect(executeMock).not.toHaveBeenCalled();
+      expect(em.find).not.toHaveBeenCalled();
     });
-  });
 
-  describe('search filter', () => {
-    it('applies $ilike on fullName with wrapping %', async () => {
+    it('returns zero meta and skips enrichment on empty result', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
+      primeListingEmpty();
+
+      const result = await service.ListFaculty(baseQuery);
+
+      expect(result.data).toEqual([]);
+      expect(result.meta.totalItems).toBe(0);
+      expect(em.find).not.toHaveBeenCalled();
+    });
+
+    it('paginates: passes limit + offset as the last two SQL params', async () => {
       setupSemesterFound();
       scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
-      primePrimary([], 0);
+      const user1 = mockUser('u1', 'Alice', 'Alice', 'Smith', '');
+      primeListing(['u1'], 25, [user1], []);
 
-      await service.ListFaculty({ ...baseQuery, search: 'Varst' });
+      await service.ListFaculty({ ...baseQuery, page: 2, limit: 10 });
 
-      expect(filterOf(em.findAndCount).fullName).toEqual({
-        $ilike: '%Varst%',
-      });
+      const paginatedCall = executeMock.mock.calls[1] as [string, unknown[]];
+      expect(paginatedCall[1].slice(-2)).toEqual([10, 10]);
     });
-  });
 
-  describe('departmentId outside dean scope', () => {
-    it('throws ForbiddenException', async () => {
+    it('escapes LIKE wildcards in search and threads to the SQL params', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
+      primeListingEmpty();
+
+      await service.ListFaculty({ ...baseQuery, search: '%admin_test' });
+
+      const [, params] = executeMock.mock.calls[0] as [string, unknown[]];
+      expect(params).toContain('%\\%admin\\_test%');
+    });
+
+    it('subjects[] dedupes and sorts alphabetically', async () => {
+      setupSemesterFound();
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
+      const user = mockUser('u1', 'Alice', 'Alice', 'Smith', '');
+      primeListing(
+        ['u1'],
+        1,
+        [user],
+        [
+          mockEnrollment('u1', 'BETA'),
+          mockEnrollment('u1', 'ALPHA'),
+          mockEnrollment('u1', 'BETA'), // duplicate
+        ],
+      );
+
+      const result = await service.ListFaculty(baseQuery);
+
+      expect(result.data[0].subjects).toEqual(['ALPHA', 'BETA']);
+    });
+
+    it('throws ForbiddenException when departmentId is outside dean scope', async () => {
       setupSemesterFound();
       scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
 
@@ -262,12 +277,11 @@ describe('FacultyService', () => {
         service.ListFaculty({ ...baseQuery, departmentId: deptId2 }),
       ).rejects.toThrow(ForbiddenException);
     });
-  });
 
-  describe('programId not belonging to department', () => {
-    it('throws BadRequestException', async () => {
+    it('throws BadRequestException when programId does not belong to specified departmentId', async () => {
+      setupSemesterFound();
       scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
-
+      em.findOne.mockReset();
       em.findOne
         .mockResolvedValueOnce({ id: semesterId })
         .mockResolvedValueOnce({ id: programId, department: { id: deptId2 } });
@@ -280,12 +294,11 @@ describe('FacultyService', () => {
         }),
       ).rejects.toThrow(BadRequestException);
     });
-  });
 
-  describe('programId without departmentId outside dean scope', () => {
-    it('throws ForbiddenException', async () => {
+    it('throws ForbiddenException when programId belongs to a department outside dean scope', async () => {
+      setupSemesterFound();
       scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
-
+      em.findOne.mockReset();
       em.findOne
         .mockResolvedValueOnce({ id: semesterId })
         .mockResolvedValueOnce({ id: programId, department: { id: deptId2 } });
@@ -294,324 +307,53 @@ describe('FacultyService', () => {
         service.ListFaculty({ ...baseQuery, programId }),
       ).rejects.toThrow(ForbiddenException);
     });
-  });
 
-  describe('subjects aggregation', () => {
-    it('dedupes and sorts shortnames for faculty teaching multiple courses', async () => {
-      setupSemesterFound();
+    it('throws NotFoundException when programId does not exist', async () => {
       scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
+      em.findOne
+        .mockResolvedValueOnce({ id: semesterId })
+        .mockResolvedValueOnce(null);
 
-      const user1 = mockUser('u1', 'John Doe', 'John', 'Doe', 'pic.jpg');
-      primePrimary([user1], 1, [
-        mockEnrollment('u1', 'FREAI'),
-        mockEnrollment('u1', 'ELEMSYS'),
-        mockEnrollment('u1', 'ELDNET1'),
-      ]);
-
-      const result = await service.ListFaculty(baseQuery);
-
-      expect(result.data).toHaveLength(1);
-      expect(result.data[0].subjects).toEqual(['ELDNET1', 'ELEMSYS', 'FREAI']);
+      await expect(
+        service.ListFaculty({ ...baseQuery, programId: 'missing' }),
+      ).rejects.toThrow(NotFoundException);
     });
-  });
 
-  describe('subjects sorted alphabetically', () => {
-    it('sorts subjects array', async () => {
-      setupSemesterFound();
-      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
-
-      const user1 = mockUser('u1', 'John Doe', 'John', 'Doe', '');
-      primePrimary([user1], 1, [
-        mockEnrollment('u1', 'ZETA'),
-        mockEnrollment('u1', 'ALPHA'),
-        mockEnrollment('u1', 'MIDDLE'),
-      ]);
-
-      const result = await service.ListFaculty(baseQuery);
-
-      expect(result.data[0].subjects).toEqual(['ALPHA', 'MIDDLE', 'ZETA']);
-    });
-  });
-
-  describe('empty result', () => {
-    it('returns empty data with zero meta', async () => {
-      setupSemesterFound();
-      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
-      primePrimary([], 0);
-
-      const result = await service.ListFaculty(baseQuery);
-
-      expect(result).toEqual({
-        data: [],
-        meta: {
-          totalItems: 0,
-          itemCount: 0,
-          itemsPerPage: 20,
-          totalPages: 0,
-          currentPage: 1,
-        },
-      });
-    });
-  });
-
-  describe('LIKE wildcard escaping', () => {
-    it('escapes % and _ in search term', async () => {
-      setupSemesterFound();
-      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
-      primePrimary([], 0);
-
-      await service.ListFaculty({ ...baseQuery, search: '%admin_test' });
-
-      expect(filterOf(em.findAndCount).fullName).toEqual({
-        $ilike: '%\\%admin\\_test%',
-      });
-    });
-  });
-
-  describe('non-existent semesterId', () => {
-    it('throws NotFoundException', async () => {
+    it('throws NotFoundException when semester does not exist', async () => {
       em.findOne.mockResolvedValue(null);
 
       await expect(service.ListFaculty(baseQuery)).rejects.toThrow(
         NotFoundException,
       );
     });
-  });
 
-  describe('fullName fallback', () => {
     it('uses firstName + lastName when fullName is null', async () => {
       setupSemesterFound();
       scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
-
-      const user1 = mockUser('u1', undefined, 'John', 'Doe', '');
-      primePrimary([user1], 1, [mockEnrollment('u1', 'CS101')]);
-
-      const result = await service.ListFaculty(baseQuery);
-
-      expect(result.data[0].fullName).toBe('John Doe');
-    });
-  });
-
-  describe('page beyond totalPages', () => {
-    it('returns empty data with correct currentPage', async () => {
-      setupSemesterFound();
-      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
-
-      // findAndCount reports totalCount=3 but page=5 gives no rows.
-      em.findAndCount.mockResolvedValueOnce([[], 3]);
-
-      const result = await service.ListFaculty({
-        ...baseQuery,
-        page: 5,
-        limit: 5,
-      });
-
-      expect(result.data).toHaveLength(0);
-      expect(result.meta).toEqual({
-        totalItems: 3,
-        itemCount: 0,
-        itemsPerPage: 5,
-        totalPages: 1,
-        currentPage: 5,
-      });
-    });
-  });
-
-  describe('dean with empty department scope (AC 19)', () => {
-    it('short-circuits without calling findAndCount', async () => {
-      setupSemesterFound();
-      scopeResolver.ResolveDepartmentIds.mockResolvedValue([]);
+      const user = mockUser('u1', undefined, 'Ada', 'Lovelace', '');
+      primeListing(['u1'], 1, [user], []);
 
       const result = await service.ListFaculty(baseQuery);
 
-      expect(result).toEqual({
-        data: [],
-        meta: {
-          totalItems: 0,
-          itemCount: 0,
-          itemsPerPage: 20,
-          totalPages: 0,
-          currentPage: 1,
-        },
-      });
-      expect(em.findAndCount).not.toHaveBeenCalled();
-      expect(em.find).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('empty profilePicture', () => {
-    it('returns profilePicture as null when empty string', async () => {
-      setupSemesterFound();
-      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
-
-      const user1 = mockUser('u1', 'John Doe', 'John', 'Doe', '');
-      primePrimary([user1], 1, [mockEnrollment('u1', 'CS101')]);
-
-      const result = await service.ListFaculty(baseQuery);
-
-      expect(result.data[0].profilePicture).toBeNull();
+      expect(result.data[0].fullName).toBe('Ada Lovelace');
     });
 
-    it('returns profilePicture when present', async () => {
-      setupSemesterFound();
-      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
-
-      const user1 = mockUser('u1', 'John Doe', 'John', 'Doe', 'http://pic.jpg');
-      primePrimary([user1], 1, [mockEnrollment('u1', 'CS101')]);
-
-      const result = await service.ListFaculty(baseQuery);
-
-      expect(result.data[0].profilePicture).toBe('http://pic.jpg');
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // New spec blocks covering FAC-129 ACs 4, 5, 6, 17, 18, 20, 21, 22.
-  // ---------------------------------------------------------------------------
-
-  describe('home-dept faculty with zero scope-visible teaching (AC 3)', () => {
-    it('appears in data with subjects: []', async () => {
+    it('subjects enrichment query is scoped to the requested semester + dept scope', async () => {
       setupSemesterFound();
       scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
-
-      const user1 = mockUser('u1', 'Orphan Teacher', 'Orphan', 'T', '');
-      // enrollment enrichment returns no rows.
-      primePrimary([user1], 1, []);
-
-      const result = await service.ListFaculty(baseQuery);
-
-      expect(result.data).toHaveLength(1);
-      expect(result.data[0].subjects).toEqual([]);
-    });
-  });
-
-  describe('excludes faculty with NULL home department (AC 4, AC 18)', () => {
-    it('filter.department is {$ne: null} under super-admin', async () => {
-      setupSemesterFound();
-      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
-      primePrimary([], 0);
+      const user = mockUser('u1', 'Alice', 'Alice', 'Smith', '');
+      primeListing(['u1'], 1, [user], [mockEnrollment('u1', 'CS101')]);
 
       await service.ListFaculty(baseQuery);
 
-      expect(filterOf(em.findAndCount).department).toEqual({ $ne: null });
-    });
-
-    it('filter.department is {$in: [...]} under scoped caller', async () => {
-      setupSemesterFound();
-      scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId, deptId2]);
-      primePrimary([], 0);
-
-      await service.ListFaculty(baseQuery);
-
-      expect(filterOf(em.findAndCount).department).toEqual({
-        $in: [deptId, deptId2],
-      });
-    });
-  });
-
-  describe('departmentId param filters user.department (AC 5)', () => {
-    it('scalar department overrides scope predicate', async () => {
-      setupSemesterFound();
-      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
-      primePrimary([], 0);
-
-      await service.ListFaculty({ ...baseQuery, departmentId: deptId });
-
-      expect(filterOf(em.findAndCount).department).toBe(deptId);
-    });
-  });
-
-  describe('programId param filters user.program (AC 6)', () => {
-    it('scalar program on the user filter', async () => {
-      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
-      em.findOne
-        .mockResolvedValueOnce({ id: semesterId })
-        .mockResolvedValueOnce({ id: programId, department: { id: deptId } });
-      primePrimary([], 0);
-
-      await service.ListFaculty({ ...baseQuery, programId });
-
-      expect(filterOf(em.findAndCount).program).toBe(programId);
-    });
-  });
-
-  describe('inactive faculty excluded (AC 20)', () => {
-    it('filter always includes isActive: true', async () => {
-      setupSemesterFound();
-      scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
-      primePrimary([], 0);
-
-      await service.ListFaculty(baseQuery);
-
-      expect(filterOf(em.findAndCount).isActive).toBe(true);
-    });
-  });
-
-  describe('dual-role faculty included (AC 21)', () => {
-    it('includes user whose roles contain FACULTY', async () => {
-      setupSemesterFound();
-      scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
-
-      const dualRole = mockUser('u1', 'Dual Hat', 'Dual', 'Hat', '');
-      (dualRole as unknown as { roles: UserRole[] }).roles = [
-        UserRole.FACULTY,
-        UserRole.DEAN,
-      ];
-      primePrimary([dualRole], 1, [mockEnrollment('u1', 'CS101')]);
-
-      const result = await service.ListFaculty(baseQuery);
-
-      expect(result.data).toHaveLength(1);
-      expect(result.data[0].id).toBe('u1');
-
-      expect(filterOf(em.findAndCount).roles).toEqual({
-        $contains: [UserRole.FACULTY],
-      });
-    });
-  });
-
-  describe('subjects enrichment skipped on empty result (AC 22)', () => {
-    it('does not issue enrollment query when findAndCount returns []', async () => {
-      setupSemesterFound();
-      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
-      em.findAndCount.mockResolvedValueOnce([[], 0]);
-
-      await service.ListFaculty(baseQuery);
-
-      expect(em.find).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('orderBy uses fullName ASC NULLS LAST then id ASC', () => {
-    it('passes the documented orderBy to findAndCount', async () => {
-      setupSemesterFound();
-      scopeResolver.ResolveDepartmentIds.mockResolvedValue(null);
-      primePrimary([], 0);
-
-      await service.ListFaculty(baseQuery);
-
-      expect(optsOf(em.findAndCount).orderBy).toEqual({
-        fullName: QueryOrder.ASC_NULLS_LAST,
-        id: QueryOrder.ASC,
-      });
-    });
-  });
-
-  describe('subjects enrichment uses scope-visible courses (AC 17)', () => {
-    it('passes semester + scope course filter to em.find(Enrollment, ...)', async () => {
-      setupSemesterFound();
-      scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
-
-      const user1 = mockUser('u1', 'Jane', 'Jane', 'Doe', '');
-      primePrimary([user1], 1, [mockEnrollment('u1', 'A')]);
-
-      await service.ListFaculty(baseQuery);
-
-      const findCall = call(em.find, 0);
-      expect(findCall[0]).toBe(Enrollment);
-      const findFilter = findCall[1] as Record<string, unknown>;
-      expect(findFilter).toMatchObject({
+      // Second em.find call is the subjects-enrichment query.
+      const findCall = em.find.mock.calls[1] as unknown[];
+      const filter = findCall[1] as Record<string, unknown>;
+      expect(filter).toMatchObject({
         user: { $in: ['u1'] },
+        role: {
+          $in: [EnrollmentRole.EDITING_TEACHER, EnrollmentRole.TEACHER],
+        },
         isActive: true,
         course: {
           isActive: true,
@@ -623,8 +365,6 @@ describe('FacultyService', () => {
           },
         },
       });
-      const findOpts = findCall[2] as { populate: string[] };
-      expect(findOpts.populate).toEqual(['course']);
     });
   });
 
@@ -982,7 +722,7 @@ describe('FacultyService', () => {
       ).rejects.toThrow(ForbiddenException);
     });
 
-    it('forbids dean when faculty is outside scope', async () => {
+    it('forbids dean when faculty has no in-scope enrollments for the semester', async () => {
       em.findOne
         .mockResolvedValueOnce({ id: semesterId })
         .mockResolvedValueOnce({
@@ -992,10 +732,47 @@ describe('FacultyService', () => {
           department: { id: deptId2 },
         });
       scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
+      scopeResolver.IsFacultyInSemesterScope.mockResolvedValueOnce(false);
 
       await expect(
         service.GetFacultyEnrollments(facultyId, baseEnrollmentsQuery),
       ).rejects.toThrow(ForbiddenException);
+      expect(scopeResolver.IsFacultyInSemesterScope).toHaveBeenCalledWith(
+        facultyId,
+        semesterId,
+        [deptId],
+      );
+    });
+
+    it('allows dean to access carryover faculty (home dept in different semester) when enrollments exist in scope', async () => {
+      em.findOne
+        .mockResolvedValueOnce({ id: semesterId })
+        .mockResolvedValueOnce({
+          id: facultyId,
+          isActive: true,
+          roles: [UserRole.FACULTY],
+          // home dept is a different semester's dept (carryover scenario)
+          department: { id: deptId2 },
+          firstName: 'Ada',
+          lastName: 'Lovelace',
+          userName: 'EMP001',
+          userProfilePicture: '',
+        });
+      scopeResolver.ResolveDepartmentIds.mockResolvedValue([deptId]);
+      // IsFacultyInSemesterScope sees the enrollment join → true.
+      em.findAndCount.mockResolvedValueOnce([[], 0]);
+
+      const result = await service.GetFacultyEnrollments(
+        facultyId,
+        baseEnrollmentsQuery,
+      );
+
+      expect(result.data).toEqual([]);
+      expect(scopeResolver.IsFacultyInSemesterScope).toHaveBeenCalledWith(
+        facultyId,
+        semesterId,
+        [deptId],
+      );
     });
 
     it('throws NotFoundException when semester does not exist', async () => {

--- a/src/modules/faculty/services/faculty.service.ts
+++ b/src/modules/faculty/services/faculty.service.ts
@@ -35,143 +35,32 @@ export class FacultyService {
   async ListFaculty(
     query: ListFacultyQueryDto,
   ): Promise<FacultyListResponseDto> {
-    // 1. Validate semester exists
-    const semester = await this.em.findOne(Semester, { id: query.semesterId });
-    if (!semester) {
-      throw new NotFoundException(
-        `Semester with id '${query.semesterId}' not found.`,
-      );
-    }
-
-    // 2. Resolve scope
-    const departmentIds = await this.scopeResolverService.ResolveDepartmentIds(
-      query.semesterId,
-    );
-
-    // 3. Validate filters
-    if (query.departmentId && departmentIds !== null) {
-      if (!departmentIds.includes(query.departmentId)) {
-        throw new ForbiddenException(
-          'Department is outside your authorized scope.',
-        );
-      }
-    }
-
-    if (query.programId) {
-      const program = await this.em.findOne(
-        Program,
-        { id: query.programId },
-        { populate: ['department'] },
-      );
-
-      if (!program) {
-        throw new NotFoundException(
-          `Program with id '${query.programId}' not found.`,
-        );
-      }
-
-      if (query.departmentId && program.department.id !== query.departmentId) {
-        throw new BadRequestException(
-          'Program does not belong to the specified department.',
-        );
-      }
-
-      if (
-        departmentIds !== null &&
-        !departmentIds.includes(program.department.id)
-      ) {
-        throw new ForbiddenException(
-          'Program is outside your authorized scope.',
-        );
-      }
-    }
-
-    const page = query.page ?? 1;
-    const limit = query.limit ?? 20;
-    const offset = (page - 1) * limit;
-
-    // Empty scope → no home-dept matches are possible; skip DB entirely.
-    if (departmentIds !== null && departmentIds.length === 0) {
-      return this.EmptyListResponse(page, limit);
-    }
-
-    // 4. Query users filtered by home dept/program + role + active.
-    const userFilter = this.BuildUserFilter(query, departmentIds);
-    const [users, totalItems] = await this.em.findAndCount(User, userFilter, {
-      limit,
-      offset,
-      orderBy: {
-        fullName: QueryOrder.ASC_NULLS_LAST,
-        id: QueryOrder.ASC,
-      },
-    });
-
-    if (totalItems === 0 || users.length === 0) {
-      return {
-        data: [],
-        meta: {
-          totalItems,
-          itemCount: 0,
-          itemsPerPage: limit,
-          totalPages: Math.ceil(totalItems / limit),
-          currentPage: page,
-        },
-      };
-    }
-
-    // 5. Enrich with scope-visible teaching (subjects[] may be empty).
-    const userIds = users.map((u) => u.id);
-    const scopedEnrollments = await this.em.find(
-      Enrollment,
-      {
-        user: { $in: userIds },
-        role: {
-          $in: [EnrollmentRole.EDITING_TEACHER, EnrollmentRole.TEACHER],
-        },
-        isActive: true,
-        course: this.BuildCourseFilter(query, departmentIds),
-      },
-      { populate: ['course'] },
-    );
-
-    const userCourseMap = new Map<string, string[]>();
-    for (const enrollment of scopedEnrollments) {
-      const userId = enrollment.user.id;
-      if (!userCourseMap.has(userId)) {
-        userCourseMap.set(userId, []);
-      }
-      const shortname = enrollment.course.shortname;
-      const courses = userCourseMap.get(userId)!;
-      if (!courses.includes(shortname)) {
-        courses.push(shortname);
-      }
-    }
-
-    const userMap = new Map(users.map((u) => [u.id, u]));
-    const data: FacultyCardResponseDto[] = userIds
-      .map((id) => {
-        const u = userMap.get(id);
-        if (!u) return null;
-        return FacultyCardResponseDto.Map(u, userCourseMap.get(id) ?? []);
-      })
-      .filter((dto): dto is FacultyCardResponseDto => dto !== null);
-
-    return {
-      data,
-      meta: {
-        totalItems,
-        itemCount: data.length,
-        itemsPerPage: limit,
-        totalPages: Math.ceil(totalItems / limit),
-        currentPage: page,
-      },
-    };
+    return this.ExecuteFacultyListing(query, { crossDeptOnly: false });
   }
 
   async ListCrossDepartmentTeaching(
     query: ListFacultyQueryDto,
   ): Promise<FacultyListResponseDto> {
-    // 1. Validate semester exists
+    return this.ExecuteFacultyListing(query, { crossDeptOnly: true });
+  }
+
+  /**
+   * Lists faculty teaching in a given semester. Membership is derived from
+   * active TEACHER/EDITING_TEACHER enrollments joined to courses whose owning
+   * Department belongs to the semester (and to the caller's scope).
+   *
+   * Why enrollment-driven (not User.department-driven): Department is
+   * per-semester, but User.department is single-valued and points to the
+   * user's enrollment-majority semester — comparing it to a different
+   * semester's Department row would silently exclude carryover faculty.
+   *
+   * `query.departmentId` / `query.programId` filter on the COURSE's owning
+   * dept/program, not on the user's home dept/program.
+   */
+  private async ExecuteFacultyListing(
+    query: ListFacultyQueryDto,
+    options: { crossDeptOnly: boolean },
+  ): Promise<FacultyListResponseDto> {
     const semester = await this.em.findOne(Semester, { id: query.semesterId });
     if (!semester) {
       throw new NotFoundException(
@@ -179,13 +68,10 @@ export class FacultyService {
       );
     }
 
-    // 2. Resolve scope
     const departmentIds = await this.scopeResolverService.ResolveDepartmentIds(
       query.semesterId,
     );
 
-    // 3. Validate filters (same semantics as primary — departmentId/programId
-    // refer to course-owning dept/program here).
     if (query.departmentId && departmentIds !== null) {
       if (!departmentIds.includes(query.departmentId)) {
         throw new ForbiddenException(
@@ -231,9 +117,11 @@ export class FacultyService {
       return this.EmptyListResponse(page, limit);
     }
 
-    const enrollmentFilter = this.BuildEnrollmentFilter(query, departmentIds, {
-      crossDeptOnly: true,
-    });
+    const enrollmentFilter = this.BuildEnrollmentFilter(
+      query,
+      departmentIds,
+      options,
+    );
 
     const countResult: { count: string }[] = await this.em
       .getConnection()
@@ -445,40 +333,6 @@ export class FacultyService {
     };
   }
 
-  private BuildUserFilter(
-    query: ListFacultyQueryDto,
-    departmentIds: string[] | null,
-  ): FilterQuery<User> {
-    const filter: Record<string, unknown> = {
-      roles: { $contains: [UserRole.FACULTY] },
-      isActive: true,
-    };
-
-    // Home-dept scoping: super-admin (null scope) still excludes NULL home;
-    // restricted scope narrows to the caller's departments.
-    if (departmentIds === null) {
-      filter.department = { $ne: null };
-    } else {
-      filter.department = { $in: departmentIds };
-    }
-
-    // departmentId / programId filter against home dept/program (user.*).
-    if (query.departmentId) {
-      filter.department = query.departmentId;
-    }
-
-    if (query.programId) {
-      filter.program = query.programId;
-    }
-
-    if (query.search) {
-      const escaped = this.EscapeLikeWildcards(query.search);
-      filter.fullName = { $ilike: `%${escaped}%` };
-    }
-
-    return filter as FilterQuery<User>;
-  }
-
   private EmptyListResponse(
     page: number,
     limit: number,
@@ -643,14 +497,13 @@ export class FacultyService {
       const departmentIds =
         await this.scopeResolverService.ResolveDepartmentIds(semesterId);
 
-      if (departmentIds === null) {
-        return;
-      }
+      const inScope = await this.scopeResolverService.IsFacultyInSemesterScope(
+        faculty.id,
+        semesterId,
+        departmentIds,
+      );
 
-      if (
-        !faculty.department?.id ||
-        !departmentIds.includes(faculty.department.id)
-      ) {
+      if (!inScope) {
         throw new ForbiddenException(
           'You do not have access to this faculty member',
         );

--- a/src/modules/questionnaires/services/questionnaire.service.spec.ts
+++ b/src/modules/questionnaires/services/questionnaire.service.spec.ts
@@ -51,7 +51,10 @@ describe('QuestionnaireService', () => {
   let versionRepo: jest.Mocked<EntityRepository<QuestionnaireVersion>>;
   let questionnaireRepo: jest.Mocked<EntityRepository<Questionnaire>>;
   let analysisService: { EnqueueJob: jest.Mock };
-  let scopeResolverService: { ResolveDepartmentIds: jest.Mock };
+  let scopeResolverService: {
+    ResolveDepartmentIds: jest.Mock;
+    IsFacultyInSemesterScope: jest.Mock;
+  };
   let cacheService: {
     invalidateNamespace: jest.Mock;
     invalidateNamespaces: jest.Mock;
@@ -189,6 +192,7 @@ describe('QuestionnaireService', () => {
             ResolveDepartmentIds: jest
               .fn()
               .mockResolvedValue(['fac126-dept-1']),
+            IsFacultyInSemesterScope: jest.fn().mockResolvedValue(true),
           },
         },
       ],
@@ -630,6 +634,9 @@ describe('QuestionnaireService', () => {
         scopeResolverService.ResolveDepartmentIds.mockResolvedValueOnce([
           'other-dept',
         ]);
+        scopeResolverService.IsFacultyInSemesterScope.mockResolvedValueOnce(
+          false,
+        );
         enrollmentRepo.findOne.mockClear();
         await expect(
           service.submitQuestionnaire(mockDataNoCourse),
@@ -665,6 +672,9 @@ describe('QuestionnaireService', () => {
           cloneVersionWithType('FACULTY_IN_CLASSROOM') as any,
         );
         scopeResolverService.ResolveDepartmentIds.mockResolvedValueOnce([]);
+        scopeResolverService.IsFacultyInSemesterScope.mockResolvedValueOnce(
+          false,
+        );
         const warnSpy = jest
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           .spyOn((service as any).logger, 'warn')
@@ -698,7 +708,10 @@ describe('QuestionnaireService', () => {
         expect(enrollmentRepo.findOne).not.toHaveBeenCalled();
       });
 
-      it('dean + null faculty.department rejected with scope message', async () => {
+      it('dean rejected when faculty has no in-scope enrollments for the semester', async () => {
+        // The home-dept value on the User no longer participates in the scope
+        // check — IsFacultyInSemesterScope decides via enrollments. We set
+        // faculty.department=null only to assert the gate doesn't depend on it.
         const respondent = { ...mockRespondent, roles: [UserRole.DEAN] };
         const facultyNoDept = { ...mockFaculty, department: null };
         (em.findOne as jest.Mock).mockImplementation((entity, id) => {
@@ -711,6 +724,9 @@ describe('QuestionnaireService', () => {
         versionRepo.findOne.mockResolvedValue(
           cloneVersionWithType('FACULTY_IN_CLASSROOM') as any,
         );
+        scopeResolverService.IsFacultyInSemesterScope.mockResolvedValueOnce(
+          false,
+        );
         enrollmentRepo.findOne.mockClear();
         await expect(
           service.submitQuestionnaire(mockDataNoCourse),
@@ -718,6 +734,39 @@ describe('QuestionnaireService', () => {
           new ForbiddenException('Faculty is not within your scope.'),
         );
         expect(enrollmentRepo.findOne).not.toHaveBeenCalled();
+      });
+
+      it('dean accepted for carryover faculty (home dept in another semester) when enrollments exist in scope', async () => {
+        const respondent = { ...mockRespondent, roles: [UserRole.DEAN] };
+        const carryoverFaculty = {
+          ...mockFaculty,
+          department: { id: 'sem2-dept-id' },
+        };
+        (em.findOne as jest.Mock).mockImplementation((entity, id) => {
+          if (entity === User && id === RESPONDENT_ID) return respondent;
+          if (entity === User && id === FACULTY_ID) return carryoverFaculty;
+          if (entity === Semester && id === SEMESTER_ID) return mockSemester;
+          if (entity === Course && id === COURSE_ID) return mockCourse;
+          return null;
+        });
+        versionRepo.findOne.mockResolvedValue(
+          cloneVersionWithType('FACULTY_OUT_OF_CLASSROOM') as any,
+        );
+        // Caller's semester scope is sem1; faculty.department points to sem2.
+        // Old code rejected. New code: enrollment-driven check returns true.
+        scopeResolverService.ResolveDepartmentIds.mockResolvedValueOnce([
+          'sem1-dept-id',
+        ]);
+        scopeResolverService.IsFacultyInSemesterScope.mockResolvedValueOnce(
+          true,
+        );
+
+        const result = await service.submitQuestionnaire(mockDataNoCourse);
+
+        expect(result).toBeDefined();
+        expect(
+          scopeResolverService.IsFacultyInSemesterScope,
+        ).toHaveBeenCalledWith(FACULTY_ID, SEMESTER_ID, ['sem1-dept-id']);
       });
 
       it('super admin + FACULTY_FEEDBACK succeeds and ScopeResolver NOT called', async () => {

--- a/src/modules/questionnaires/services/questionnaire.service.ts
+++ b/src/modules/questionnaires/services/questionnaire.service.ts
@@ -956,7 +956,12 @@ export class QuestionnaireService {
           `Respondent ${respondent.id} (role=${role}) has an empty department scope for semester ${semesterId} — likely mis-provisioned.`,
         );
       }
-      if (!allowedDepartmentIds.includes(faculty.department?.id ?? '')) {
+      const inScope = await this.scopeResolverService.IsFacultyInSemesterScope(
+        faculty.id,
+        semesterId,
+        allowedDepartmentIds,
+      );
+      if (!inScope) {
         throw new ForbiddenException('Faculty is not within your scope.');
       }
     }

--- a/src/modules/reports/reports.service.spec.ts
+++ b/src/modules/reports/reports.service.spec.ts
@@ -22,7 +22,10 @@ describe('ReportsService', () => {
     findOne: jest.Mock;
     find: jest.Mock;
   };
-  let mockScopeResolver: { ResolveDepartmentIds: jest.Mock };
+  let mockScopeResolver: {
+    ResolveDepartmentIds: jest.Mock;
+    IsFacultyInSemesterScope: jest.Mock;
+  };
   let mockEntityManager: {
     fork: jest.Mock;
     nativeDelete: jest.Mock;
@@ -74,6 +77,7 @@ describe('ReportsService', () => {
     };
     mockScopeResolver = {
       ResolveDepartmentIds: jest.fn().mockResolvedValue(null),
+      IsFacultyInSemesterScope: jest.fn().mockResolvedValue(true),
     };
     mockConnection.execute = jest.fn().mockResolvedValue([]);
     mockEntityManager = {
@@ -138,14 +142,13 @@ describe('ReportsService', () => {
           return [{ id: semesterId }];
         }
         if (sql.includes('FROM "user"')) {
-          return [
-            { department_id: 'dept-001', first_name: 'John', last_name: 'Doe' },
-          ];
+          return [{ id: facultyId, first_name: 'John', last_name: 'Doe' }];
         }
         return [];
       });
       // Scope: dean with access
       mockScopeResolver.ResolveDepartmentIds.mockResolvedValue(['dept-001']);
+      mockScopeResolver.IsFacultyInSemesterScope.mockResolvedValue(true);
     });
 
     it('should create entity, enqueue job, and return jobId', async () => {
@@ -196,31 +199,40 @@ describe('ReportsService', () => {
       expect(opts.removeOnFail).toBe(100);
     });
 
-    it('should throw ForbiddenException when faculty is out of scope', async () => {
-      // Faculty belongs to dept-002 but dean only has access to dept-001
+    it('should throw ForbiddenException when faculty has no in-scope enrollments for the semester', async () => {
+      // Dean's scope is dept-001 but faculty has no TEACHER enrollments in
+      // dept-001 courses for this semester (carryover-faculty-aware check).
       mockScopeResolver.ResolveDepartmentIds.mockResolvedValue(['dept-001']);
-      mockConnection.execute.mockImplementation((sql: string) => {
-        if (sql.includes('FROM semester')) {
-          return [{ id: semesterId }];
-        }
-        if (sql.includes('FROM "user"')) {
-          return [
-            {
-              department_id: 'dept-002',
-              first_name: 'Jane',
-              last_name: 'Smith',
-            },
-          ];
-        }
-        return [];
-      });
+      mockScopeResolver.IsFacultyInSemesterScope.mockResolvedValueOnce(false);
 
       await expect(service.GenerateSingle(dto, userId)).rejects.toThrow(
         ForbiddenException,
       );
+      expect(mockScopeResolver.IsFacultyInSemesterScope).toHaveBeenCalledWith(
+        facultyId,
+        semesterId,
+        ['dept-001'],
+      );
       // Should never reach entity creation or enqueue
       expect(mockForkEm.create).not.toHaveBeenCalled();
       expect(mockQueue.add).not.toHaveBeenCalled();
+    });
+
+    it('should pass scope check for carryover faculty (home dept in different semester)', async () => {
+      // Faculty's User.department points to a previous semester's Department,
+      // but they have an active TEACHER enrollment in this semester's courses.
+      // IsFacultyInSemesterScope sees the enrollment join → true.
+      mockScopeResolver.ResolveDepartmentIds.mockResolvedValue(['dept-001']);
+      mockScopeResolver.IsFacultyInSemesterScope.mockResolvedValueOnce(true);
+
+      const result = await service.GenerateSingle(dto, userId);
+
+      expect(result).toEqual({ jobId: 'report-job-001' });
+      expect(mockScopeResolver.IsFacultyInSemesterScope).toHaveBeenCalledWith(
+        facultyId,
+        semesterId,
+        ['dept-001'],
+      );
     });
 
     it('should return existing jobId when duplicate pending job exists (dedup)', async () => {

--- a/src/modules/reports/reports.service.ts
+++ b/src/modules/reports/reports.service.ts
@@ -473,8 +473,8 @@ export class ReportsService {
       return; // super admin — unrestricted
     }
 
-    const userRows: { department_id: string }[] = await this.em.execute(
-      'SELECT u.department_id FROM "user" u WHERE u.id = ? AND u.deleted_at IS NULL',
+    const userRows: { id: string }[] = await this.em.execute(
+      'SELECT u.id FROM "user" u WHERE u.id = ? AND u.deleted_at IS NULL',
       [facultyId],
     );
 
@@ -482,7 +482,13 @@ export class ReportsService {
       throw new NotFoundException('Faculty not found');
     }
 
-    if (!deptIds.includes(userRows[0].department_id)) {
+    const inScope = await this.scopeResolver.IsFacultyInSemesterScope(
+      facultyId,
+      semesterId,
+      deptIds,
+    );
+
+    if (!inScope) {
       throw new ForbiddenException(
         'You do not have access to this faculty member',
       );


### PR DESCRIPTION
…sters (#387)

Department is per-semester (Department @ManyToOne Semester), but User.department is single-valued and points to the user's enrollment- majority semester. Comparing User.department.id against ResolveDepartmentIds(otherSemesterId) silently excluded carryover faculty — Dean/Chairperson/Campus Head queries returned empty lists and 403'd faculty detail/analytics/reports/evaluation submissions for faculty teaching in the requested semester.

Add ScopeResolverService.IsFacultyInSemesterScope as the single enrollment-driven scope check (joins enrollment -> course -> program -> department WHERE d.semester_id = ? AND d.id IN (?)) and switch five callers to it:

- FacultyService.ListFaculty: refactor to share the existing raw-SQL enrollment-join path with ListCrossDepartmentTeaching; drop the obsolete BuildUserFilter that filtered by User.department.
- FacultyService.AssertFacultyAccess
- AnalyticsService.validateFacultyScope
- ReportsService.validateFacultyInScope
- QuestionnaireService submission scope gate (Dean/Chairperson)

departmentId/programId query params on ListFaculty now filter the course-side dept/program (consistent with ListCrossDepartmentTeaching) since the user-side filter cannot represent membership in a semester under the per-semester Department model.

Tightens semantics: a Dean/Chair/Campus Head can only access a faculty for a semester they actually teach in. Previously, access bled across semesters via the home-dept link.