### PR TITLE
fix: stop stale sentiment chunk retries from failing advanced pipelines

### DIFF
--- a/src/modules/analysis/processors/sentiment.processor.spec.ts
+++ b/src/modules/analysis/processors/sentiment.processor.spec.ts
@@ -457,6 +457,43 @@ describe('SentimentProcessor', () => {
       mockEm.fork = originalFork;
     });
 
+    it('lets UniqueConstraintViolation propagate out of the transactional callback so MikroORM rolls back before translation', async () => {
+      // Regression: catching 23505 inside the transactional callback and
+      // returning normally tells MikroORM to COMMIT on top of an
+      // already-aborted Postgres txn, which then fails with 25P02
+      // ("current transaction is aborted, commands ignored until end of
+      // transaction block"). The catch must live in the OUTER .catch() so
+      // the rollback happens first.
+      tx.flush.mockRejectedValue(
+        new UniqueConstraintViolationException(
+          new Error('duplicate key value violates unique constraint'),
+        ),
+      );
+
+      let callbackRejected = false;
+      mockEm.transactional.mockImplementation(
+        async (fn: (tx: unknown) => Promise<unknown>) => {
+          try {
+            return await fn(tx);
+          } catch (err) {
+            callbackRejected = true;
+            throw err;
+          }
+        },
+      );
+
+      const logSpy = jest
+        .spyOn(processor['logger'], 'log')
+        .mockImplementation();
+
+      await processor.Persist(createMockBatchJob(), buildResult());
+
+      expect(callbackRejected).toBe(true);
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'duplicate-swallowed' }),
+      );
+    });
+
     it('reports counter-saturated reason when UPDATE matches zero rows and run is saturated', async () => {
       execute.mockResolvedValue([]);
 

--- a/src/modules/analysis/processors/sentiment.processor.ts
+++ b/src/modules/analysis/processors/sentiment.processor.ts
@@ -237,14 +237,13 @@ export class SentimentProcessor extends RunPodBatchProcessor {
           });
         }
 
-        try {
-          await tx.flush();
-        } catch (err) {
-          if (err instanceof UniqueConstraintViolationException) {
-            return { kind: 'duplicate-swallowed' as const };
-          }
-          throw err;
-        }
+        // Let errors propagate out of the callback. Catching a 23505 here
+        // and returning normally tells MikroORM to COMMIT on top of an
+        // already-aborted Postgres transaction, which then fails with
+        // 25P02 ("current transaction is aborted, commands ignored until
+        // end of transaction block"). The duplicate-swallow translation
+        // lives in the outer .catch() so MikroORM rolls back first.
+        await tx.flush();
 
         // Pass tx context so the raw UPDATE runs inside the active transaction.
         // Without it, AbstractSqlConnection.execute uses a pooled Knex connection
