### PR TITLE
fix: remove [name] redaction from qualitative summary quotes

### DIFF
--- a/src/modules/analytics/analytics.service.spec.ts
+++ b/src/modules/analytics/analytics.service.spec.ts
@@ -1563,8 +1563,9 @@ describe('AnalyticsService', () => {
       });
       expect(result.themes[1].label).toBe('Content Quality');
       expect(result.themes[1].count).toBe(1);
-      // PII scrub: "John Smith" -> "[name]"
-      expect(result.themes[1].sampleQuotes?.[0]).toContain('[name]');
+      expect(result.themes[1].sampleQuotes?.[0]).toBe(
+        'Great teacher John Smith here',
+      );
     });
 
     it('caps sample quotes at 3 per theme and applies length truncation', async () => {

--- a/src/modules/analytics/analytics.service.ts
+++ b/src/modules/analytics/analytics.service.ts
@@ -109,11 +109,9 @@ const SENTIMENT_LABEL_VALUES: SentimentLabel[] = [
 ];
 
 function scrubQuote(raw: string): string {
-  const truncated =
-    raw.length > QUALITATIVE_SUMMARY_LIMITS.QUOTE_MAX_LENGTH
-      ? `${raw.slice(0, QUALITATIVE_SUMMARY_LIMITS.QUOTE_MAX_LENGTH)}…`
-      : raw;
-  return truncated.replace(/[A-Z][a-z]+\s[A-Z][a-z]+/g, '[name]');
+  return raw.length > QUALITATIVE_SUMMARY_LIMITS.QUOTE_MAX_LENGTH
+    ? `${raw.slice(0, QUALITATIVE_SUMMARY_LIMITS.QUOTE_MAX_LENGTH)}…`
+    : raw;
 }
 
 @Injectable()


### PR DESCRIPTION
## Summary
- Remove the `[A-Z][a-z]+\s[A-Z][a-z]+` → `[name]` regex in `scrubQuote` so faculty/dean qualitative summary quotes display the original student wording (e.g. "Heubert Ferolino" instead of "[name] Ferolino").
- Keep the 280-character truncation logic intact.
- Update the analytics spec to assert the unredacted quote.

## Test plan
- [x] `npx jest --testPathPatterns=analytics.service.spec` (64 passed)
- [ ] Visual check on the "What students say" panel in the frontend after deploy