### PR TITLE
[STAGING] fix: surface pipeline dispatch failures and raise Redis memory cap #391

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -25,7 +25,7 @@ services:
   redis:
     image: redis:7-alpine
     restart: unless-stopped
-    command: redis-server --maxmemory 256mb --maxmemory-policy noeviction
+    command: redis-server --maxmemory 1gb --maxmemory-policy noeviction
     volumes:
       - redis_data:/data
     healthcheck:
@@ -36,7 +36,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 512m
+          memory: 1280m
 
   api-production:
     image: faculytics-api:production

--- a/src/modules/analysis/services/pipeline-orchestrator.service.ts
+++ b/src/modules/analysis/services/pipeline-orchestrator.service.ts
@@ -521,7 +521,19 @@ export class PipelineOrchestratorService {
     pipeline.status = PipelineStatus.TOPIC_MODELING;
     await fork.flush();
 
-    await this.dispatchTopicModeling(fork, pipeline, sentimentRun);
+    try {
+      await this.dispatchTopicModeling(fork, pipeline, sentimentRun);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        `Failed to dispatch topic modeling for pipeline ${pipeline.id}: ${message}`,
+      );
+      await this.failPipeline(
+        fork,
+        pipeline,
+        `topic_modeling: failed to dispatch topic modeling job: ${message}`,
+      );
+    }
   }
 
   async OnTopicModelComplete(pipelineId: string): Promise<void> {
@@ -545,7 +557,19 @@ export class PipelineOrchestratorService {
     pipeline.status = PipelineStatus.GENERATING_RECOMMENDATIONS;
     await fork.flush();
 
-    await this.dispatchRecommendations(fork, pipeline);
+    try {
+      await this.dispatchRecommendations(fork, pipeline);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        `Failed to dispatch recommendations for pipeline ${pipeline.id}: ${message}`,
+      );
+      await this.failPipeline(
+        fork,
+        pipeline,
+        `generating_recommendations: failed to dispatch recommendations job: ${message}`,
+      );
+    }
   }
 
   async OnRecommendationsComplete(pipelineId: string): Promise<void> {


### PR DESCRIPTION


Pipeline a5c89edf-... stranded in TOPIC_MODELING with no BullMQ job queued. Root cause: shared Redis was at 240MB / 256MB cap with maxmemory-policy noeviction, so the EVALSHA underlying topicModelQueue.add() failed with "OOM command not allowed". The exception bubbled up unhandled — pipeline status had already been flushed to TOPIC_MODELING and a TopicModelRun row created with status=PROCESSING, but no job ever made it onto the queue. The SENTIMENT_ANALYSIS guard in OnSentimentComplete made every retry a no-op, so the pipeline could only be resolved by manual cancel.

Two changes:

1. Wrap dispatchTopicModeling and dispatchRecommendations in try/catch at their callers (OnSentimentComplete, OnTopicModelComplete). On failure, log and call failPipeline so the pipeline transitions to FAILED with a stage-prefixed message ("topic_modeling: ...", "generating_recommendations: ...") that the audit emitter parses correctly. The user can retry instead of being stranded.

2. Raise Redis maxmemory from 256mb to 1gb and the redis container memory limit from 512m to 1280m (1gb cap + ~25% headroom for fragmentation and persistence COW). Eviction policy stays noeviction — eviction would silently drop BullMQ jobs.

dispatchSentiment is HTTP-driven (called from the confirm endpoint), so an exception there already surfaces as a 500. Only the completion-handler dispatches were silent.