@@ -297,6 +296,9 @@ export class SentimentProcessor extends RunPodBatchProcessor {
       .catch((err: unknown) => {
         if (err instanceof SupersededChunkError) {
           return { kind: 'superseded' as const, reason: '' };
+        }
+        if (err instanceof UniqueConstraintViolationException) {
+          return { kind: 'duplicate-swallowed' as const };
         }
         throw err;
       });

--- a/src/modules/analysis/services/__tests__/pipeline-orchestrator.audit.spec.ts
+++ b/src/modules/analysis/services/__tests__/pipeline-orchestrator.audit.spec.ts
@@ -171,6 +171,87 @@ describe('PipelineOrchestratorService — pipeline failure audit', () => {
 
       expect(emit).not.toHaveBeenCalled();
     });
+
+    it('ignores stale sentiment_analysis failure when pipeline is already in SENTIMENT_GATE', async () => {
+      // Reproduces the production case: chunk 19/20 retried after its first
+      // attempt had already saturated the run counter and OnSentimentComplete
+      // had advanced the pipeline through the gate. The late onFailed must
+      // NOT stomp the pipeline back to FAILED.
+      const pipeline = buildPipeline({ status: PipelineStatus.SENTIMENT_GATE });
+      const { service, emit, flush } = makeService({
+        findOne: jest.fn().mockResolvedValue(pipeline),
+      });
+
+      await service.OnStageFailed(
+        pipeline.id,
+        'sentiment_analysis',
+        'chunk 19/20 failed after 3 retries: insert into ...',
+      );
+
+      expect(flush).not.toHaveBeenCalled();
+      expect(emit).not.toHaveBeenCalled();
+      expect(pipeline.status).toBe(PipelineStatus.SENTIMENT_GATE);
+      expect(pipeline.errorMessage).toBeUndefined();
+    });
+
+    it('ignores stale sentiment_analysis failure when pipeline has advanced to TOPIC_MODELING', async () => {
+      const pipeline = buildPipeline({ status: PipelineStatus.TOPIC_MODELING });
+      const { service, emit, flush } = makeService({
+        findOne: jest.fn().mockResolvedValue(pipeline),
+      });
+
+      await service.OnStageFailed(pipeline.id, 'sentiment_analysis', 'late');
+
+      expect(flush).not.toHaveBeenCalled();
+      expect(emit).not.toHaveBeenCalled();
+      expect(pipeline.status).toBe(PipelineStatus.TOPIC_MODELING);
+    });
+
+    it('ignores stale topic_modeling failure when pipeline has advanced to GENERATING_RECOMMENDATIONS', async () => {
+      const pipeline = buildPipeline({
+        status: PipelineStatus.GENERATING_RECOMMENDATIONS,
+      });
+      const { service, emit, flush } = makeService({
+        findOne: jest.fn().mockResolvedValue(pipeline),
+      });
+
+      await service.OnStageFailed(pipeline.id, 'topic_modeling', 'late');
+
+      expect(flush).not.toHaveBeenCalled();
+      expect(emit).not.toHaveBeenCalled();
+      expect(pipeline.status).toBe(PipelineStatus.GENERATING_RECOMMENDATIONS);
+    });
+
+    it('still stomps when stage matches current status (sentiment_analysis on SENTIMENT_ANALYSIS)', async () => {
+      const pipeline = buildPipeline({
+        status: PipelineStatus.SENTIMENT_ANALYSIS,
+      });
+      const { service, emit, flush } = makeService({
+        findOne: jest.fn().mockResolvedValue(pipeline),
+      });
+
+      await service.OnStageFailed(pipeline.id, 'sentiment_analysis', 'real');
+
+      expect(flush).toHaveBeenCalledTimes(1);
+      expect(emit).toHaveBeenCalledTimes(1);
+      expect(pipeline.status).toBe(PipelineStatus.FAILED);
+      expect(pipeline.errorMessage).toBe('sentiment_analysis: real');
+    });
+
+    it('falls through to FAILED on unknown stage name (no mapping → no guard)', async () => {
+      const pipeline = buildPipeline({
+        status: PipelineStatus.SENTIMENT_ANALYSIS,
+      });
+      const { service, emit, flush } = makeService({
+        findOne: jest.fn().mockResolvedValue(pipeline),
+      });
+
+      await service.OnStageFailed(pipeline.id, 'mystery_stage', 'huh');
+
+      expect(flush).toHaveBeenCalledTimes(1);
+      expect(emit).toHaveBeenCalledTimes(1);
+      expect(pipeline.status).toBe(PipelineStatus.FAILED);
+    });
   });
 
   describe('emitPipelineFailAudit (private)', () => {

--- a/src/modules/analysis/services/pipeline-orchestrator.service.ts
+++ b/src/modules/analysis/services/pipeline-orchestrator.service.ts
@@ -115,6 +115,18 @@ export const TERMINAL_STATUSES = [
   PipelineStatus.CANCELLED,
 ];
 
+// Stage name -> the pipeline status during which a failure for that stage
+// is meaningful. A failure reported when the pipeline is already past the
+// expected status is stale (the stage has saturated and the pipeline has
+// moved on) and must NOT stomp the pipeline. Common cause: BullMQ
+// stalled-job retries firing on a chunk whose first attempt had already
+// committed and saturated the run counter.
+const STAGE_TO_STATUS: Readonly<Record<string, PipelineStatus>> = {
+  sentiment_analysis: PipelineStatus.SENTIMENT_ANALYSIS,
+  topic_modeling: PipelineStatus.TOPIC_MODELING,
+  generating_recommendations: PipelineStatus.GENERATING_RECOMMENDATIONS,
+};
+
 // Populate list for endpoints that return a PipelineSummary to the
 // frontend. Covers every scope FK + the faculty name used in the summary
 // DTO. Keeping this centralized prevents drift between Create/Confirm/
@@ -974,6 +986,17 @@ export class PipelineOrchestratorService {
     const pipeline = await fork.findOne(AnalysisPipeline, pipelineId);
 
     if (!pipeline || TERMINAL_STATUSES.includes(pipeline.status)) return;
+
+    // Forward-progress guard: ignore stale stage failures that arrive after
+    // the pipeline has already advanced past the failing stage. See
+    // STAGE_TO_STATUS for the rationale.
+    const expectedStatus = STAGE_TO_STATUS[stage];
+    if (expectedStatus && pipeline.status !== expectedStatus) {
+      this.logger.warn(
+        `Ignoring stale ${stage} failure for pipeline ${pipelineId}: pipeline is now in ${pipeline.status} (expected ${expectedStatus}). ${error}`,
+      );
+      return;
+    }
 
     pipeline.status = PipelineStatus.FAILED;
     pipeline.errorMessage = `${stage}: ${error}`;


### PR DESCRIPTION
## Summary

Two compounding bugs were marking analysis pipelines `FAILED` with a Postgres `25P02 - current transaction is aborted` error even though sentiment analysis had already completed and the pipeline had advanced through the gate into topic modeling.

- **`sentiment.processor.ts`** — moved the `UniqueConstraintViolationException` catch out of the `em.transactional()` callback into the outer `.catch()`. Returning normally after a 23505 told MikroORM to `COMMIT` on top of an already-aborted Postgres transaction; the commit failed with `25P02`, which then surfaced as the chunk's terminal error. Now MikroORM rolls back first and the duplicate translates cleanly to `duplicate-swallowed`.
- **`pipeline-orchestrator.service.ts`** — `OnStageFailed` now consults a `STAGE_TO_STATUS` map and ignores stage failures that arrive after the pipeline has advanced past the failing stage. Most common cause: a BullMQ stalled-job retry on a chunk whose first attempt had already saturated the run counter, firing a late `onFailed` long after `OnSentimentComplete` had moved the pipeline forward.

The two fixes are complementary: the first eliminates the `25P02` error so retries resolve as `duplicate-swallowed`; the second prevents any future stale stage failure (from any cause) from stomping a pipeline that's already moved on.

## Test plan

- [x] `npm run test -- --testPathPatterns=sentiment.processor` — 28/28 passing, includes new regression test that the unique violation propagates out of the `transactional()` callback (so MikroORM rolls back) before being translated.
- [x] `npm run test -- --testPathPatterns=pipeline-orchestrator.audit` — 13/13 passing, includes 5 new tests covering: stale `sentiment_analysis` failure during `SENTIMENT_GATE` / `TOPIC_MODELING`, stale `topic_modeling` failure during `GENERATING_RECOMMENDATIONS`, the still-stomps case when stage matches status, and the unknown-stage fallthrough.
- [x] `npm run test -- --testPathPatterns=analysis` — 203/203 passing across the analysis module.
- [x] `npm run build` clean.
- [ ] Post-deploy: re-trigger the FAILED `Department: CCS` pipeline (and any others with `retryable: true`) and confirm it advances through topic modeling and recommendations without the `25P02` signature.
- [ ] Watch logs for the new `Ignoring stale <stage> failure ...` warning; presence in moderation is fine and informative, but a flood would indicate retries are still firing more than expected.